### PR TITLE
add missing version for chrome and opera

### DIFF
--- a/environments.json
+++ b/environments.json
@@ -2670,7 +2670,7 @@
     "short": "CH 86",
     "release": "2020-10-06",
     "retire": "2020-11-17",
-    "obsolete": true
+    "obsolete": "very"
   },
   "chrome87": {
     "full": "Chrome 87",
@@ -2678,7 +2678,7 @@
     "short": "CH 87",
     "release": "2020-11-17",
     "retire": "2021-01-19",
-    "obsolete": true
+    "obsolete": "very"
   },
   "chrome88": {
     "full": "Chrome 88",
@@ -2686,21 +2686,21 @@
     "short": "CH 88",
     "release": "2021-01-19",
     "retire": "2021-03-02",
-    "obsolete": true
+    "obsolete": "very"
   },
   "chrome89": {
     "full": "Chrome 89",
     "family": "V8",
     "short": "CH 89",
     "release": "2021-03-02",
-    "obsolete": true
+    "obsolete": "very"
   },
   "chrome90": {
     "full": "Chrome 90",
     "family": "V8",
     "short": "CH 90",
     "release": "2021-04-13",
-    "obsolete": true
+    "obsolete": "very"
   },
   "chrome91": {
     "full": "Chrome 91",
@@ -2763,19 +2763,40 @@
     "family": "V8",
     "short": "CH 99",
     "release": "2022-03-01",
-    "unstable": false
+    "obsolete": true
   },
   "chrome100": {
     "full": "Chrome 100",
     "family": "V8",
     "short": "CH 100",
     "release": "2022-03-29",
-    "unstable": false
+    "obsolete": true
   },
   "chrome101": {
-    "full": "Chrome 101 Beta",
+    "full": "Chrome 101",
     "family": "V8",
     "short": "CH 101",
+    "release": "2022-04-26",
+    "obsolete": true
+  },
+  "chrome102": {
+    "full": "Chrome 102",
+    "family": "V8",
+    "short": "CH 102",
+    "release": "2022-05-24",
+    "obsolete": false
+  },
+  "chrome103": {
+    "full": "Chrome 103",
+    "family": "V8",
+    "short": "CH 103",
+    "release": "2022-06-21",
+    "obsolete": false
+  },
+  "chrome104": {
+    "full": "Chrome 104 Beta",
+    "family": "V8",
+    "short": "CH 104",
     "unstable": true
   },
   "edge12": {
@@ -3652,7 +3673,7 @@
     "equals": "chrome87",
     "short": "OP 73",
     "release": "2020-12-09",
-    "obsolete": true
+    "obsolete": "very"
   },
   "opera74": {
     "full": "Opera 74",
@@ -3660,7 +3681,7 @@
     "equals": "chrome88",
     "short": "OP 74",
     "release": "2021-02-02",
-    "obsolete": true
+    "obsolete": "very"
   },
   "opera75": {
     "full": "Opera 75",
@@ -3668,7 +3689,7 @@
     "equals": "chrome89",
     "short": "OP 75",
     "release": "2021-03-24",
-    "obsolete": true
+    "obsolete": "very"
   },
   "opera76": {
     "full": "Opera 76",
@@ -3676,7 +3697,7 @@
     "equals": "chrome90",
     "short": "OP 76",
     "release": "2021-04-28",
-    "obsolete": true
+    "obsolete": "very"
   },
   "opera77": {
     "full": "Opera 77",
@@ -3684,7 +3705,7 @@
     "equals": "chrome91",
     "short": "OP 77",
     "release": "2021-07-21",
-    "obsolete": true
+    "obsolete": "very"
   },
   "opera78": {
     "full": "Opera 78",
@@ -3692,7 +3713,7 @@
     "equals": "chrome92",
     "short": "OP 78",
     "release": "2021-08-03",
-    "obsolete": true
+    "obsolete": "very"
   },
   "opera79": {
     "full": "Opera 79",
@@ -3700,7 +3721,7 @@
     "equals": "chrome93",
     "short": "OP 79",
     "release": "2021-09-14",
-    "obsolete": false
+    "obsolete": true
   },
   "opera80": {
     "full": "Opera 80",
@@ -3708,13 +3729,77 @@
     "equals": "chrome94",
     "short": "OP 80",
     "release": "2021-10-05",
-    "obsolete": false
+    "obsolete": true
   },
   "opera81": {
     "full": "Opera 81",
     "family": "V8",
     "equals": "chrome95",
-    "short": "OP 81",
+    "short": "OP 82",
+    "release": "2021-11-04",
+    "obsolete": true
+  },
+  "opera82": {
+    "full": "Opera 82",
+    "family": "V8",
+    "equals": "chrome96",
+    "short": "OP 82",
+    "release": "2021-12-02",
+    "obsolete": true
+  },
+  "opera83": {
+    "full": "Opera 83",
+    "family": "V8",
+    "equals": "chrome97",
+    "short": "OP 83",
+    "release": "2022-01-19",
+    "obsolete": true
+  },
+  "opera84": {
+    "full": "Opera 84",
+    "family": "V8",
+    "equals": "chrome98",
+    "short": "OP 84",
+    "release": "2022-02-16",
+    "obsolete": true
+  },
+  "opera85": {
+    "full": "Opera 85",
+    "family": "V8",
+    "equals": "chrome99",
+    "short": "OP 85",
+    "release": "2022-03-23",
+    "obsolete": true
+  },
+  "opera86": {
+    "full": "Opera 86",
+    "family": "V8",
+    "equals": "chrome100",
+    "short": "OP 86",
+    "release": "2022-04-20",
+    "obsolete": true
+  },
+  "opera87": {
+    "full": "Opera 87",
+    "family": "V8",
+    "equals": "chrome101",
+    "short": "OP 87",
+    "release": "2022-05-17",
+    "obsolete": false
+  },
+  "opera88": {
+    "full": "Opera 88",
+    "family": "V8",
+    "equals": "chrome102",
+    "short": "OP 88",
+    "release": "2022-06-07",
+    "obsolete": false
+  },
+  "opera89": {
+    "full": "Opera 89",
+    "family": "V8",
+    "equals": "chrome103",
+    "short": "OP 89",
     "unstable": true
   },
   "rhino1_7_13": {

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -173,7 +173,7 @@
 <th class="platform chrome98 desktop obsolete" data-browser="chrome98"><a href="#chrome98" class="browser-name"><abbr title="Chrome 98">CH 98</abbr></a></th>
 <th class="platform chrome99 desktop obsolete" data-browser="chrome99"><a href="#chrome99" class="browser-name"><abbr title="Chrome 99">CH 99</abbr></a></th>
 <th class="platform chrome100 desktop obsolete" data-browser="chrome100"><a href="#chrome100" class="browser-name"><abbr title="Chrome 100">CH 100</abbr></a></th>
-<th class="platform chrome101 desktop" data-browser="chrome101"><a href="#chrome101" class="browser-name"><abbr title="Chrome 101">CH 101</abbr></a></th>
+<th class="platform chrome101 desktop obsolete" data-browser="chrome101"><a href="#chrome101" class="browser-name"><abbr title="Chrome 101">CH 101</abbr></a></th>
 <th class="platform chrome102 desktop" data-browser="chrome102"><a href="#chrome102" class="browser-name"><abbr title="Chrome 102">CH 102</abbr></a></th>
 <th class="platform chrome103 desktop" data-browser="chrome103"><a href="#chrome103" class="browser-name"><abbr title="Chrome 103">CH 103</abbr></a></th>
 <th class="platform chrome104 desktop unstable" data-browser="chrome104"><a href="#chrome104" class="browser-name"><abbr title="Chrome 104 Beta">CH 104</abbr></a></th>
@@ -334,7 +334,7 @@
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">3/3</td>
-<td class="tally" data-browser="chrome101" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">3/3</td>
 <td class="tally" data-browser="chrome102" data-tally="1">3/3</td>
 <td class="tally" data-browser="chrome103" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">3/3</td>
@@ -492,7 +492,7 @@ return 2 ** 3 === 8 &amp;&amp; -(5 ** 2) === -25 &amp;&amp; (-5) ** 2 === 25;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -650,7 +650,7 @@ var a = 2; a **= 3; return a === 8;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -813,7 +813,7 @@ return true;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -968,7 +968,7 @@ return true;
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">4/4</td>
-<td class="tally" data-browser="chrome101" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">4/4</td>
 <td class="tally" data-browser="chrome102" data-tally="1">4/4</td>
 <td class="tally" data-browser="chrome103" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">4/4</td>
@@ -1129,7 +1129,7 @@ return [1, 2, 3].includes(1)
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -1288,7 +1288,7 @@ return [,].includes()
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -1468,7 +1468,7 @@ return 24;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -1631,7 +1631,7 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -1798,7 +1798,7 @@ return true;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -1969,7 +1969,7 @@ return iter[&apos;throw&apos;]().value === &apos;bar&apos;;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -2132,7 +2132,7 @@ return true;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -2291,7 +2291,7 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -2451,7 +2451,7 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -2616,7 +2616,7 @@ return passed;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -2783,7 +2783,7 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -2940,7 +2940,7 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">4/4</td>
-<td class="tally" data-browser="chrome101" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">4/4</td>
 <td class="tally" data-browser="chrome102" data-tally="1">4/4</td>
 <td class="tally" data-browser="chrome103" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">4/4</td>
@@ -3101,7 +3101,7 @@ return Array.isArray(v) &amp;&amp; String(v) === &quot;foo,bar,baz&quot;;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -3266,7 +3266,7 @@ return Array.isArray(e)
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -3432,7 +3432,7 @@ return D.a.value === 1 &amp;&amp; D.a.enumerable === true &amp;&amp; D.a.configu
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -3593,7 +3593,7 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -3748,7 +3748,7 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">2/2</td>
-<td class="tally" data-browser="chrome101" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">2/2</td>
 <td class="tally" data-browser="chrome102" data-tally="1">2/2</td>
 <td class="tally" data-browser="chrome103" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">2/2</td>
@@ -3911,7 +3911,7 @@ return &apos;hello&apos;.padStart(10) === &apos;     hello&apos;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -4074,7 +4074,7 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -4229,7 +4229,7 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">2/2</td>
-<td class="tally" data-browser="chrome101" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">2/2</td>
 <td class="tally" data-browser="chrome102" data-tally="1">2/2</td>
 <td class="tally" data-browser="chrome103" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">2/2</td>
@@ -4387,7 +4387,7 @@ return typeof function f( a, b, ){} === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -4545,7 +4545,7 @@ return Math.min(1,2,3,) === 1;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -4700,7 +4700,7 @@ return Math.min(1,2,3,) === 1;
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">16/16</td>
-<td class="tally" data-browser="chrome101" data-tally="1">16/16</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">16/16</td>
 <td class="tally" data-browser="chrome102" data-tally="1">16/16</td>
 <td class="tally" data-browser="chrome103" data-tally="1">16/16</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">16/16</td>
@@ -4869,7 +4869,7 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -5038,7 +5038,7 @@ p.catch(function(result) {
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -5197,7 +5197,7 @@ try { Function(&quot;async\n function a(){await 0}&quot;)(); } catch(e) { return
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -5356,7 +5356,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -5521,7 +5521,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -5688,7 +5688,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -5847,7 +5847,7 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -6011,7 +6011,7 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -6170,7 +6170,7 @@ try { Function(&quot;(async function a(b = await Promise.resolve()){}())&quot;)(
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -6339,7 +6339,7 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -6508,7 +6508,7 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -6677,7 +6677,7 @@ var p = new C().a();
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -6844,7 +6844,7 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -7004,7 +7004,7 @@ return asyncFunctionProto !== function(){}.prototype
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -7162,7 +7162,7 @@ return Object.getPrototypeOf(async function (){})[Symbol.toStringTag] === &quot;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -7329,7 +7329,7 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -7484,7 +7484,7 @@ p.then(function(result) {
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">17/17</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">17/17</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">17/17</td>
-<td class="tally" data-browser="chrome101" data-tally="1">17/17</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">17/17</td>
 <td class="tally" data-browser="chrome102" data-tally="1">17/17</td>
 <td class="tally" data-browser="chrome103" data-tally="1">17/17</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">17/17</td>
@@ -7642,7 +7642,7 @@ return typeof SharedArrayBuffer === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -7800,7 +7800,7 @@ return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -7958,7 +7958,7 @@ return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -8116,7 +8116,7 @@ return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -8274,7 +8274,7 @@ return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuff
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -8432,7 +8432,7 @@ return typeof Atomics.add === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -8590,7 +8590,7 @@ return typeof Atomics.and === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -8748,7 +8748,7 @@ return typeof Atomics.compareExchange === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -8906,7 +8906,7 @@ return typeof Atomics.exchange === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -9064,7 +9064,7 @@ return typeof Atomics.wait === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -9222,7 +9222,7 @@ return typeof Atomics.notify === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -9380,7 +9380,7 @@ return typeof Atomics.isLockFree === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -9538,7 +9538,7 @@ return typeof Atomics.load === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -9696,7 +9696,7 @@ return typeof Atomics.or === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -9854,7 +9854,7 @@ return typeof Atomics.store === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -10012,7 +10012,7 @@ return typeof Atomics.sub === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -10170,7 +10170,7 @@ return typeof Atomics.xor === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -10333,7 +10333,7 @@ return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -10494,7 +10494,7 @@ return (function(){
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -10651,7 +10651,7 @@ return (function(){
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">16/16</td>
-<td class="tally" data-browser="chrome101" data-tally="1">16/16</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">16/16</td>
 <td class="tally" data-browser="chrome102" data-tally="1">16/16</td>
 <td class="tally" data-browser="chrome103" data-tally="1">16/16</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">16/16</td>
@@ -10814,7 +10814,7 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -10978,7 +10978,7 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -11142,7 +11142,7 @@ return true;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -11305,7 +11305,7 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -11469,7 +11469,7 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -11633,7 +11633,7 @@ return true;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -11798,7 +11798,7 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -11963,7 +11963,7 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -12129,7 +12129,7 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -12292,7 +12292,7 @@ return true;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -12454,7 +12454,7 @@ return b.__lookupGetter__(&quot;foo&quot;) === void undefined
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -12619,7 +12619,7 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -12784,7 +12784,7 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -12950,7 +12950,7 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -13113,7 +13113,7 @@ return true;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -13275,7 +13275,7 @@ return b.__lookupSetter__(&quot;foo&quot;) === void undefined
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -13430,7 +13430,7 @@ return b.__lookupSetter__(&quot;foo&quot;) === void undefined
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">4/4</td>
-<td class="tally" data-browser="chrome101" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">4/4</td>
 <td class="tally" data-browser="chrome102" data-tally="1">4/4</td>
 <td class="tally" data-browser="chrome103" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">4/4</td>
@@ -13592,7 +13592,7 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -13754,7 +13754,7 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -13921,7 +13921,7 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -14088,7 +14088,7 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -14247,7 +14247,7 @@ return i === 0;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -14404,7 +14404,7 @@ return i === 0;
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">2/2</td>
-<td class="tally" data-browser="chrome101" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">2/2</td>
 <td class="tally" data-browser="chrome102" data-tally="1">2/2</td>
 <td class="tally" data-browser="chrome103" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">2/2</td>
@@ -14563,7 +14563,7 @@ return a === 1 &amp;&amp; rest.a === void undefined &amp;&amp; rest.b === 2 &amp
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -14723,7 +14723,7 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -14878,7 +14878,7 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">3/3</td>
-<td class="tally" data-browser="chrome101" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">3/3</td>
 <td class="tally" data-browser="chrome102" data-tally="1">3/3</td>
 <td class="tally" data-browser="chrome103" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">3/3</td>
@@ -15062,7 +15062,7 @@ function check() {
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -15238,7 +15238,7 @@ function check() {
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -15416,7 +15416,7 @@ function check() {
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -15575,7 +15575,7 @@ return regex.test(&apos;foo\nbar&apos;);
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -15740,7 +15740,7 @@ return result.groups.year === &apos;2016&apos;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -15899,7 +15899,7 @@ return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&a
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -16058,7 +16058,7 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -16213,7 +16213,7 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">2/2</td>
-<td class="tally" data-browser="chrome101" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">2/2</td>
 <td class="tally" data-browser="chrome102" data-tally="1">2/2</td>
 <td class="tally" data-browser="chrome103" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">2/2</td>
@@ -16378,7 +16378,7 @@ iterator.next().then(function(step){
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -16553,7 +16553,7 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -16723,7 +16723,7 @@ return false;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -16888,7 +16888,7 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -17045,7 +17045,7 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">3/3</td>
-<td class="tally" data-browser="chrome101" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">3/3</td>
 <td class="tally" data-browser="chrome102" data-tally="1">3/3</td>
 <td class="tally" data-browser="chrome103" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">3/3</td>
@@ -17203,7 +17203,7 @@ return Symbol(&apos;foo&apos;).description === &apos;foo&apos;;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -17361,7 +17361,7 @@ return Symbol(&apos;&apos;).description === &apos;&apos;;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -17520,7 +17520,7 @@ return Symbol.prototype.hasOwnProperty(&apos;description&apos;)
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -17679,7 +17679,7 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -17834,7 +17834,7 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">4/4</td>
-<td class="tally" data-browser="chrome101" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">4/4</td>
 <td class="tally" data-browser="chrome102" data-tally="1">4/4</td>
 <td class="tally" data-browser="chrome103" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">4/4</td>
@@ -17992,7 +17992,7 @@ return &apos; \t \n abc   \t\n&apos;.trimLeft() === &apos;abc   \t\n&apos;;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -18150,7 +18150,7 @@ return &apos; \t \n abc   \t\n&apos;.trimRight() === &apos; \t \n abc&apos;;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -18308,7 +18308,7 @@ return &apos; \t \n abc   \t\n&apos;.trimStart() === &apos;abc   \t\n&apos;;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -18466,7 +18466,7 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -18621,7 +18621,7 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">3/3</td>
-<td class="tally" data-browser="chrome101" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">3/3</td>
 <td class="tally" data-browser="chrome102" data-tally="1">3/3</td>
 <td class="tally" data-browser="chrome103" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">3/3</td>
@@ -18779,7 +18779,7 @@ return [1, [2, 3], [4, [5, 6]]].flat().join(&apos;&apos;) === &apos;12345,6&apos
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -18939,7 +18939,7 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -19098,7 +19098,7 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -19255,7 +19255,7 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">3/3</td>
-<td class="tally" data-browser="chrome101" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">3/3</td>
 <td class="tally" data-browser="chrome102" data-tally="1">3/3</td>
 <td class="tally" data-browser="chrome103" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">3/3</td>
@@ -19419,7 +19419,7 @@ return false;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -19584,7 +19584,7 @@ return false;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -19753,7 +19753,7 @@ return it.throw().value;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -19908,7 +19908,7 @@ return it.throw().value;
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">7/7</td>
-<td class="tally" data-browser="chrome101" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">7/7</td>
 <td class="tally" data-browser="chrome102" data-tally="1">7/7</td>
 <td class="tally" data-browser="chrome103" data-tally="1">7/7</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">7/7</td>
@@ -20068,7 +20068,7 @@ return fn + &apos;&apos; === str;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -20227,7 +20227,7 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -20386,7 +20386,7 @@ return NATIVE_EVAL_RE.test(eval + &apos;&apos;);
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -20545,7 +20545,7 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -20704,7 +20704,7 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -20863,7 +20863,7 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -21022,7 +21022,7 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -21177,7 +21177,7 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">2/2</td>
-<td class="tally" data-browser="chrome101" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">2/2</td>
 <td class="tally" data-browser="chrome102" data-tally="1">2/2</td>
 <td class="tally" data-browser="chrome103" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">2/2</td>
@@ -21335,7 +21335,7 @@ return eval(&quot;&apos;\u2028&apos;&quot;) === &quot;\u2028&quot;;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -21493,7 +21493,7 @@ return eval(&quot;&apos;\u2029&apos;&quot;) === &quot;\u2029&quot;;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -21652,7 +21652,7 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -21809,7 +21809,7 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">2/2</td>
-<td class="tally" data-browser="chrome101" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">2/2</td>
 <td class="tally" data-browser="chrome102" data-tally="1">2/2</td>
 <td class="tally" data-browser="chrome103" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">2/2</td>
@@ -21977,7 +21977,7 @@ return a === &apos;1a2b&apos;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -22140,7 +22140,7 @@ try {
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -22295,7 +22295,7 @@ try {
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">8/8</td>
-<td class="tally" data-browser="chrome101" data-tally="1">8/8</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">8/8</td>
 <td class="tally" data-browser="chrome102" data-tally="1">8/8</td>
 <td class="tally" data-browser="chrome103" data-tally="1">8/8</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">8/8</td>
@@ -22453,7 +22453,7 @@ return (1n + 2n) === 3n;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -22611,7 +22611,7 @@ return BigInt(&quot;3&quot;) === 3n;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -22769,7 +22769,7 @@ return typeof BigInt.asUintN === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -22927,7 +22927,7 @@ return typeof BigInt.asIntN === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -23088,7 +23088,7 @@ return view[0] === -0x8000000000000000n;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -23249,7 +23249,7 @@ return view[0] === 0n;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -23410,7 +23410,7 @@ return view.getBigInt64(0) === 1n;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -23571,7 +23571,7 @@ return view.getBigUint64(0) === 1n;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -23740,7 +23740,7 @@ Promise.allSettled([
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -23895,7 +23895,7 @@ Promise.allSettled([
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">2/2</td>
-<td class="tally" data-browser="chrome101" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">2/2</td>
 <td class="tally" data-browser="chrome102" data-tally="1">2/2</td>
 <td class="tally" data-browser="chrome103" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">2/2</td>
@@ -24055,7 +24055,7 @@ return typeof globalThis === &apos;object&apos; &amp;&amp; globalThis &amp;&amp;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -24219,7 +24219,7 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -24374,7 +24374,7 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">5/5</td>
-<td class="tally" data-browser="chrome101" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">5/5</td>
 <td class="tally" data-browser="chrome102" data-tally="1">5/5</td>
 <td class="tally" data-browser="chrome103" data-tally="1">5/5</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">5/5</td>
@@ -24534,7 +24534,7 @@ return foo?.baz === 42 &amp;&amp; bar?.baz === void undefined;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -24694,7 +24694,7 @@ return foo?.[&apos;baz&apos;] === 42 &amp;&amp; bar?.[&apos;baz&apos;] === void 
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -24854,7 +24854,7 @@ return foo?.baz() === 42 &amp;&amp; bar?.baz() === void undefined;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -25016,7 +25016,7 @@ return foo.baz?.() === 42 &amp;&amp; bar.baz?.() === void undefined &amp;&amp; b
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -25178,7 +25178,7 @@ return fn?.(...[], 1) === void undefined &amp;&amp; fn?.(...[], ...[]) === void 
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -25341,7 +25341,7 @@ return (null ?? 42) === 42 &amp;&amp;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -25501,7 +25501,7 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -25656,7 +25656,7 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">2/2</td>
-<td class="tally" data-browser="chrome101" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">2/2</td>
 <td class="tally" data-browser="chrome102" data-tally="1">2/2</td>
 <td class="tally" data-browser="chrome103" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">2/2</td>
@@ -25820,7 +25820,7 @@ Promise.any([
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -25984,7 +25984,7 @@ Promise.any([
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -26139,7 +26139,7 @@ Promise.any([
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">2/2</td>
-<td class="tally" data-browser="chrome101" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">2/2</td>
 <td class="tally" data-browser="chrome102" data-tally="1">2/2</td>
 <td class="tally" data-browser="chrome103" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">2/2</td>
@@ -26299,7 +26299,7 @@ return weakref.deref() === O;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -26458,7 +26458,7 @@ return Object.getPrototypeOf(fr) === FinalizationRegistry.prototype;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -26613,7 +26613,7 @@ return Object.getPrototypeOf(fr) === FinalizationRegistry.prototype;
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">9/9</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">9/9</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">9/9</td>
-<td class="tally" data-browser="chrome101" data-tally="1">9/9</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">9/9</td>
 <td class="tally" data-browser="chrome102" data-tally="1">9/9</td>
 <td class="tally" data-browser="chrome103" data-tally="1">9/9</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">9/9</td>
@@ -26777,7 +26777,7 @@ return a === 2 &amp;&amp; b === 2 &amp;&amp; c === 1;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -26938,7 +26938,7 @@ return a === 1 &amp;&amp; i === 1;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -27099,7 +27099,7 @@ return i === 1;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -27263,7 +27263,7 @@ return typeof a === &apos;undefined&apos; &amp;&amp; b === 0 &amp;&amp; c === 2;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -27424,7 +27424,7 @@ return typeof a === &apos;undefined&apos; &amp;&amp; i === 1;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -27585,7 +27585,7 @@ return i === 1;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -27749,7 +27749,7 @@ return a === 2 &amp;&amp; b === 0 &amp;&amp; c === 1;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -27910,7 +27910,7 @@ return a === 1 &amp;&amp; i === 1;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -28071,7 +28071,7 @@ return i === 1;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -28230,7 +28230,7 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -28387,7 +28387,7 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">6/6</td>
-<td class="tally" data-browser="chrome101" data-tally="1">6/6</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">6/6</td>
 <td class="tally" data-browser="chrome102" data-tally="1">6/6</td>
 <td class="tally" data-browser="chrome103" data-tally="1">6/6</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">6/6</td>
@@ -28548,7 +28548,7 @@ return new C().x === &apos;x&apos;;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -28715,7 +28715,7 @@ return new C(42).x() === 42;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -28879,7 +28879,7 @@ return new C().x() === 42;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -29043,7 +29043,7 @@ return new C().x() === 42 &amp;&amp; new C().x(null) === void 0;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -29207,7 +29207,7 @@ return new C().x() === 42 &amp;&amp; new C().x(null) === void 0;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -29368,7 +29368,7 @@ return new C().x === 42;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -29523,7 +29523,7 @@ return new C().x === 42;
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">4/4</td>
-<td class="tally" data-browser="chrome101" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">4/4</td>
 <td class="tally" data-browser="chrome102" data-tally="1">4/4</td>
 <td class="tally" data-browser="chrome103" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">4/4</td>
@@ -29684,7 +29684,7 @@ return C.x === &apos;x&apos;;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -29842,7 +29842,7 @@ return (class X { static name = &quot;name&quot;; }).name === &apos;name&apos;;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -30006,7 +30006,7 @@ return new C().x() === 42;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -30167,7 +30167,7 @@ return C.x === 42;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -30322,7 +30322,7 @@ return C.x === 42;
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">4/4</td>
-<td class="tally" data-browser="chrome101" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">4/4</td>
 <td class="tally" data-browser="chrome102" data-tally="1">4/4</td>
 <td class="tally" data-browser="chrome103" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">4/4</td>
@@ -30486,7 +30486,7 @@ return new C().x() === 42;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -30650,7 +30650,7 @@ return new C().x() === 42;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -30817,7 +30817,7 @@ return new C().x() === 42 &amp;&amp; y;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -30984,7 +30984,7 @@ return new C().x() === 42 &amp;&amp; y;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -31148,7 +31148,7 @@ return A.check(new A) &amp;&amp; !A.check({});
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -31303,7 +31303,7 @@ return A.check(new A) &amp;&amp; !A.check({});
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">3/3</td>
-<td class="tally" data-browser="chrome101" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">3/3</td>
 <td class="tally" data-browser="chrome102" data-tally="1">3/3</td>
 <td class="tally" data-browser="chrome103" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">3/3</td>
@@ -31469,7 +31469,7 @@ return arr.at(0) === 1
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -31635,7 +31635,7 @@ return str.at(0) === &apos;a&apos;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -31817,7 +31817,7 @@ return [
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -31972,7 +31972,7 @@ return [
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">2/2</td>
-<td class="tally" data-browser="chrome101" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">2/2</td>
 <td class="tally" data-browser="chrome102" data-tally="1">2/2</td>
 <td class="tally" data-browser="chrome103" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">2/2</td>
@@ -32130,7 +32130,7 @@ return Object.hasOwn({ x: 2 }, &quot;x&quot;) === true;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -32294,7 +32294,7 @@ try {
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -32456,7 +32456,7 @@ return ok;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -32611,7 +32611,7 @@ return ok;
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">16/16</td>
-<td class="tally" data-browser="chrome101" data-tally="1">16/16</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">16/16</td>
 <td class="tally" data-browser="chrome102" data-tally="1">16/16</td>
 <td class="tally" data-browser="chrome103" data-tally="1">16/16</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">16/16</td>
@@ -32770,7 +32770,7 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -32928,7 +32928,7 @@ return !(&apos;cause&apos; in Error.prototype);
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -33087,7 +33087,7 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -33245,7 +33245,7 @@ return !(&apos;cause&apos; in EvalError.prototype);
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -33404,7 +33404,7 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -33562,7 +33562,7 @@ return !(&apos;cause&apos; in RangeError.prototype);
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -33721,7 +33721,7 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -33879,7 +33879,7 @@ return !(&apos;cause&apos; in ReferenceError.prototype);
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -34038,7 +34038,7 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -34196,7 +34196,7 @@ return !(&apos;cause&apos; in SyntaxError.prototype);
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -34355,7 +34355,7 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -34513,7 +34513,7 @@ return !(&apos;cause&apos; in TypeError.prototype);
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -34672,7 +34672,7 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -34830,7 +34830,7 @@ return !(&apos;cause&apos; in URIError.prototype);
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -34989,7 +34989,7 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -35147,7 +35147,7 @@ return !(&apos;cause&apos; in AggregateError.prototype);
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -35302,7 +35302,7 @@ return !(&apos;cause&apos; in AggregateError.prototype);
 <td class="tally obsolete" data-browser="chrome98" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally" data-browser="chrome101" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally" data-browser="chrome102" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally" data-browser="chrome103" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
@@ -35460,7 +35460,7 @@ return new RegExp(&apos;a&apos;, &apos;d&apos;) instanceof RegExp;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -35633,7 +35633,7 @@ return true;
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -163,11 +163,6 @@
 <th class="platform firefox102 desktop unstable" data-browser="firefox102"><a href="#firefox102" class="browser-name"><abbr title="Firefox 102 Beta">FF 102</abbr></a></th>
 <th class="platform firefox103 desktop unstable" data-browser="firefox103"><a href="#firefox103" class="browser-name"><abbr title="Firefox 103 Nightly">FF 103</abbr></a></th>
 <th class="platform opera12_10 desktop obsolete" data-browser="opera12_10"><a href="#opera12_10" class="browser-name"><abbr title="Opera 12.10">OP 12.10</abbr></a></th>
-<th class="platform chrome86 desktop obsolete" data-browser="chrome86"><a href="#chrome86" class="browser-name"><abbr title="Chrome 86">CH 86</abbr></a></th>
-<th class="platform chrome87 desktop obsolete" data-browser="chrome87"><a href="#chrome87" class="browser-name"><abbr title="Chrome 87">CH 87</abbr></a></th>
-<th class="platform chrome88 desktop obsolete" data-browser="chrome88"><a href="#chrome88" class="browser-name"><abbr title="Chrome 88">CH 88</abbr></a></th>
-<th class="platform chrome89 desktop obsolete" data-browser="chrome89"><a href="#chrome89" class="browser-name"><abbr title="Chrome 89">CH 89</abbr></a></th>
-<th class="platform chrome90 desktop obsolete" data-browser="chrome90"><a href="#chrome90" class="browser-name"><abbr title="Chrome 90">CH 90</abbr></a></th>
 <th class="platform chrome91 desktop obsolete" data-browser="chrome91"><a href="#chrome91" class="browser-name"><abbr title="Chrome 91">CH 91</abbr></a></th>
 <th class="platform chrome92 desktop obsolete" data-browser="chrome92"><a href="#chrome92" class="browser-name"><abbr title="Chrome 92">CH 92</abbr></a></th>
 <th class="platform chrome93 desktop obsolete" data-browser="chrome93"><a href="#chrome93" class="browser-name"><abbr title="Chrome 93">CH 93</abbr></a></th>
@@ -176,9 +171,12 @@
 <th class="platform chrome96 desktop obsolete" data-browser="chrome96"><a href="#chrome96" class="browser-name"><abbr title="Chrome 96">CH 96</abbr></a></th>
 <th class="platform chrome97 desktop obsolete" data-browser="chrome97"><a href="#chrome97" class="browser-name"><abbr title="Chrome 97">CH 97</abbr></a></th>
 <th class="platform chrome98 desktop obsolete" data-browser="chrome98"><a href="#chrome98" class="browser-name"><abbr title="Chrome 98">CH 98</abbr></a></th>
-<th class="platform chrome99 desktop" data-browser="chrome99"><a href="#chrome99" class="browser-name"><abbr title="Chrome 99">CH 99</abbr></a></th>
-<th class="platform chrome100 desktop" data-browser="chrome100"><a href="#chrome100" class="browser-name"><abbr title="Chrome 100">CH 100</abbr></a></th>
-<th class="platform chrome101 desktop unstable" data-browser="chrome101"><a href="#chrome101" class="browser-name"><abbr title="Chrome 101 Beta">CH 101</abbr></a></th>
+<th class="platform chrome99 desktop obsolete" data-browser="chrome99"><a href="#chrome99" class="browser-name"><abbr title="Chrome 99">CH 99</abbr></a></th>
+<th class="platform chrome100 desktop obsolete" data-browser="chrome100"><a href="#chrome100" class="browser-name"><abbr title="Chrome 100">CH 100</abbr></a></th>
+<th class="platform chrome101 desktop" data-browser="chrome101"><a href="#chrome101" class="browser-name"><abbr title="Chrome 101">CH 101</abbr></a></th>
+<th class="platform chrome102 desktop" data-browser="chrome102"><a href="#chrome102" class="browser-name"><abbr title="Chrome 102">CH 102</abbr></a></th>
+<th class="platform chrome103 desktop" data-browser="chrome103"><a href="#chrome103" class="browser-name"><abbr title="Chrome 103">CH 103</abbr></a></th>
+<th class="platform chrome104 desktop unstable" data-browser="chrome104"><a href="#chrome104" class="browser-name"><abbr title="Chrome 104 Beta">CH 104</abbr></a></th>
 <th class="platform edge18 desktop obsolete" data-browser="edge18"><a href="#edge18" class="browser-name"><abbr title="Microsoft Edge 18">Edge 18</abbr></a></th>
 <th class="platform edge87 desktop obsolete" data-browser="edge87"><a href="#edge87" class="browser-name"><abbr title="Microsoft Edge 87">Edge 87</abbr></a></th>
 <th class="platform edge88 desktop obsolete" data-browser="edge88"><a href="#edge88" class="browser-name"><abbr title="Microsoft Edge 88">Edge 88</abbr></a></th>
@@ -198,15 +196,17 @@
 <th class="platform safari15_2 desktop" data-browser="safari15_2"><a href="#safari15_2" class="browser-name"><abbr title="Safari 15.2">SF&#xA0;15.2</abbr></a></th>
 <th class="platform safaritp desktop unstable" data-browser="safaritp"><a href="#safaritp" class="browser-name"><abbr title="Safari Technology Preview Release 133">SF TP</abbr></a></th>
 <th class="platform webkit desktop unstable" data-browser="webkit"><a href="#webkit" class="browser-name"><abbr title="Webkit Nightly">WK</abbr></a></th>
-<th class="platform opera73 desktop obsolete" data-browser="opera73"><a href="#opera73" class="browser-name"><abbr title="Opera 73">OP 73</abbr></a></th>
-<th class="platform opera74 desktop obsolete" data-browser="opera74"><a href="#opera74" class="browser-name"><abbr title="Opera 74">OP 74</abbr></a></th>
-<th class="platform opera75 desktop obsolete" data-browser="opera75"><a href="#opera75" class="browser-name"><abbr title="Opera 75">OP 75</abbr></a></th>
-<th class="platform opera76 desktop obsolete" data-browser="opera76"><a href="#opera76" class="browser-name"><abbr title="Opera 76">OP 76</abbr></a></th>
-<th class="platform opera77 desktop obsolete" data-browser="opera77"><a href="#opera77" class="browser-name"><abbr title="Opera 77">OP 77</abbr></a></th>
-<th class="platform opera78 desktop obsolete" data-browser="opera78"><a href="#opera78" class="browser-name"><abbr title="Opera 78">OP 78</abbr></a></th>
-<th class="platform opera79 desktop" data-browser="opera79"><a href="#opera79" class="browser-name"><abbr title="Opera 79">OP 79</abbr></a></th>
-<th class="platform opera80 desktop" data-browser="opera80"><a href="#opera80" class="browser-name"><abbr title="Opera 80">OP 80</abbr></a></th>
-<th class="platform opera81 desktop unstable" data-browser="opera81"><a href="#opera81" class="browser-name"><abbr title="Opera 81">OP 81</abbr></a></th>
+<th class="platform opera79 desktop obsolete" data-browser="opera79"><a href="#opera79" class="browser-name"><abbr title="Opera 79">OP 79</abbr></a></th>
+<th class="platform opera80 desktop obsolete" data-browser="opera80"><a href="#opera80" class="browser-name"><abbr title="Opera 80">OP 80</abbr></a></th>
+<th class="platform opera81 desktop obsolete" data-browser="opera81"><a href="#opera81" class="browser-name"><abbr title="Opera 81">OP 82</abbr></a></th>
+<th class="platform opera82 desktop obsolete" data-browser="opera82"><a href="#opera82" class="browser-name"><abbr title="Opera 82">OP 82</abbr></a></th>
+<th class="platform opera83 desktop obsolete" data-browser="opera83"><a href="#opera83" class="browser-name"><abbr title="Opera 83">OP 83</abbr></a></th>
+<th class="platform opera84 desktop obsolete" data-browser="opera84"><a href="#opera84" class="browser-name"><abbr title="Opera 84">OP 84</abbr></a></th>
+<th class="platform opera85 desktop obsolete" data-browser="opera85"><a href="#opera85" class="browser-name"><abbr title="Opera 85">OP 85</abbr></a></th>
+<th class="platform opera86 desktop obsolete" data-browser="opera86"><a href="#opera86" class="browser-name"><abbr title="Opera 86">OP 86</abbr></a></th>
+<th class="platform opera87 desktop" data-browser="opera87"><a href="#opera87" class="browser-name"><abbr title="Opera 87">OP 87</abbr></a></th>
+<th class="platform opera88 desktop" data-browser="opera88"><a href="#opera88" class="browser-name"><abbr title="Opera 88">OP 88</abbr></a></th>
+<th class="platform opera89 desktop unstable" data-browser="opera89"><a href="#opera89" class="browser-name"><abbr title="Opera 89">OP 89</abbr></a></th>
 <th class="platform rhino1_7_13 engine obsolete" data-browser="rhino1_7_13"><a href="#rhino1_7_13" class="browser-name"><abbr title="Rhino 1.7.13">Rhino 1.7.13</abbr></a></th>
 <th class="platform rhino1_7_14 engine obsolete" data-browser="rhino1_7_14"><a href="#rhino1_7_14" class="browser-name"><abbr title="Rhino 1.7.14">Rhino 1.7.14</abbr></a></th>
 <th class="platform phantom2_1 engine obsolete" data-browser="phantom2_1"><a href="#phantom2_1" class="browser-name"><abbr title="PhantomJS 2.1">PJS</abbr></a></th>
@@ -324,11 +324,6 @@
 <td class="tally unstable" data-browser="firefox102" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">3/3</td>
@@ -337,9 +332,12 @@
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">3/3</td>
-<td class="tally" data-browser="chrome99" data-tally="1">3/3</td>
-<td class="tally" data-browser="chrome100" data-tally="1">3/3</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">3/3</td>
+<td class="tally" data-browser="chrome101" data-tally="1">3/3</td>
+<td class="tally" data-browser="chrome102" data-tally="1">3/3</td>
+<td class="tally" data-browser="chrome103" data-tally="1">3/3</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="1">3/3</td>
@@ -359,15 +357,17 @@
 <td class="tally" data-browser="safari15_2" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">3/3</td>
-<td class="tally" data-browser="opera79" data-tally="1">3/3</td>
-<td class="tally" data-browser="opera80" data-tally="1">3/3</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">3/3</td>
+<td class="tally" data-browser="opera87" data-tally="1">3/3</td>
+<td class="tally" data-browser="opera88" data-tally="1">3/3</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/3</td>
@@ -482,11 +482,6 @@ return 2 ** 3 === 8 &amp;&amp; -(5 ** 2) === -25 &amp;&amp; (-5) ** 2 === 25;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -495,9 +490,12 @@ return 2 ** 3 === 8 &amp;&amp; -(5 ** 2) === -25 &amp;&amp; (-5) ** 2 === 25;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -517,15 +515,17 @@ return 2 ** 3 === 8 &amp;&amp; -(5 ** 2) === -25 &amp;&amp; (-5) ** 2 === 25;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -640,11 +640,6 @@ var a = 2; a **= 3; return a === 8;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -653,9 +648,12 @@ var a = 2; a **= 3; return a === 8;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -675,15 +673,17 @@ var a = 2; a **= 3; return a === 8;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -803,11 +803,6 @@ return true;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -816,9 +811,12 @@ return true;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -838,15 +836,17 @@ return true;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -958,11 +958,6 @@ return true;
 <td class="tally unstable" data-browser="firefox102" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">4/4</td>
@@ -971,9 +966,12 @@ return true;
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">4/4</td>
-<td class="tally" data-browser="chrome99" data-tally="1">4/4</td>
-<td class="tally" data-browser="chrome100" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">4/4</td>
+<td class="tally" data-browser="chrome101" data-tally="1">4/4</td>
+<td class="tally" data-browser="chrome102" data-tally="1">4/4</td>
+<td class="tally" data-browser="chrome103" data-tally="1">4/4</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="1">4/4</td>
@@ -993,15 +991,17 @@ return true;
 <td class="tally" data-browser="safari15_2" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">4/4</td>
-<td class="tally" data-browser="opera79" data-tally="1">4/4</td>
-<td class="tally" data-browser="opera80" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">4/4</td>
+<td class="tally" data-browser="opera87" data-tally="1">4/4</td>
+<td class="tally" data-browser="opera88" data-tally="1">4/4</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/4</td>
@@ -1119,11 +1119,6 @@ return [1, 2, 3].includes(1)
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -1132,9 +1127,12 @@ return [1, 2, 3].includes(1)
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -1154,15 +1152,17 @@ return [1, 2, 3].includes(1)
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -1278,11 +1278,6 @@ return [,].includes()
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -1291,9 +1286,12 @@ return [,].includes()
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -1313,15 +1311,17 @@ return [,].includes()
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -1458,11 +1458,6 @@ return 24;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -1471,9 +1466,12 @@ return 24;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -1493,15 +1491,17 @@ return 24;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -1621,11 +1621,6 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -1634,9 +1629,12 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -1656,15 +1654,17 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -1788,11 +1788,6 @@ return true;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -1801,9 +1796,12 @@ return true;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -1823,15 +1821,17 @@ return true;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -1959,11 +1959,6 @@ return iter[&apos;throw&apos;]().value === &apos;bar&apos;;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -1972,9 +1967,12 @@ return iter[&apos;throw&apos;]().value === &apos;bar&apos;;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -1994,15 +1992,17 @@ return iter[&apos;throw&apos;]().value === &apos;bar&apos;;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -2122,11 +2122,6 @@ return true;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -2135,9 +2130,12 @@ return true;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -2157,15 +2155,17 @@ return true;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -2281,11 +2281,6 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -2294,9 +2289,12 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -2316,15 +2314,17 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -2441,11 +2441,6 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -2454,9 +2449,12 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -2476,15 +2474,17 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -2606,11 +2606,6 @@ return passed;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -2619,9 +2614,12 @@ return passed;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -2641,15 +2639,17 @@ return passed;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -2773,11 +2773,6 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -2786,9 +2781,12 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -2808,15 +2806,17 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -2930,11 +2930,6 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="tally unstable" data-browser="firefox102" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">4/4</td>
@@ -2943,9 +2938,12 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">4/4</td>
-<td class="tally" data-browser="chrome99" data-tally="1">4/4</td>
-<td class="tally" data-browser="chrome100" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">4/4</td>
+<td class="tally" data-browser="chrome101" data-tally="1">4/4</td>
+<td class="tally" data-browser="chrome102" data-tally="1">4/4</td>
+<td class="tally" data-browser="chrome103" data-tally="1">4/4</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="1">4/4</td>
@@ -2965,15 +2963,17 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="tally" data-browser="safari15_2" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">4/4</td>
-<td class="tally" data-browser="opera79" data-tally="1">4/4</td>
-<td class="tally" data-browser="opera80" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">4/4</td>
+<td class="tally" data-browser="opera87" data-tally="1">4/4</td>
+<td class="tally" data-browser="opera88" data-tally="1">4/4</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/4</td>
@@ -3091,11 +3091,6 @@ return Array.isArray(v) &amp;&amp; String(v) === &quot;foo,bar,baz&quot;;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -3104,9 +3099,12 @@ return Array.isArray(v) &amp;&amp; String(v) === &quot;foo,bar,baz&quot;;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -3126,15 +3124,17 @@ return Array.isArray(v) &amp;&amp; String(v) === &quot;foo,bar,baz&quot;;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -3256,11 +3256,6 @@ return Array.isArray(e)
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -3269,9 +3264,12 @@ return Array.isArray(e)
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -3291,15 +3289,17 @@ return Array.isArray(e)
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -3422,11 +3422,6 @@ return D.a.value === 1 &amp;&amp; D.a.enumerable === true &amp;&amp; D.a.configu
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -3435,9 +3430,12 @@ return D.a.value === 1 &amp;&amp; D.a.enumerable === true &amp;&amp; D.a.configu
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -3457,15 +3455,17 @@ return D.a.value === 1 &amp;&amp; D.a.enumerable === true &amp;&amp; D.a.configu
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -3583,11 +3583,6 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -3596,9 +3591,12 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -3618,15 +3616,17 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -3738,11 +3738,6 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="tally unstable" data-browser="firefox102" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">2/2</td>
@@ -3751,9 +3746,12 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">2/2</td>
-<td class="tally" data-browser="chrome99" data-tally="1">2/2</td>
-<td class="tally" data-browser="chrome100" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">2/2</td>
+<td class="tally" data-browser="chrome101" data-tally="1">2/2</td>
+<td class="tally" data-browser="chrome102" data-tally="1">2/2</td>
+<td class="tally" data-browser="chrome103" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="1">2/2</td>
@@ -3773,15 +3771,17 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="tally" data-browser="safari15_2" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">2/2</td>
-<td class="tally" data-browser="opera79" data-tally="1">2/2</td>
-<td class="tally" data-browser="opera80" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">2/2</td>
+<td class="tally" data-browser="opera87" data-tally="1">2/2</td>
+<td class="tally" data-browser="opera88" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/2</td>
@@ -3901,11 +3901,6 @@ return &apos;hello&apos;.padStart(10) === &apos;     hello&apos;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -3914,9 +3909,12 @@ return &apos;hello&apos;.padStart(10) === &apos;     hello&apos;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -3936,15 +3934,17 @@ return &apos;hello&apos;.padStart(10) === &apos;     hello&apos;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -4064,11 +4064,6 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -4077,9 +4072,12 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -4099,15 +4097,17 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -4219,11 +4219,6 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="tally unstable" data-browser="firefox102" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">2/2</td>
@@ -4232,9 +4227,12 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">2/2</td>
-<td class="tally" data-browser="chrome99" data-tally="1">2/2</td>
-<td class="tally" data-browser="chrome100" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">2/2</td>
+<td class="tally" data-browser="chrome101" data-tally="1">2/2</td>
+<td class="tally" data-browser="chrome102" data-tally="1">2/2</td>
+<td class="tally" data-browser="chrome103" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="1">2/2</td>
@@ -4254,15 +4252,17 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="tally" data-browser="safari15_2" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">2/2</td>
-<td class="tally" data-browser="opera79" data-tally="1">2/2</td>
-<td class="tally" data-browser="opera80" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">2/2</td>
+<td class="tally" data-browser="opera87" data-tally="1">2/2</td>
+<td class="tally" data-browser="opera88" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/2</td>
@@ -4377,11 +4377,6 @@ return typeof function f( a, b, ){} === &apos;function&apos;;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -4390,9 +4385,12 @@ return typeof function f( a, b, ){} === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -4412,15 +4410,17 @@ return typeof function f( a, b, ){} === &apos;function&apos;;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -4535,11 +4535,6 @@ return Math.min(1,2,3,) === 1;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -4548,9 +4543,12 @@ return Math.min(1,2,3,) === 1;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -4570,15 +4568,17 @@ return Math.min(1,2,3,) === 1;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -4690,11 +4690,6 @@ return Math.min(1,2,3,) === 1;
 <td class="tally unstable" data-browser="firefox102" data-tally="1">16/16</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/16</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="1">16/16</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="1">16/16</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="1">16/16</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="1">16/16</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">16/16</td>
@@ -4703,9 +4698,12 @@ return Math.min(1,2,3,) === 1;
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">16/16</td>
-<td class="tally" data-browser="chrome99" data-tally="1">16/16</td>
-<td class="tally" data-browser="chrome100" data-tally="1">16/16</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">16/16</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">16/16</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">16/16</td>
+<td class="tally" data-browser="chrome101" data-tally="1">16/16</td>
+<td class="tally" data-browser="chrome102" data-tally="1">16/16</td>
+<td class="tally" data-browser="chrome103" data-tally="1">16/16</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="1">16/16</td>
@@ -4725,15 +4723,17 @@ return Math.min(1,2,3,) === 1;
 <td class="tally" data-browser="safari15_2" data-tally="1">16/16</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">16/16</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">16/16</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="1">16/16</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="1">16/16</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="1">16/16</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="1">16/16</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="1">16/16</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">16/16</td>
-<td class="tally" data-browser="opera79" data-tally="1">16/16</td>
-<td class="tally" data-browser="opera80" data-tally="1">16/16</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">16/16</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">16/16</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">16/16</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">16/16</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">16/16</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">16/16</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">16/16</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">16/16</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">16/16</td>
+<td class="tally" data-browser="opera87" data-tally="1">16/16</td>
+<td class="tally" data-browser="opera88" data-tally="1">16/16</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/16</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0">0/16</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/16</td>
@@ -4859,11 +4859,6 @@ p.then(function(result) {
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -4872,9 +4867,12 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -4894,15 +4892,17 @@ p.then(function(result) {
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -5028,11 +5028,6 @@ p.catch(function(result) {
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -5041,9 +5036,12 @@ p.catch(function(result) {
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -5063,15 +5061,17 @@ p.catch(function(result) {
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -5187,11 +5187,6 @@ try { Function(&quot;async\n function a(){await 0}&quot;)(); } catch(e) { return
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -5200,9 +5195,12 @@ try { Function(&quot;async\n function a(){await 0}&quot;)(); } catch(e) { return
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -5222,15 +5220,17 @@ try { Function(&quot;async\n function a(){await 0}&quot;)(); } catch(e) { return
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -5346,11 +5346,6 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -5359,9 +5354,12 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -5381,15 +5379,17 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -5511,11 +5511,6 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -5524,9 +5519,12 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -5546,15 +5544,17 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -5678,11 +5678,6 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -5691,9 +5686,12 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -5713,15 +5711,17 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -5837,11 +5837,6 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -5850,9 +5845,12 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -5872,15 +5870,17 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -6001,11 +6001,6 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -6014,9 +6009,12 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -6036,15 +6034,17 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -6160,11 +6160,6 @@ try { Function(&quot;(async function a(b = await Promise.resolve()){}())&quot;)(
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -6173,9 +6168,12 @@ try { Function(&quot;(async function a(b = await Promise.resolve()){}())&quot;)(
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -6195,15 +6193,17 @@ try { Function(&quot;(async function a(b = await Promise.resolve()){}())&quot;)(
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -6329,11 +6329,6 @@ p.then(function(result) {
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -6342,9 +6337,12 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -6364,15 +6362,17 @@ p.then(function(result) {
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -6498,11 +6498,6 @@ p.then(function(result) {
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -6511,9 +6506,12 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -6533,15 +6531,17 @@ p.then(function(result) {
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -6667,11 +6667,6 @@ var p = new C().a();
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -6680,9 +6675,12 @@ var p = new C().a();
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -6702,15 +6700,17 @@ var p = new C().a();
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -6834,11 +6834,6 @@ p.then(function(result) {
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -6847,9 +6842,12 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -6869,15 +6867,17 @@ p.then(function(result) {
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -6994,11 +6994,6 @@ return asyncFunctionProto !== function(){}.prototype
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -7007,9 +7002,12 @@ return asyncFunctionProto !== function(){}.prototype
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -7029,15 +7027,17 @@ return asyncFunctionProto !== function(){}.prototype
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -7152,11 +7152,6 @@ return Object.getPrototypeOf(async function (){})[Symbol.toStringTag] === &quot;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -7165,9 +7160,12 @@ return Object.getPrototypeOf(async function (){})[Symbol.toStringTag] === &quot;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -7187,15 +7185,17 @@ return Object.getPrototypeOf(async function (){})[Symbol.toStringTag] === &quot;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -7319,11 +7319,6 @@ p.then(function(result) {
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -7332,9 +7327,12 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -7354,15 +7352,17 @@ p.then(function(result) {
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -7474,11 +7474,6 @@ p.then(function(result) {
 <td class="tally unstable" data-browser="firefox102" data-tally="1">17/17</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">17/17</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/17</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="1">17/17</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="1">17/17</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="1">17/17</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="1">17/17</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="1">17/17</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="1">17/17</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">17/17</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">17/17</td>
@@ -7487,9 +7482,12 @@ p.then(function(result) {
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">17/17</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">17/17</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">17/17</td>
-<td class="tally" data-browser="chrome99" data-tally="1">17/17</td>
-<td class="tally" data-browser="chrome100" data-tally="1">17/17</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">17/17</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">17/17</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">17/17</td>
+<td class="tally" data-browser="chrome101" data-tally="1">17/17</td>
+<td class="tally" data-browser="chrome102" data-tally="1">17/17</td>
+<td class="tally" data-browser="chrome103" data-tally="1">17/17</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">17/17</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="1">17/17</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="1">17/17</td>
@@ -7509,15 +7507,17 @@ p.then(function(result) {
 <td class="tally" data-browser="safari15_2" data-tally="1">17/17</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">17/17</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">17/17</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="1">17/17</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="1">17/17</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="1">17/17</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="1">17/17</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="1">17/17</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">17/17</td>
-<td class="tally" data-browser="opera79" data-tally="1">17/17</td>
-<td class="tally" data-browser="opera80" data-tally="1">17/17</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">17/17</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">17/17</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">17/17</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">17/17</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">17/17</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">17/17</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">17/17</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">17/17</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">17/17</td>
+<td class="tally" data-browser="opera87" data-tally="1">17/17</td>
+<td class="tally" data-browser="opera88" data-tally="1">17/17</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">17/17</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/17</td>
@@ -7632,11 +7632,6 @@ return typeof SharedArrayBuffer === &apos;function&apos;;
 <td class="yes unstable" data-browser="firefox102">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[16]</sup></a></td>
 <td class="yes unstable" data-browser="firefox103">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -7645,9 +7640,12 @@ return typeof SharedArrayBuffer === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[17]</sup></a></td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -7667,15 +7665,17 @@ return typeof SharedArrayBuffer === &apos;function&apos;;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -7790,11 +7790,6 @@ return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
 <td class="yes unstable" data-browser="firefox102">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[16]</sup></a></td>
 <td class="yes unstable" data-browser="firefox103">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -7803,9 +7798,12 @@ return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[17]</sup></a></td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -7825,15 +7823,17 @@ return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -7948,11 +7948,6 @@ return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
 <td class="yes unstable" data-browser="firefox102">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[16]</sup></a></td>
 <td class="yes unstable" data-browser="firefox103">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -7961,9 +7956,12 @@ return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[17]</sup></a></td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -7983,15 +7981,17 @@ return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -8106,11 +8106,6 @@ return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
 <td class="yes unstable" data-browser="firefox102">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[16]</sup></a></td>
 <td class="yes unstable" data-browser="firefox103">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -8119,9 +8114,12 @@ return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[17]</sup></a></td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -8141,15 +8139,17 @@ return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -8264,11 +8264,6 @@ return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuff
 <td class="yes unstable" data-browser="firefox102">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[16]</sup></a></td>
 <td class="yes unstable" data-browser="firefox103">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -8277,9 +8272,12 @@ return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuff
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[17]</sup></a></td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -8299,15 +8297,17 @@ return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuff
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -8422,11 +8422,6 @@ return typeof Atomics.add === &apos;function&apos;;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -8435,9 +8430,12 @@ return typeof Atomics.add === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[17]</sup></a></td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -8457,15 +8455,17 @@ return typeof Atomics.add === &apos;function&apos;;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -8580,11 +8580,6 @@ return typeof Atomics.and === &apos;function&apos;;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -8593,9 +8588,12 @@ return typeof Atomics.and === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[17]</sup></a></td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -8615,15 +8613,17 @@ return typeof Atomics.and === &apos;function&apos;;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -8738,11 +8738,6 @@ return typeof Atomics.compareExchange === &apos;function&apos;;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -8751,9 +8746,12 @@ return typeof Atomics.compareExchange === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[17]</sup></a></td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -8773,15 +8771,17 @@ return typeof Atomics.compareExchange === &apos;function&apos;;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -8896,11 +8896,6 @@ return typeof Atomics.exchange === &apos;function&apos;;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -8909,9 +8904,12 @@ return typeof Atomics.exchange === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[17]</sup></a></td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -8931,15 +8929,17 @@ return typeof Atomics.exchange === &apos;function&apos;;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -9054,11 +9054,6 @@ return typeof Atomics.wait === &apos;function&apos;;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -9067,9 +9062,12 @@ return typeof Atomics.wait === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[17]</sup></a></td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -9089,15 +9087,17 @@ return typeof Atomics.wait === &apos;function&apos;;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -9212,11 +9212,6 @@ return typeof Atomics.notify === &apos;function&apos;;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -9225,9 +9220,12 @@ return typeof Atomics.notify === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[17]</sup></a></td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -9247,15 +9245,17 @@ return typeof Atomics.notify === &apos;function&apos;;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -9370,11 +9370,6 @@ return typeof Atomics.isLockFree === &apos;function&apos;;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -9383,9 +9378,12 @@ return typeof Atomics.isLockFree === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[17]</sup></a></td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -9405,15 +9403,17 @@ return typeof Atomics.isLockFree === &apos;function&apos;;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -9528,11 +9528,6 @@ return typeof Atomics.load === &apos;function&apos;;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -9541,9 +9536,12 @@ return typeof Atomics.load === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[17]</sup></a></td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -9563,15 +9561,17 @@ return typeof Atomics.load === &apos;function&apos;;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -9686,11 +9686,6 @@ return typeof Atomics.or === &apos;function&apos;;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -9699,9 +9694,12 @@ return typeof Atomics.or === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[17]</sup></a></td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -9721,15 +9719,17 @@ return typeof Atomics.or === &apos;function&apos;;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -9844,11 +9844,6 @@ return typeof Atomics.store === &apos;function&apos;;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -9857,9 +9852,12 @@ return typeof Atomics.store === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[17]</sup></a></td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -9879,15 +9877,17 @@ return typeof Atomics.store === &apos;function&apos;;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -10002,11 +10002,6 @@ return typeof Atomics.sub === &apos;function&apos;;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -10015,9 +10010,12 @@ return typeof Atomics.sub === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[17]</sup></a></td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -10037,15 +10035,17 @@ return typeof Atomics.sub === &apos;function&apos;;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -10160,11 +10160,6 @@ return typeof Atomics.xor === &apos;function&apos;;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -10173,9 +10168,12 @@ return typeof Atomics.xor === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[17]</sup></a></td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -10195,15 +10193,17 @@ return typeof Atomics.xor === &apos;function&apos;;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -10323,11 +10323,6 @@ return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -10336,9 +10331,12 @@ return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -10358,15 +10356,17 @@ return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -10484,11 +10484,6 @@ return (function(){
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -10497,9 +10492,12 @@ return (function(){
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -10519,15 +10517,17 @@ return (function(){
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -10641,11 +10641,6 @@ return (function(){
 <td class="tally unstable" data-browser="firefox102" data-tally="1">16/16</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="1">16/16</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="1">16/16</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="1">16/16</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="1">16/16</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">16/16</td>
@@ -10654,9 +10649,12 @@ return (function(){
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">16/16</td>
-<td class="tally" data-browser="chrome99" data-tally="1">16/16</td>
-<td class="tally" data-browser="chrome100" data-tally="1">16/16</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">16/16</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">16/16</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">16/16</td>
+<td class="tally" data-browser="chrome101" data-tally="1">16/16</td>
+<td class="tally" data-browser="chrome102" data-tally="1">16/16</td>
+<td class="tally" data-browser="chrome103" data-tally="1">16/16</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="0.875" style="background-color:hsl(105,47%,50%)">14/16</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="1">16/16</td>
@@ -10676,15 +10674,17 @@ return (function(){
 <td class="tally" data-browser="safari15_2" data-tally="1">16/16</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">16/16</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">16/16</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="1">16/16</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="1">16/16</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="1">16/16</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="1">16/16</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="1">16/16</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">16/16</td>
-<td class="tally" data-browser="opera79" data-tally="1">16/16</td>
-<td class="tally" data-browser="opera80" data-tally="1">16/16</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">16/16</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">16/16</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">16/16</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">16/16</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">16/16</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">16/16</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">16/16</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">16/16</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">16/16</td>
+<td class="tally" data-browser="opera87" data-tally="1">16/16</td>
+<td class="tally" data-browser="opera88" data-tally="1">16/16</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">16/16</td>
 <td class="tally obsolete not-applicable" data-browser="rhino1_7_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.625">10/16</td>
 <td class="tally obsolete not-applicable" data-browser="rhino1_7_14" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.625">10/16</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
@@ -10804,11 +10804,6 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -10817,9 +10812,12 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -10839,15 +10837,17 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="rhino1_7_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="rhino1_7_14" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
@@ -10968,11 +10968,6 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -10981,9 +10976,12 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -11003,15 +11001,17 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="rhino1_7_14" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -11132,11 +11132,6 @@ return true;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -11145,9 +11140,12 @@ return true;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -11167,15 +11165,17 @@ return true;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="rhino1_7_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="rhino1_7_14" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
@@ -11295,11 +11295,6 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -11308,9 +11303,12 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -11330,15 +11328,17 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="rhino1_7_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="rhino1_7_14" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
@@ -11459,11 +11459,6 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -11472,9 +11467,12 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -11494,15 +11492,17 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="rhino1_7_14" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -11623,11 +11623,6 @@ return true;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -11636,9 +11631,12 @@ return true;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -11658,15 +11656,17 @@ return true;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="rhino1_7_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="rhino1_7_14" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
@@ -11788,11 +11788,6 @@ return foo() === &quot;bar&quot;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -11801,9 +11796,12 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -11823,15 +11821,17 @@ return foo() === &quot;bar&quot;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="rhino1_7_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="rhino1_7_14" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
@@ -11953,11 +11953,6 @@ return foo() === &quot;bar&quot;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -11966,9 +11961,12 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -11988,15 +11986,17 @@ return foo() === &quot;bar&quot;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="rhino1_7_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="rhino1_7_14" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
@@ -12119,11 +12119,6 @@ return foo() === &quot;bar&quot;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -12132,9 +12127,12 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -12154,15 +12152,17 @@ return foo() === &quot;bar&quot;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="rhino1_7_14" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -12282,11 +12282,6 @@ return true;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -12295,9 +12290,12 @@ return true;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -12317,15 +12315,17 @@ return true;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="rhino1_7_14" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
@@ -12444,11 +12444,6 @@ return b.__lookupGetter__(&quot;foo&quot;) === void undefined
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -12457,9 +12452,12 @@ return b.__lookupGetter__(&quot;foo&quot;) === void undefined
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -12479,15 +12477,17 @@ return b.__lookupGetter__(&quot;foo&quot;) === void undefined
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="rhino1_7_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="rhino1_7_14" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
@@ -12609,11 +12609,6 @@ return foo() === &quot;bar&quot;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -12622,9 +12617,12 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -12644,15 +12642,17 @@ return foo() === &quot;bar&quot;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="rhino1_7_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="rhino1_7_14" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
@@ -12774,11 +12774,6 @@ return foo() === &quot;bar&quot;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -12787,9 +12782,12 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -12809,15 +12807,17 @@ return foo() === &quot;bar&quot;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="rhino1_7_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="rhino1_7_14" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
@@ -12940,11 +12940,6 @@ return foo() === &quot;bar&quot;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -12953,9 +12948,12 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -12975,15 +12973,17 @@ return foo() === &quot;bar&quot;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="rhino1_7_14" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -13103,11 +13103,6 @@ return true;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -13116,9 +13111,12 @@ return true;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -13138,15 +13136,17 @@ return true;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="rhino1_7_14" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
@@ -13265,11 +13265,6 @@ return b.__lookupSetter__(&quot;foo&quot;) === void undefined
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -13278,9 +13273,12 @@ return b.__lookupSetter__(&quot;foo&quot;) === void undefined
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -13300,15 +13298,17 @@ return b.__lookupSetter__(&quot;foo&quot;) === void undefined
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="rhino1_7_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="rhino1_7_14" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
@@ -13420,11 +13420,6 @@ return b.__lookupSetter__(&quot;foo&quot;) === void undefined
 <td class="tally unstable" data-browser="firefox102" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">4/4</td>
@@ -13433,9 +13428,12 @@ return b.__lookupSetter__(&quot;foo&quot;) === void undefined
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">4/4</td>
-<td class="tally" data-browser="chrome99" data-tally="1">4/4</td>
-<td class="tally" data-browser="chrome100" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">4/4</td>
+<td class="tally" data-browser="chrome101" data-tally="1">4/4</td>
+<td class="tally" data-browser="chrome102" data-tally="1">4/4</td>
+<td class="tally" data-browser="chrome103" data-tally="1">4/4</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="1">4/4</td>
@@ -13455,15 +13453,17 @@ return b.__lookupSetter__(&quot;foo&quot;) === void undefined
 <td class="tally" data-browser="safari15_2" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">4/4</td>
-<td class="tally" data-browser="opera79" data-tally="1">4/4</td>
-<td class="tally" data-browser="opera80" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">4/4</td>
+<td class="tally" data-browser="opera87" data-tally="1">4/4</td>
+<td class="tally" data-browser="opera88" data-tally="1">4/4</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">4/4</td>
 <td class="tally obsolete not-applicable" data-browser="rhino1_7_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="rhino1_7_14" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/4</td>
@@ -13582,11 +13582,6 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -13595,9 +13590,12 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -13617,15 +13615,17 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="rhino1_7_14" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -13744,11 +13744,6 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -13757,9 +13752,12 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -13779,15 +13777,17 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="rhino1_7_14" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -13911,11 +13911,6 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -13924,9 +13919,12 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -13946,15 +13944,17 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="rhino1_7_14" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -14078,11 +14078,6 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -14091,9 +14086,12 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -14113,15 +14111,17 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="rhino1_7_14" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -14237,11 +14237,6 @@ return i === 0;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -14250,9 +14245,12 @@ return i === 0;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -14272,15 +14270,17 @@ return i === 0;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="rhino1_7_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="rhino1_7_14" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
@@ -14394,11 +14394,6 @@ return i === 0;
 <td class="tally unstable" data-browser="firefox102" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">2/2</td>
@@ -14407,9 +14402,12 @@ return i === 0;
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">2/2</td>
-<td class="tally" data-browser="chrome99" data-tally="1">2/2</td>
-<td class="tally" data-browser="chrome100" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">2/2</td>
+<td class="tally" data-browser="chrome101" data-tally="1">2/2</td>
+<td class="tally" data-browser="chrome102" data-tally="1">2/2</td>
+<td class="tally" data-browser="chrome103" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="1">2/2</td>
@@ -14429,15 +14427,17 @@ return i === 0;
 <td class="tally" data-browser="safari15_2" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">2/2</td>
-<td class="tally" data-browser="opera79" data-tally="1">2/2</td>
-<td class="tally" data-browser="opera80" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">2/2</td>
+<td class="tally" data-browser="opera87" data-tally="1">2/2</td>
+<td class="tally" data-browser="opera88" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/2</td>
@@ -14553,11 +14553,6 @@ return a === 1 &amp;&amp; rest.a === void undefined &amp;&amp; rest.b === 2 &amp
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -14566,9 +14561,12 @@ return a === 1 &amp;&amp; rest.a === void undefined &amp;&amp; rest.b === 2 &amp
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -14588,15 +14586,17 @@ return a === 1 &amp;&amp; rest.a === void undefined &amp;&amp; rest.b === 2 &amp
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -14713,11 +14713,6 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -14726,9 +14721,12 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -14748,15 +14746,17 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -14868,11 +14868,6 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="tally unstable" data-browser="firefox102" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">3/3</td>
@@ -14881,9 +14876,12 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">3/3</td>
-<td class="tally" data-browser="chrome99" data-tally="1">3/3</td>
-<td class="tally" data-browser="chrome100" data-tally="1">3/3</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">3/3</td>
+<td class="tally" data-browser="chrome101" data-tally="1">3/3</td>
+<td class="tally" data-browser="chrome102" data-tally="1">3/3</td>
+<td class="tally" data-browser="chrome103" data-tally="1">3/3</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="1">3/3</td>
@@ -14903,15 +14901,17 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="tally" data-browser="safari15_2" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">3/3</td>
-<td class="tally" data-browser="opera79" data-tally="1">3/3</td>
-<td class="tally" data-browser="opera80" data-tally="1">3/3</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">3/3</td>
+<td class="tally" data-browser="opera87" data-tally="1">3/3</td>
+<td class="tally" data-browser="opera88" data-tally="1">3/3</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/3</td>
@@ -15052,11 +15052,6 @@ function check() {
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -15065,9 +15060,12 @@ function check() {
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -15087,15 +15085,17 @@ function check() {
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -15228,11 +15228,6 @@ function check() {
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -15241,9 +15236,12 @@ function check() {
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -15263,15 +15261,17 @@ function check() {
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -15406,11 +15406,6 @@ function check() {
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -15419,9 +15414,12 @@ function check() {
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -15441,15 +15439,17 @@ function check() {
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -15565,11 +15565,6 @@ return regex.test(&apos;foo\nbar&apos;);
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -15578,9 +15573,12 @@ return regex.test(&apos;foo\nbar&apos;);
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -15600,15 +15598,17 @@ return regex.test(&apos;foo\nbar&apos;);
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -15730,11 +15730,6 @@ return result.groups.year === &apos;2016&apos;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -15743,9 +15738,12 @@ return result.groups.year === &apos;2016&apos;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -15765,15 +15763,17 @@ return result.groups.year === &apos;2016&apos;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -15889,11 +15889,6 @@ return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&a
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -15902,9 +15897,12 @@ return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&a
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -15924,15 +15922,17 @@ return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&a
 <td class="no" data-browser="safari15_2">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -16048,11 +16048,6 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -16061,9 +16056,12 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -16083,15 +16081,17 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -16203,11 +16203,6 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="tally unstable" data-browser="firefox102" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">2/2</td>
@@ -16216,9 +16211,12 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">2/2</td>
-<td class="tally" data-browser="chrome99" data-tally="1">2/2</td>
-<td class="tally" data-browser="chrome100" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">2/2</td>
+<td class="tally" data-browser="chrome101" data-tally="1">2/2</td>
+<td class="tally" data-browser="chrome102" data-tally="1">2/2</td>
+<td class="tally" data-browser="chrome103" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="1">2/2</td>
@@ -16238,15 +16236,17 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="tally" data-browser="safari15_2" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">2/2</td>
-<td class="tally" data-browser="opera79" data-tally="1">2/2</td>
-<td class="tally" data-browser="opera80" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">2/2</td>
+<td class="tally" data-browser="opera87" data-tally="1">2/2</td>
+<td class="tally" data-browser="opera88" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/2</td>
@@ -16368,11 +16368,6 @@ iterator.next().then(function(step){
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -16381,9 +16376,12 @@ iterator.next().then(function(step){
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -16403,15 +16401,17 @@ iterator.next().then(function(step){
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -16543,11 +16543,6 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -16556,9 +16551,12 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -16578,15 +16576,17 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -16713,11 +16713,6 @@ return false;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -16726,9 +16721,12 @@ return false;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -16748,15 +16746,17 @@ return false;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -16878,11 +16878,6 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -16891,9 +16886,12 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -16913,15 +16911,17 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -17035,11 +17035,6 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="tally unstable" data-browser="firefox102" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">3/3</td>
@@ -17048,9 +17043,12 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">3/3</td>
-<td class="tally" data-browser="chrome99" data-tally="1">3/3</td>
-<td class="tally" data-browser="chrome100" data-tally="1">3/3</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">3/3</td>
+<td class="tally" data-browser="chrome101" data-tally="1">3/3</td>
+<td class="tally" data-browser="chrome102" data-tally="1">3/3</td>
+<td class="tally" data-browser="chrome103" data-tally="1">3/3</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="1">3/3</td>
@@ -17070,15 +17068,17 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="tally" data-browser="safari15_2" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">3/3</td>
-<td class="tally" data-browser="opera79" data-tally="1">3/3</td>
-<td class="tally" data-browser="opera80" data-tally="1">3/3</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">3/3</td>
+<td class="tally" data-browser="opera87" data-tally="1">3/3</td>
+<td class="tally" data-browser="opera88" data-tally="1">3/3</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/3</td>
@@ -17193,11 +17193,6 @@ return Symbol(&apos;foo&apos;).description === &apos;foo&apos;;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -17206,9 +17201,12 @@ return Symbol(&apos;foo&apos;).description === &apos;foo&apos;;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -17228,15 +17226,17 @@ return Symbol(&apos;foo&apos;).description === &apos;foo&apos;;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -17351,11 +17351,6 @@ return Symbol(&apos;&apos;).description === &apos;&apos;;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -17364,9 +17359,12 @@ return Symbol(&apos;&apos;).description === &apos;&apos;;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -17386,15 +17384,17 @@ return Symbol(&apos;&apos;).description === &apos;&apos;;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -17510,11 +17510,6 @@ return Symbol.prototype.hasOwnProperty(&apos;description&apos;)
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -17523,9 +17518,12 @@ return Symbol.prototype.hasOwnProperty(&apos;description&apos;)
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -17545,15 +17543,17 @@ return Symbol.prototype.hasOwnProperty(&apos;description&apos;)
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -17669,11 +17669,6 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -17682,9 +17677,12 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -17704,15 +17702,17 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -17824,11 +17824,6 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="tally unstable" data-browser="firefox102" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">4/4</td>
@@ -17837,9 +17832,12 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">4/4</td>
-<td class="tally" data-browser="chrome99" data-tally="1">4/4</td>
-<td class="tally" data-browser="chrome100" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">4/4</td>
+<td class="tally" data-browser="chrome101" data-tally="1">4/4</td>
+<td class="tally" data-browser="chrome102" data-tally="1">4/4</td>
+<td class="tally" data-browser="chrome103" data-tally="1">4/4</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="1">4/4</td>
@@ -17859,15 +17857,17 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="tally" data-browser="safari15_2" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">4/4</td>
-<td class="tally" data-browser="opera79" data-tally="1">4/4</td>
-<td class="tally" data-browser="opera80" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">4/4</td>
+<td class="tally" data-browser="opera87" data-tally="1">4/4</td>
+<td class="tally" data-browser="opera88" data-tally="1">4/4</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
@@ -17982,11 +17982,6 @@ return &apos; \t \n abc   \t\n&apos;.trimLeft() === &apos;abc   \t\n&apos;;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -17995,9 +17990,12 @@ return &apos; \t \n abc   \t\n&apos;.trimLeft() === &apos;abc   \t\n&apos;;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -18017,15 +18015,17 @@ return &apos; \t \n abc   \t\n&apos;.trimLeft() === &apos;abc   \t\n&apos;;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
@@ -18140,11 +18140,6 @@ return &apos; \t \n abc   \t\n&apos;.trimRight() === &apos; \t \n abc&apos;;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -18153,9 +18148,12 @@ return &apos; \t \n abc   \t\n&apos;.trimRight() === &apos; \t \n abc&apos;;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -18175,15 +18173,17 @@ return &apos; \t \n abc   \t\n&apos;.trimRight() === &apos; \t \n abc&apos;;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
@@ -18298,11 +18298,6 @@ return &apos; \t \n abc   \t\n&apos;.trimStart() === &apos;abc   \t\n&apos;;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -18311,9 +18306,12 @@ return &apos; \t \n abc   \t\n&apos;.trimStart() === &apos;abc   \t\n&apos;;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -18333,15 +18331,17 @@ return &apos; \t \n abc   \t\n&apos;.trimStart() === &apos;abc   \t\n&apos;;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -18456,11 +18456,6 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -18469,9 +18464,12 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -18491,15 +18489,17 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -18611,11 +18611,6 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="tally unstable" data-browser="firefox102" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">3/3</td>
@@ -18624,9 +18619,12 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">3/3</td>
-<td class="tally" data-browser="chrome99" data-tally="1">3/3</td>
-<td class="tally" data-browser="chrome100" data-tally="1">3/3</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">3/3</td>
+<td class="tally" data-browser="chrome101" data-tally="1">3/3</td>
+<td class="tally" data-browser="chrome102" data-tally="1">3/3</td>
+<td class="tally" data-browser="chrome103" data-tally="1">3/3</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="1">3/3</td>
@@ -18646,15 +18644,17 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="tally" data-browser="safari15_2" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">3/3</td>
-<td class="tally" data-browser="opera79" data-tally="1">3/3</td>
-<td class="tally" data-browser="opera80" data-tally="1">3/3</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">3/3</td>
+<td class="tally" data-browser="opera87" data-tally="1">3/3</td>
+<td class="tally" data-browser="opera88" data-tally="1">3/3</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/3</td>
@@ -18769,11 +18769,6 @@ return [1, [2, 3], [4, [5, 6]]].flat().join(&apos;&apos;) === &apos;12345,6&apos
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -18782,9 +18777,12 @@ return [1, [2, 3], [4, [5, 6]]].flat().join(&apos;&apos;) === &apos;12345,6&apos
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -18804,15 +18802,17 @@ return [1, [2, 3], [4, [5, 6]]].flat().join(&apos;&apos;) === &apos;12345,6&apos
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -18929,11 +18929,6 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -18942,9 +18937,12 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -18964,15 +18962,17 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -19088,11 +19088,6 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -19101,9 +19096,12 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -19123,15 +19121,17 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -19245,11 +19245,6 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="tally unstable" data-browser="firefox102" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">3/3</td>
@@ -19258,9 +19253,12 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">3/3</td>
-<td class="tally" data-browser="chrome99" data-tally="1">3/3</td>
-<td class="tally" data-browser="chrome100" data-tally="1">3/3</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">3/3</td>
+<td class="tally" data-browser="chrome101" data-tally="1">3/3</td>
+<td class="tally" data-browser="chrome102" data-tally="1">3/3</td>
+<td class="tally" data-browser="chrome103" data-tally="1">3/3</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="1">3/3</td>
@@ -19280,15 +19278,17 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="tally" data-browser="safari15_2" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">3/3</td>
-<td class="tally" data-browser="opera79" data-tally="1">3/3</td>
-<td class="tally" data-browser="opera80" data-tally="1">3/3</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">3/3</td>
+<td class="tally" data-browser="opera87" data-tally="1">3/3</td>
+<td class="tally" data-browser="opera88" data-tally="1">3/3</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/3</td>
@@ -19409,11 +19409,6 @@ return false;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -19422,9 +19417,12 @@ return false;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -19444,15 +19442,17 @@ return false;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -19574,11 +19574,6 @@ return false;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -19587,9 +19582,12 @@ return false;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -19609,15 +19607,17 @@ return false;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -19743,11 +19743,6 @@ return it.throw().value;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -19756,9 +19751,12 @@ return it.throw().value;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -19778,15 +19776,17 @@ return it.throw().value;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -19898,11 +19898,6 @@ return it.throw().value;
 <td class="tally unstable" data-browser="firefox102" data-tally="1">7/7</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">7/7</td>
@@ -19911,9 +19906,12 @@ return it.throw().value;
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">7/7</td>
-<td class="tally" data-browser="chrome99" data-tally="1">7/7</td>
-<td class="tally" data-browser="chrome100" data-tally="1">7/7</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">7/7</td>
+<td class="tally" data-browser="chrome101" data-tally="1">7/7</td>
+<td class="tally" data-browser="chrome102" data-tally="1">7/7</td>
+<td class="tally" data-browser="chrome103" data-tally="1">7/7</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="1">7/7</td>
@@ -19933,15 +19931,17 @@ return it.throw().value;
 <td class="tally" data-browser="safari15_2" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
 <td class="tally unstable" data-browser="webkit" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">7/7</td>
-<td class="tally" data-browser="opera79" data-tally="1">7/7</td>
-<td class="tally" data-browser="opera80" data-tally="1">7/7</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">7/7</td>
+<td class="tally" data-browser="opera87" data-tally="1">7/7</td>
+<td class="tally" data-browser="opera88" data-tally="1">7/7</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
@@ -20058,11 +20058,6 @@ return fn + &apos;&apos; === str;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -20071,9 +20066,12 @@ return fn + &apos;&apos; === str;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -20093,15 +20091,17 @@ return fn + &apos;&apos; === str;
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -20217,11 +20217,6 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -20230,9 +20225,12 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -20252,15 +20250,17 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -20376,11 +20376,6 @@ return NATIVE_EVAL_RE.test(eval + &apos;&apos;);
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -20389,9 +20384,12 @@ return NATIVE_EVAL_RE.test(eval + &apos;&apos;);
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -20411,15 +20409,17 @@ return NATIVE_EVAL_RE.test(eval + &apos;&apos;);
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
@@ -20535,11 +20535,6 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -20548,9 +20543,12 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -20570,15 +20568,17 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -20694,11 +20694,6 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -20707,9 +20702,12 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -20729,15 +20727,17 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -20853,11 +20853,6 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -20866,9 +20861,12 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -20888,15 +20886,17 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -21012,11 +21012,6 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -21025,9 +21020,12 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -21047,15 +21045,17 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -21167,11 +21167,6 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="tally unstable" data-browser="firefox102" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">2/2</td>
@@ -21180,9 +21175,12 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">2/2</td>
-<td class="tally" data-browser="chrome99" data-tally="1">2/2</td>
-<td class="tally" data-browser="chrome100" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">2/2</td>
+<td class="tally" data-browser="chrome101" data-tally="1">2/2</td>
+<td class="tally" data-browser="chrome102" data-tally="1">2/2</td>
+<td class="tally" data-browser="chrome103" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="1">2/2</td>
@@ -21202,15 +21200,17 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="tally" data-browser="safari15_2" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">2/2</td>
-<td class="tally" data-browser="opera79" data-tally="1">2/2</td>
-<td class="tally" data-browser="opera80" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">2/2</td>
+<td class="tally" data-browser="opera87" data-tally="1">2/2</td>
+<td class="tally" data-browser="opera88" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/2</td>
@@ -21325,11 +21325,6 @@ return eval(&quot;&apos;\u2028&apos;&quot;) === &quot;\u2028&quot;;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -21338,9 +21333,12 @@ return eval(&quot;&apos;\u2028&apos;&quot;) === &quot;\u2028&quot;;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -21360,15 +21358,17 @@ return eval(&quot;&apos;\u2028&apos;&quot;) === &quot;\u2028&quot;;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -21483,11 +21483,6 @@ return eval(&quot;&apos;\u2029&apos;&quot;) === &quot;\u2029&quot;;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -21496,9 +21491,12 @@ return eval(&quot;&apos;\u2029&apos;&quot;) === &quot;\u2029&quot;;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -21518,15 +21516,17 @@ return eval(&quot;&apos;\u2029&apos;&quot;) === &quot;\u2029&quot;;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -21642,11 +21642,6 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -21655,9 +21650,12 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -21677,15 +21675,17 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="no obsolete" data-browser="phantom2_1">No</td>
@@ -21799,11 +21799,6 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 <td class="tally unstable" data-browser="firefox102" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">2/2</td>
@@ -21812,9 +21807,12 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">2/2</td>
-<td class="tally" data-browser="chrome99" data-tally="1">2/2</td>
-<td class="tally" data-browser="chrome100" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">2/2</td>
+<td class="tally" data-browser="chrome101" data-tally="1">2/2</td>
+<td class="tally" data-browser="chrome102" data-tally="1">2/2</td>
+<td class="tally" data-browser="chrome103" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="1">2/2</td>
@@ -21834,15 +21832,17 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 <td class="tally" data-browser="safari15_2" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">2/2</td>
-<td class="tally" data-browser="opera79" data-tally="1">2/2</td>
-<td class="tally" data-browser="opera80" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">2/2</td>
+<td class="tally" data-browser="opera87" data-tally="1">2/2</td>
+<td class="tally" data-browser="opera88" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/2</td>
@@ -21967,11 +21967,6 @@ return a === &apos;1a2b&apos;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -21980,9 +21975,12 @@ return a === &apos;1a2b&apos;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -22002,15 +22000,17 @@ return a === &apos;1a2b&apos;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -22130,11 +22130,6 @@ try {
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -22143,9 +22138,12 @@ try {
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -22165,15 +22163,17 @@ try {
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -22285,11 +22285,6 @@ try {
 <td class="tally unstable" data-browser="firefox102" data-tally="1">8/8</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="1">8/8</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="1">8/8</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="1">8/8</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="1">8/8</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">8/8</td>
@@ -22298,9 +22293,12 @@ try {
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">8/8</td>
-<td class="tally" data-browser="chrome99" data-tally="1">8/8</td>
-<td class="tally" data-browser="chrome100" data-tally="1">8/8</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">8/8</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">8/8</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">8/8</td>
+<td class="tally" data-browser="chrome101" data-tally="1">8/8</td>
+<td class="tally" data-browser="chrome102" data-tally="1">8/8</td>
+<td class="tally" data-browser="chrome103" data-tally="1">8/8</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="1">8/8</td>
@@ -22320,15 +22318,17 @@ try {
 <td class="tally" data-browser="safari15_2" data-tally="1">8/8</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">8/8</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">8/8</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="1">8/8</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="1">8/8</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="1">8/8</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="1">8/8</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="1">8/8</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">8/8</td>
-<td class="tally" data-browser="opera79" data-tally="1">8/8</td>
-<td class="tally" data-browser="opera80" data-tally="1">8/8</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">8/8</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">8/8</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">8/8</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">8/8</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">8/8</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">8/8</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">8/8</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">8/8</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">8/8</td>
+<td class="tally" data-browser="opera87" data-tally="1">8/8</td>
+<td class="tally" data-browser="opera88" data-tally="1">8/8</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0.5" style="background-color:hsl(60,64%,50%)">4/8</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/8</td>
@@ -22443,11 +22443,6 @@ return (1n + 2n) === 3n;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -22456,9 +22451,12 @@ return (1n + 2n) === 3n;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -22478,15 +22476,17 @@ return (1n + 2n) === 3n;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -22601,11 +22601,6 @@ return BigInt(&quot;3&quot;) === 3n;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -22614,9 +22609,12 @@ return BigInt(&quot;3&quot;) === 3n;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -22636,15 +22634,17 @@ return BigInt(&quot;3&quot;) === 3n;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -22759,11 +22759,6 @@ return typeof BigInt.asUintN === &apos;function&apos;;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -22772,9 +22767,12 @@ return typeof BigInt.asUintN === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -22794,15 +22792,17 @@ return typeof BigInt.asUintN === &apos;function&apos;;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -22917,11 +22917,6 @@ return typeof BigInt.asIntN === &apos;function&apos;;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -22930,9 +22925,12 @@ return typeof BigInt.asIntN === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -22952,15 +22950,17 @@ return typeof BigInt.asIntN === &apos;function&apos;;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -23078,11 +23078,6 @@ return view[0] === -0x8000000000000000n;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -23091,9 +23086,12 @@ return view[0] === -0x8000000000000000n;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -23113,15 +23111,17 @@ return view[0] === -0x8000000000000000n;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -23239,11 +23239,6 @@ return view[0] === 0n;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -23252,9 +23247,12 @@ return view[0] === 0n;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -23274,15 +23272,17 @@ return view[0] === 0n;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -23400,11 +23400,6 @@ return view.getBigInt64(0) === 1n;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -23413,9 +23408,12 @@ return view.getBigInt64(0) === 1n;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -23435,15 +23433,17 @@ return view.getBigInt64(0) === 1n;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -23561,11 +23561,6 @@ return view.getBigUint64(0) === 1n;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -23574,9 +23569,12 @@ return view.getBigUint64(0) === 1n;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -23596,15 +23594,17 @@ return view.getBigUint64(0) === 1n;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -23730,11 +23730,6 @@ Promise.allSettled([
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -23743,9 +23738,12 @@ Promise.allSettled([
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -23765,15 +23763,17 @@ Promise.allSettled([
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -23885,11 +23885,6 @@ Promise.allSettled([
 <td class="tally unstable" data-browser="firefox102" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">2/2</td>
@@ -23898,9 +23893,12 @@ Promise.allSettled([
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">2/2</td>
-<td class="tally" data-browser="chrome99" data-tally="1">2/2</td>
-<td class="tally" data-browser="chrome100" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">2/2</td>
+<td class="tally" data-browser="chrome101" data-tally="1">2/2</td>
+<td class="tally" data-browser="chrome102" data-tally="1">2/2</td>
+<td class="tally" data-browser="chrome103" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="1">2/2</td>
@@ -23920,15 +23918,17 @@ Promise.allSettled([
 <td class="tally" data-browser="safari15_2" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">2/2</td>
-<td class="tally" data-browser="opera79" data-tally="1">2/2</td>
-<td class="tally" data-browser="opera80" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">2/2</td>
+<td class="tally" data-browser="opera87" data-tally="1">2/2</td>
+<td class="tally" data-browser="opera88" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/2</td>
@@ -24045,11 +24045,6 @@ return typeof globalThis === &apos;object&apos; &amp;&amp; globalThis &amp;&amp;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -24058,9 +24053,12 @@ return typeof globalThis === &apos;object&apos; &amp;&amp; globalThis &amp;&amp;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -24080,15 +24078,17 @@ return typeof globalThis === &apos;object&apos; &amp;&amp; globalThis &amp;&amp;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -24209,11 +24209,6 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -24222,9 +24217,12 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -24244,15 +24242,17 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -24364,11 +24364,6 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="tally unstable" data-browser="firefox102" data-tally="1">5/5</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">5/5</td>
@@ -24377,9 +24372,12 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">5/5</td>
-<td class="tally" data-browser="chrome99" data-tally="1">5/5</td>
-<td class="tally" data-browser="chrome100" data-tally="1">5/5</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">5/5</td>
+<td class="tally" data-browser="chrome101" data-tally="1">5/5</td>
+<td class="tally" data-browser="chrome102" data-tally="1">5/5</td>
+<td class="tally" data-browser="chrome103" data-tally="1">5/5</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
@@ -24399,15 +24397,17 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="tally" data-browser="safari15_2" data-tally="1">5/5</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">5/5</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">5/5</td>
-<td class="tally" data-browser="opera79" data-tally="1">5/5</td>
-<td class="tally" data-browser="opera80" data-tally="1">5/5</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">5/5</td>
+<td class="tally" data-browser="opera87" data-tally="1">5/5</td>
+<td class="tally" data-browser="opera88" data-tally="1">5/5</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/5</td>
@@ -24524,11 +24524,6 @@ return foo?.baz === 42 &amp;&amp; bar?.baz === void undefined;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -24537,9 +24532,12 @@ return foo?.baz === 42 &amp;&amp; bar?.baz === void undefined;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -24559,15 +24557,17 @@ return foo?.baz === 42 &amp;&amp; bar?.baz === void undefined;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -24684,11 +24684,6 @@ return foo?.[&apos;baz&apos;] === 42 &amp;&amp; bar?.[&apos;baz&apos;] === void 
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -24697,9 +24692,12 @@ return foo?.[&apos;baz&apos;] === 42 &amp;&amp; bar?.[&apos;baz&apos;] === void 
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -24719,15 +24717,17 @@ return foo?.[&apos;baz&apos;] === 42 &amp;&amp; bar?.[&apos;baz&apos;] === void 
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -24844,11 +24844,6 @@ return foo?.baz() === 42 &amp;&amp; bar?.baz() === void undefined;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -24857,9 +24852,12 @@ return foo?.baz() === 42 &amp;&amp; bar?.baz() === void undefined;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -24879,15 +24877,17 @@ return foo?.baz() === 42 &amp;&amp; bar?.baz() === void undefined;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -25006,11 +25006,6 @@ return foo.baz?.() === 42 &amp;&amp; bar.baz?.() === void undefined &amp;&amp; b
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -25019,9 +25014,12 @@ return foo.baz?.() === 42 &amp;&amp; bar.baz?.() === void undefined &amp;&amp; b
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -25041,15 +25039,17 @@ return foo.baz?.() === 42 &amp;&amp; bar.baz?.() === void undefined &amp;&amp; b
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -25168,11 +25168,6 @@ return fn?.(...[], 1) === void undefined &amp;&amp; fn?.(...[], ...[]) === void 
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -25181,9 +25176,12 @@ return fn?.(...[], 1) === void undefined &amp;&amp; fn?.(...[], ...[]) === void 
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -25203,15 +25201,17 @@ return fn?.(...[], 1) === void undefined &amp;&amp; fn?.(...[], ...[]) === void 
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -25331,11 +25331,6 @@ return (null ?? 42) === 42 &amp;&amp;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -25344,9 +25339,12 @@ return (null ?? 42) === 42 &amp;&amp;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -25366,15 +25364,17 @@ return (null ?? 42) === 42 &amp;&amp;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -25491,11 +25491,6 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -25504,9 +25499,12 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -25526,15 +25524,17 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -25646,11 +25646,6 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="tally unstable" data-browser="firefox102" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">2/2</td>
@@ -25659,9 +25654,12 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">2/2</td>
-<td class="tally" data-browser="chrome99" data-tally="1">2/2</td>
-<td class="tally" data-browser="chrome100" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">2/2</td>
+<td class="tally" data-browser="chrome101" data-tally="1">2/2</td>
+<td class="tally" data-browser="chrome102" data-tally="1">2/2</td>
+<td class="tally" data-browser="chrome103" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="1">2/2</td>
@@ -25681,15 +25679,17 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="tally" data-browser="safari15_2" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">2/2</td>
-<td class="tally" data-browser="opera79" data-tally="1">2/2</td>
-<td class="tally" data-browser="opera80" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">2/2</td>
+<td class="tally" data-browser="opera87" data-tally="1">2/2</td>
+<td class="tally" data-browser="opera88" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/2</td>
@@ -25810,11 +25810,6 @@ Promise.any([
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -25823,9 +25818,12 @@ Promise.any([
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -25845,15 +25843,17 @@ Promise.any([
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -25974,11 +25974,6 @@ Promise.any([
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -25987,9 +25982,12 @@ Promise.any([
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -26009,15 +26007,17 @@ Promise.any([
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -26129,11 +26129,6 @@ Promise.any([
 <td class="tally unstable" data-browser="firefox102" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">2/2</td>
@@ -26142,9 +26137,12 @@ Promise.any([
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">2/2</td>
-<td class="tally" data-browser="chrome99" data-tally="1">2/2</td>
-<td class="tally" data-browser="chrome100" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">2/2</td>
+<td class="tally" data-browser="chrome101" data-tally="1">2/2</td>
+<td class="tally" data-browser="chrome102" data-tally="1">2/2</td>
+<td class="tally" data-browser="chrome103" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="1">2/2</td>
@@ -26164,15 +26162,17 @@ Promise.any([
 <td class="tally" data-browser="safari15_2" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">2/2</td>
-<td class="tally" data-browser="opera79" data-tally="1">2/2</td>
-<td class="tally" data-browser="opera80" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">2/2</td>
+<td class="tally" data-browser="opera87" data-tally="1">2/2</td>
+<td class="tally" data-browser="opera88" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/2</td>
@@ -26289,11 +26289,6 @@ return weakref.deref() === O;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -26302,9 +26297,12 @@ return weakref.deref() === O;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -26324,15 +26322,17 @@ return weakref.deref() === O;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -26448,11 +26448,6 @@ return Object.getPrototypeOf(fr) === FinalizationRegistry.prototype;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -26461,9 +26456,12 @@ return Object.getPrototypeOf(fr) === FinalizationRegistry.prototype;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -26483,15 +26481,17 @@ return Object.getPrototypeOf(fr) === FinalizationRegistry.prototype;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -26603,11 +26603,6 @@ return Object.getPrototypeOf(fr) === FinalizationRegistry.prototype;
 <td class="tally unstable" data-browser="firefox102" data-tally="1">9/9</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">9/9</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/9</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="1">9/9</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="1">9/9</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="1">9/9</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="1">9/9</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="1">9/9</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="1">9/9</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">9/9</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">9/9</td>
@@ -26616,9 +26611,12 @@ return Object.getPrototypeOf(fr) === FinalizationRegistry.prototype;
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">9/9</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">9/9</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">9/9</td>
-<td class="tally" data-browser="chrome99" data-tally="1">9/9</td>
-<td class="tally" data-browser="chrome100" data-tally="1">9/9</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">9/9</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">9/9</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">9/9</td>
+<td class="tally" data-browser="chrome101" data-tally="1">9/9</td>
+<td class="tally" data-browser="chrome102" data-tally="1">9/9</td>
+<td class="tally" data-browser="chrome103" data-tally="1">9/9</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">9/9</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="1">9/9</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="1">9/9</td>
@@ -26638,15 +26636,17 @@ return Object.getPrototypeOf(fr) === FinalizationRegistry.prototype;
 <td class="tally" data-browser="safari15_2" data-tally="1">9/9</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">9/9</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">9/9</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="1">9/9</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="1">9/9</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="1">9/9</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="1">9/9</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="1">9/9</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">9/9</td>
-<td class="tally" data-browser="opera79" data-tally="1">9/9</td>
-<td class="tally" data-browser="opera80" data-tally="1">9/9</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">9/9</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">9/9</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">9/9</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">9/9</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">9/9</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">9/9</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">9/9</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">9/9</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">9/9</td>
+<td class="tally" data-browser="opera87" data-tally="1">9/9</td>
+<td class="tally" data-browser="opera88" data-tally="1">9/9</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">9/9</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/9</td>
@@ -26767,11 +26767,6 @@ return a === 2 &amp;&amp; b === 2 &amp;&amp; c === 1;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -26780,9 +26775,12 @@ return a === 2 &amp;&amp; b === 2 &amp;&amp; c === 1;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -26802,15 +26800,17 @@ return a === 2 &amp;&amp; b === 2 &amp;&amp; c === 1;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -26928,11 +26928,6 @@ return a === 1 &amp;&amp; i === 1;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -26941,9 +26936,12 @@ return a === 1 &amp;&amp; i === 1;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -26963,15 +26961,17 @@ return a === 1 &amp;&amp; i === 1;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -27089,11 +27089,6 @@ return i === 1;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -27102,9 +27097,12 @@ return i === 1;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -27124,15 +27122,17 @@ return i === 1;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -27253,11 +27253,6 @@ return typeof a === &apos;undefined&apos; &amp;&amp; b === 0 &amp;&amp; c === 2;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -27266,9 +27261,12 @@ return typeof a === &apos;undefined&apos; &amp;&amp; b === 0 &amp;&amp; c === 2;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -27288,15 +27286,17 @@ return typeof a === &apos;undefined&apos; &amp;&amp; b === 0 &amp;&amp; c === 2;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -27414,11 +27414,6 @@ return typeof a === &apos;undefined&apos; &amp;&amp; i === 1;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -27427,9 +27422,12 @@ return typeof a === &apos;undefined&apos; &amp;&amp; i === 1;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -27449,15 +27447,17 @@ return typeof a === &apos;undefined&apos; &amp;&amp; i === 1;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -27575,11 +27575,6 @@ return i === 1;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -27588,9 +27583,12 @@ return i === 1;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -27610,15 +27608,17 @@ return i === 1;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -27739,11 +27739,6 @@ return a === 2 &amp;&amp; b === 0 &amp;&amp; c === 1;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -27752,9 +27747,12 @@ return a === 2 &amp;&amp; b === 0 &amp;&amp; c === 1;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -27774,15 +27772,17 @@ return a === 2 &amp;&amp; b === 0 &amp;&amp; c === 1;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -27900,11 +27900,6 @@ return a === 1 &amp;&amp; i === 1;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -27913,9 +27908,12 @@ return a === 1 &amp;&amp; i === 1;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -27935,15 +27933,17 @@ return a === 1 &amp;&amp; i === 1;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -28061,11 +28061,6 @@ return i === 1;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -28074,9 +28069,12 @@ return i === 1;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -28096,15 +28094,17 @@ return i === 1;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -28220,11 +28220,6 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -28233,9 +28228,12 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -28255,15 +28253,17 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -28377,11 +28377,6 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="tally unstable" data-browser="firefox102" data-tally="1">6/6</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">6/6</td>
@@ -28390,9 +28385,12 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">6/6</td>
-<td class="tally" data-browser="chrome99" data-tally="1">6/6</td>
-<td class="tally" data-browser="chrome100" data-tally="1">6/6</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">6/6</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">6/6</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">6/6</td>
+<td class="tally" data-browser="chrome101" data-tally="1">6/6</td>
+<td class="tally" data-browser="chrome102" data-tally="1">6/6</td>
+<td class="tally" data-browser="chrome103" data-tally="1">6/6</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="1">6/6</td>
@@ -28412,15 +28410,17 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="tally" data-browser="safari15_2" data-tally="1">6/6</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">6/6</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">6/6</td>
-<td class="tally" data-browser="opera79" data-tally="1">6/6</td>
-<td class="tally" data-browser="opera80" data-tally="1">6/6</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">6/6</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">6/6</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">6/6</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">6/6</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">6/6</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">6/6</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">6/6</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">6/6</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">6/6</td>
+<td class="tally" data-browser="opera87" data-tally="1">6/6</td>
+<td class="tally" data-browser="opera88" data-tally="1">6/6</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/6</td>
@@ -28538,11 +28538,6 @@ return new C().x === &apos;x&apos;;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -28551,9 +28546,12 @@ return new C().x === &apos;x&apos;;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -28573,15 +28571,17 @@ return new C().x === &apos;x&apos;;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -28705,11 +28705,6 @@ return new C(42).x() === 42;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -28718,9 +28713,12 @@ return new C(42).x() === 42;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -28740,15 +28738,17 @@ return new C(42).x() === 42;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -28869,11 +28869,6 @@ return new C().x() === 42;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -28882,9 +28877,12 @@ return new C().x() === 42;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -28904,15 +28902,17 @@ return new C().x() === 42;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -29033,11 +29033,6 @@ return new C().x() === 42 &amp;&amp; new C().x(null) === void 0;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -29046,9 +29041,12 @@ return new C().x() === 42 &amp;&amp; new C().x(null) === void 0;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -29068,15 +29066,17 @@ return new C().x() === 42 &amp;&amp; new C().x(null) === void 0;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="no obsolete" data-browser="phantom2_1">No</td>
@@ -29197,11 +29197,6 @@ return new C().x() === 42 &amp;&amp; new C().x(null) === void 0;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -29210,9 +29205,12 @@ return new C().x() === 42 &amp;&amp; new C().x(null) === void 0;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -29232,15 +29230,17 @@ return new C().x() === 42 &amp;&amp; new C().x(null) === void 0;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="no obsolete" data-browser="phantom2_1">No</td>
@@ -29358,11 +29358,6 @@ return new C().x === 42;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -29371,9 +29366,12 @@ return new C().x === 42;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -29393,15 +29391,17 @@ return new C().x === 42;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -29513,11 +29513,6 @@ return new C().x === 42;
 <td class="tally unstable" data-browser="firefox102" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">4/4</td>
@@ -29526,9 +29521,12 @@ return new C().x === 42;
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">4/4</td>
-<td class="tally" data-browser="chrome99" data-tally="1">4/4</td>
-<td class="tally" data-browser="chrome100" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">4/4</td>
+<td class="tally" data-browser="chrome101" data-tally="1">4/4</td>
+<td class="tally" data-browser="chrome102" data-tally="1">4/4</td>
+<td class="tally" data-browser="chrome103" data-tally="1">4/4</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="1">4/4</td>
@@ -29548,15 +29546,17 @@ return new C().x === 42;
 <td class="tally" data-browser="safari15_2" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">4/4</td>
-<td class="tally" data-browser="opera79" data-tally="1">4/4</td>
-<td class="tally" data-browser="opera80" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">4/4</td>
+<td class="tally" data-browser="opera87" data-tally="1">4/4</td>
+<td class="tally" data-browser="opera88" data-tally="1">4/4</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/4</td>
@@ -29674,11 +29674,6 @@ return C.x === &apos;x&apos;;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -29687,9 +29682,12 @@ return C.x === &apos;x&apos;;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -29709,15 +29707,17 @@ return C.x === &apos;x&apos;;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -29832,11 +29832,6 @@ return (class X { static name = &quot;name&quot;; }).name === &apos;name&apos;;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -29845,9 +29840,12 @@ return (class X { static name = &quot;name&quot;; }).name === &apos;name&apos;;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="unknown obsolete" data-browser="edge18">?</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -29867,15 +29865,17 @@ return (class X { static name = &quot;name&quot;; }).name === &apos;name&apos;;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="unknown obsolete" data-browser="rhino1_7_13">?</td>
 <td class="unknown obsolete" data-browser="rhino1_7_14">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -29996,11 +29996,6 @@ return new C().x() === 42;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -30009,9 +30004,12 @@ return new C().x() === 42;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -30031,15 +30029,17 @@ return new C().x() === 42;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -30157,11 +30157,6 @@ return C.x === 42;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -30170,9 +30165,12 @@ return C.x === 42;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -30192,15 +30190,17 @@ return C.x === 42;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -30312,11 +30312,6 @@ return C.x === 42;
 <td class="tally unstable" data-browser="firefox102" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">4/4</td>
@@ -30325,9 +30320,12 @@ return C.x === 42;
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">4/4</td>
-<td class="tally" data-browser="chrome99" data-tally="1">4/4</td>
-<td class="tally" data-browser="chrome100" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">4/4</td>
+<td class="tally" data-browser="chrome101" data-tally="1">4/4</td>
+<td class="tally" data-browser="chrome102" data-tally="1">4/4</td>
+<td class="tally" data-browser="chrome103" data-tally="1">4/4</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="1">4/4</td>
@@ -30347,15 +30345,17 @@ return C.x === 42;
 <td class="tally" data-browser="safari15_2" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">4/4</td>
-<td class="tally" data-browser="opera79" data-tally="1">4/4</td>
-<td class="tally" data-browser="opera80" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">4/4</td>
+<td class="tally" data-browser="opera87" data-tally="1">4/4</td>
+<td class="tally" data-browser="opera88" data-tally="1">4/4</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/4</td>
@@ -30476,11 +30476,6 @@ return new C().x() === 42;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -30489,9 +30484,12 @@ return new C().x() === 42;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -30511,15 +30509,17 @@ return new C().x() === 42;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -30640,11 +30640,6 @@ return new C().x() === 42;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -30653,9 +30648,12 @@ return new C().x() === 42;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -30675,15 +30673,17 @@ return new C().x() === 42;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -30807,11 +30807,6 @@ return new C().x() === 42 &amp;&amp; y;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -30820,9 +30815,12 @@ return new C().x() === 42 &amp;&amp; y;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -30842,15 +30840,17 @@ return new C().x() === 42 &amp;&amp; y;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -30974,11 +30974,6 @@ return new C().x() === 42 &amp;&amp; y;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -30987,9 +30982,12 @@ return new C().x() === 42 &amp;&amp; y;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -31009,15 +31007,17 @@ return new C().x() === 42 &amp;&amp; y;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -31138,11 +31138,6 @@ return A.check(new A) &amp;&amp; !A.check({});
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -31151,9 +31146,12 @@ return A.check(new A) &amp;&amp; !A.check({});
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -31173,15 +31171,17 @@ return A.check(new A) &amp;&amp; !A.check({});
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -31293,11 +31293,6 @@ return A.check(new A) &amp;&amp; !A.check({});
 <td class="tally unstable" data-browser="firefox102" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">3/3</td>
@@ -31306,9 +31301,12 @@ return A.check(new A) &amp;&amp; !A.check({});
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">3/3</td>
-<td class="tally" data-browser="chrome99" data-tally="1">3/3</td>
-<td class="tally" data-browser="chrome100" data-tally="1">3/3</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">3/3</td>
+<td class="tally" data-browser="chrome101" data-tally="1">3/3</td>
+<td class="tally" data-browser="chrome102" data-tally="1">3/3</td>
+<td class="tally" data-browser="chrome103" data-tally="1">3/3</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="0">0/3</td>
@@ -31328,15 +31326,17 @@ return A.check(new A) &amp;&amp; !A.check({});
 <td class="tally" data-browser="safari15_2" data-tally="0" data-flagged-tally="1">0/3</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">3/3</td>
-<td class="tally" data-browser="opera79" data-tally="1">3/3</td>
-<td class="tally" data-browser="opera80" data-tally="1">3/3</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">3/3</td>
+<td class="tally" data-browser="opera87" data-tally="1">3/3</td>
+<td class="tally" data-browser="opera88" data-tally="1">3/3</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/3</td>
@@ -31459,11 +31459,6 @@ return arr.at(0) === 1
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -31472,9 +31467,12 @@ return arr.at(0) === 1
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -31494,15 +31492,17 @@ return arr.at(0) === 1
 <td class="no flagged" data-browser="safari15_2">Flag<a href="#safari-at-method-note"><sup>[40]</sup></a></td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -31625,11 +31625,6 @@ return str.at(0) === &apos;a&apos;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -31638,9 +31633,12 @@ return str.at(0) === &apos;a&apos;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -31660,15 +31658,17 @@ return str.at(0) === &apos;a&apos;
 <td class="no flagged" data-browser="safari15_2">Flag<a href="#safari-at-method-note"><sup>[40]</sup></a></td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -31807,11 +31807,6 @@ return [
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -31820,9 +31815,12 @@ return [
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -31842,15 +31840,17 @@ return [
 <td class="no flagged" data-browser="safari15_2">Flag<a href="#safari-at-method-note"><sup>[40]</sup></a></td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -31962,11 +31962,6 @@ return [
 <td class="tally unstable" data-browser="firefox102" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">2/2</td>
@@ -31975,9 +31970,12 @@ return [
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">2/2</td>
-<td class="tally" data-browser="chrome99" data-tally="1">2/2</td>
-<td class="tally" data-browser="chrome100" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">2/2</td>
+<td class="tally" data-browser="chrome101" data-tally="1">2/2</td>
+<td class="tally" data-browser="chrome102" data-tally="1">2/2</td>
+<td class="tally" data-browser="chrome103" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="0">0/2</td>
@@ -31997,15 +31995,17 @@ return [
 <td class="tally" data-browser="safari15_2" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="0">0/2</td>
-<td class="tally" data-browser="opera79" data-tally="1">2/2</td>
-<td class="tally" data-browser="opera80" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">2/2</td>
+<td class="tally" data-browser="opera87" data-tally="1">2/2</td>
+<td class="tally" data-browser="opera88" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/2</td>
@@ -32120,11 +32120,6 @@ return Object.hasOwn({ x: 2 }, &quot;x&quot;) === true;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -32133,9 +32128,12 @@ return Object.hasOwn({ x: 2 }, &quot;x&quot;) === true;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -32155,15 +32153,17 @@ return Object.hasOwn({ x: 2 }, &quot;x&quot;) === true;
 <td class="no" data-browser="safari15_2">No</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -32284,11 +32284,6 @@ try {
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -32297,9 +32292,12 @@ try {
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -32319,15 +32317,17 @@ try {
 <td class="no" data-browser="safari15_2">No</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -32446,11 +32446,6 @@ return ok;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no flagged obsolete" data-browser="chrome91">Flag<a href="#ch-static-init-blocks-note"><sup>[44]</sup></a></td>
 <td class="no flagged obsolete" data-browser="chrome92">Flag<a href="#ch-static-init-blocks-note"><sup>[44]</sup></a></td>
 <td class="no flagged obsolete" data-browser="chrome93">Flag<a href="#ch-static-init-blocks-note"><sup>[44]</sup></a></td>
@@ -32459,9 +32454,12 @@ return ok;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -32481,15 +32479,17 @@ return ok;
 <td class="no" data-browser="safari15_2">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no flagged obsolete" data-browser="opera77">Flag<a href="#ch-static-init-blocks-note"><sup>[44]</sup></a></td>
-<td class="no flagged obsolete" data-browser="opera78">Flag<a href="#ch-static-init-blocks-note"><sup>[44]</sup></a></td>
-<td class="no flagged" data-browser="opera79">Flag<a href="#ch-static-init-blocks-note"><sup>[44]</sup></a></td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="no flagged obsolete" data-browser="opera79">Flag<a href="#ch-static-init-blocks-note"><sup>[44]</sup></a></td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -32601,11 +32601,6 @@ return ok;
 <td class="tally unstable" data-browser="firefox102" data-tally="1">16/16</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/16</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="0">0/16</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="0">0/16</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="0">0/16</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="0">0/16</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="0">0/16</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="0">0/16</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="0">0/16</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="0.5" style="background-color:hsl(60,64%,50%)">8/16</td>
@@ -32614,9 +32609,12 @@ return ok;
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">16/16</td>
-<td class="tally" data-browser="chrome99" data-tally="1">16/16</td>
-<td class="tally" data-browser="chrome100" data-tally="1">16/16</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">16/16</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">16/16</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">16/16</td>
+<td class="tally" data-browser="chrome101" data-tally="1">16/16</td>
+<td class="tally" data-browser="chrome102" data-tally="1">16/16</td>
+<td class="tally" data-browser="chrome103" data-tally="1">16/16</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="0">0/16</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="0">0/16</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="0">0/16</td>
@@ -32636,15 +32634,17 @@ return ok;
 <td class="tally" data-browser="safari15_2" data-tally="1">16/16</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">16/16</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">16/16</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="0">0/16</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="0">0/16</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="0">0/16</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="0">0/16</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="0">0/16</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="0">0/16</td>
-<td class="tally" data-browser="opera79" data-tally="0.5" style="background-color:hsl(60,64%,50%)">8/16</td>
-<td class="tally" data-browser="opera80" data-tally="1">16/16</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">16/16</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="0.5" style="background-color:hsl(60,64%,50%)">8/16</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">16/16</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">16/16</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">16/16</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">16/16</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">16/16</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">16/16</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">16/16</td>
+<td class="tally" data-browser="opera87" data-tally="1">16/16</td>
+<td class="tally" data-browser="opera88" data-tally="1">16/16</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/16</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0.4375" style="background-color:hsl(52,66%,50%)">7/16</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/16</td>
@@ -32760,11 +32760,6 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -32773,9 +32768,12 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -32795,15 +32793,17 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="unknown obsolete" data-browser="rhino1_7_13">?</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -32918,11 +32918,6 @@ return !(&apos;cause&apos; in Error.prototype);
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -32931,9 +32926,12 @@ return !(&apos;cause&apos; in Error.prototype);
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -32953,15 +32951,17 @@ return !(&apos;cause&apos; in Error.prototype);
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="unknown obsolete" data-browser="rhino1_7_13">?</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -33077,11 +33077,6 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -33090,9 +33085,12 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -33112,15 +33110,17 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="unknown obsolete" data-browser="rhino1_7_13">?</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -33235,11 +33235,6 @@ return !(&apos;cause&apos; in EvalError.prototype);
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -33248,9 +33243,12 @@ return !(&apos;cause&apos; in EvalError.prototype);
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -33270,15 +33268,17 @@ return !(&apos;cause&apos; in EvalError.prototype);
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="unknown obsolete" data-browser="rhino1_7_13">?</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -33394,11 +33394,6 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -33407,9 +33402,12 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -33429,15 +33427,17 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="unknown obsolete" data-browser="rhino1_7_13">?</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -33552,11 +33552,6 @@ return !(&apos;cause&apos; in RangeError.prototype);
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -33565,9 +33560,12 @@ return !(&apos;cause&apos; in RangeError.prototype);
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -33587,15 +33585,17 @@ return !(&apos;cause&apos; in RangeError.prototype);
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="unknown obsolete" data-browser="rhino1_7_13">?</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -33711,11 +33711,6 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -33724,9 +33719,12 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -33746,15 +33744,17 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="unknown obsolete" data-browser="rhino1_7_13">?</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -33869,11 +33869,6 @@ return !(&apos;cause&apos; in ReferenceError.prototype);
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -33882,9 +33877,12 @@ return !(&apos;cause&apos; in ReferenceError.prototype);
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -33904,15 +33902,17 @@ return !(&apos;cause&apos; in ReferenceError.prototype);
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="unknown obsolete" data-browser="rhino1_7_13">?</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -34028,11 +34028,6 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -34041,9 +34036,12 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -34063,15 +34061,17 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="unknown obsolete" data-browser="rhino1_7_13">?</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -34186,11 +34186,6 @@ return !(&apos;cause&apos; in SyntaxError.prototype);
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -34199,9 +34194,12 @@ return !(&apos;cause&apos; in SyntaxError.prototype);
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -34221,15 +34219,17 @@ return !(&apos;cause&apos; in SyntaxError.prototype);
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="unknown obsolete" data-browser="rhino1_7_13">?</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -34345,11 +34345,6 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -34358,9 +34353,12 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -34380,15 +34378,17 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="unknown obsolete" data-browser="rhino1_7_13">?</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -34503,11 +34503,6 @@ return !(&apos;cause&apos; in TypeError.prototype);
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -34516,9 +34511,12 @@ return !(&apos;cause&apos; in TypeError.prototype);
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -34538,15 +34536,17 @@ return !(&apos;cause&apos; in TypeError.prototype);
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="unknown obsolete" data-browser="rhino1_7_13">?</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -34662,11 +34662,6 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -34675,9 +34670,12 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -34697,15 +34695,17 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="unknown obsolete" data-browser="rhino1_7_13">?</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -34820,11 +34820,6 @@ return !(&apos;cause&apos; in URIError.prototype);
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -34833,9 +34828,12 @@ return !(&apos;cause&apos; in URIError.prototype);
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -34855,15 +34853,17 @@ return !(&apos;cause&apos; in URIError.prototype);
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="unknown obsolete" data-browser="rhino1_7_13">?</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -34979,11 +34979,6 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -34992,9 +34987,12 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -35014,15 +35012,17 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="unknown obsolete" data-browser="rhino1_7_13">?</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -35137,11 +35137,6 @@ return !(&apos;cause&apos; in AggregateError.prototype);
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -35150,9 +35145,12 @@ return !(&apos;cause&apos; in AggregateError.prototype);
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -35172,15 +35170,17 @@ return !(&apos;cause&apos; in AggregateError.prototype);
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="unknown obsolete" data-browser="rhino1_7_13">?</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -35292,11 +35292,6 @@ return !(&apos;cause&apos; in AggregateError.prototype);
 <td class="tally unstable" data-browser="firefox102" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
@@ -35305,9 +35300,12 @@ return !(&apos;cause&apos; in AggregateError.prototype);
 <td class="tally obsolete" data-browser="chrome96" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally" data-browser="chrome99" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally" data-browser="chrome100" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally" data-browser="chrome101" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally" data-browser="chrome102" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally" data-browser="chrome103" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="0">0/2</td>
@@ -35327,15 +35325,17 @@ return !(&apos;cause&apos; in AggregateError.prototype);
 <td class="tally" data-browser="safari15_2" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally" data-browser="opera79" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally" data-browser="opera80" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally unstable" data-browser="opera81" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally" data-browser="opera87" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally" data-browser="opera88" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally unstable" data-browser="opera89" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/2</td>
@@ -35450,11 +35450,6 @@ return new RegExp(&apos;a&apos;, &apos;d&apos;) instanceof RegExp;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="unknown obsolete" data-browser="chrome86">?</td>
-<td class="unknown obsolete" data-browser="chrome87">?</td>
-<td class="unknown obsolete" data-browser="chrome88">?</td>
-<td class="unknown obsolete" data-browser="chrome89">?</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -35463,9 +35458,12 @@ return new RegExp(&apos;a&apos;, &apos;d&apos;) instanceof RegExp;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="unknown obsolete" data-browser="edge18">?</td>
 <td class="unknown obsolete" data-browser="edge87">?</td>
 <td class="unknown obsolete" data-browser="edge88">?</td>
@@ -35485,15 +35483,17 @@ return new RegExp(&apos;a&apos;, &apos;d&apos;) instanceof RegExp;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="unknown obsolete" data-browser="opera73">?</td>
-<td class="unknown obsolete" data-browser="opera74">?</td>
-<td class="unknown obsolete" data-browser="opera75">?</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="unknown obsolete" data-browser="rhino1_7_13">?</td>
 <td class="unknown obsolete" data-browser="rhino1_7_14">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -35623,11 +35623,6 @@ return true;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="unknown obsolete" data-browser="chrome86">?</td>
-<td class="unknown obsolete" data-browser="chrome87">?</td>
-<td class="unknown obsolete" data-browser="chrome88">?</td>
-<td class="unknown obsolete" data-browser="chrome89">?</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -35636,9 +35631,12 @@ return true;
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="unknown obsolete" data-browser="edge18">?</td>
 <td class="unknown obsolete" data-browser="edge87">?</td>
 <td class="unknown obsolete" data-browser="edge88">?</td>
@@ -35658,15 +35656,17 @@ return true;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="unknown obsolete" data-browser="opera73">?</td>
-<td class="unknown obsolete" data-browser="opera74">?</td>
-<td class="unknown obsolete" data-browser="opera75">?</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="unknown obsolete" data-browser="rhino1_7_13">?</td>
 <td class="unknown obsolete" data-browser="rhino1_7_14">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>

--- a/es5/index.html
+++ b/es5/index.html
@@ -150,11 +150,6 @@
 <th class="platform firefox102 desktop unstable" data-browser="firefox102"><a href="#firefox102" class="browser-name"><abbr title="Firefox 102 Beta">FF 102</abbr></a></th>
 <th class="platform firefox103 desktop unstable" data-browser="firefox103"><a href="#firefox103" class="browser-name"><abbr title="Firefox 103 Nightly">FF 103</abbr></a></th>
 <th class="platform opera12_10 desktop obsolete" data-browser="opera12_10"><a href="#opera12_10" class="browser-name"><abbr title="Opera 12.10">OP 12.10</abbr></a></th>
-<th class="platform chrome86 desktop obsolete" data-browser="chrome86"><a href="#chrome86" class="browser-name"><abbr title="Chrome 86">CH 86</abbr></a></th>
-<th class="platform chrome87 desktop obsolete" data-browser="chrome87"><a href="#chrome87" class="browser-name"><abbr title="Chrome 87">CH 87</abbr></a></th>
-<th class="platform chrome88 desktop obsolete" data-browser="chrome88"><a href="#chrome88" class="browser-name"><abbr title="Chrome 88">CH 88</abbr></a></th>
-<th class="platform chrome89 desktop obsolete" data-browser="chrome89"><a href="#chrome89" class="browser-name"><abbr title="Chrome 89">CH 89</abbr></a></th>
-<th class="platform chrome90 desktop obsolete" data-browser="chrome90"><a href="#chrome90" class="browser-name"><abbr title="Chrome 90">CH 90</abbr></a></th>
 <th class="platform chrome91 desktop obsolete" data-browser="chrome91"><a href="#chrome91" class="browser-name"><abbr title="Chrome 91">CH 91</abbr></a></th>
 <th class="platform chrome92 desktop obsolete" data-browser="chrome92"><a href="#chrome92" class="browser-name"><abbr title="Chrome 92">CH 92</abbr></a></th>
 <th class="platform chrome93 desktop obsolete" data-browser="chrome93"><a href="#chrome93" class="browser-name"><abbr title="Chrome 93">CH 93</abbr></a></th>
@@ -163,9 +158,12 @@
 <th class="platform chrome96 desktop obsolete" data-browser="chrome96"><a href="#chrome96" class="browser-name"><abbr title="Chrome 96">CH 96</abbr></a></th>
 <th class="platform chrome97 desktop obsolete" data-browser="chrome97"><a href="#chrome97" class="browser-name"><abbr title="Chrome 97">CH 97</abbr></a></th>
 <th class="platform chrome98 desktop obsolete" data-browser="chrome98"><a href="#chrome98" class="browser-name"><abbr title="Chrome 98">CH 98</abbr></a></th>
-<th class="platform chrome99 desktop" data-browser="chrome99"><a href="#chrome99" class="browser-name"><abbr title="Chrome 99">CH 99</abbr></a></th>
-<th class="platform chrome100 desktop" data-browser="chrome100"><a href="#chrome100" class="browser-name"><abbr title="Chrome 100">CH 100</abbr></a></th>
-<th class="platform chrome101 desktop unstable" data-browser="chrome101"><a href="#chrome101" class="browser-name"><abbr title="Chrome 101 Beta">CH 101</abbr></a></th>
+<th class="platform chrome99 desktop obsolete" data-browser="chrome99"><a href="#chrome99" class="browser-name"><abbr title="Chrome 99">CH 99</abbr></a></th>
+<th class="platform chrome100 desktop obsolete" data-browser="chrome100"><a href="#chrome100" class="browser-name"><abbr title="Chrome 100">CH 100</abbr></a></th>
+<th class="platform chrome101 desktop" data-browser="chrome101"><a href="#chrome101" class="browser-name"><abbr title="Chrome 101">CH 101</abbr></a></th>
+<th class="platform chrome102 desktop" data-browser="chrome102"><a href="#chrome102" class="browser-name"><abbr title="Chrome 102">CH 102</abbr></a></th>
+<th class="platform chrome103 desktop" data-browser="chrome103"><a href="#chrome103" class="browser-name"><abbr title="Chrome 103">CH 103</abbr></a></th>
+<th class="platform chrome104 desktop unstable" data-browser="chrome104"><a href="#chrome104" class="browser-name"><abbr title="Chrome 104 Beta">CH 104</abbr></a></th>
 <th class="platform edge18 desktop obsolete" data-browser="edge18"><a href="#edge18" class="browser-name"><abbr title="Microsoft Edge 18">Edge 18</abbr></a></th>
 <th class="platform edge87 desktop obsolete" data-browser="edge87"><a href="#edge87" class="browser-name"><abbr title="Microsoft Edge 87">Edge 87</abbr></a></th>
 <th class="platform edge88 desktop obsolete" data-browser="edge88"><a href="#edge88" class="browser-name"><abbr title="Microsoft Edge 88">Edge 88</abbr></a></th>
@@ -185,15 +183,17 @@
 <th class="platform safari15_2 desktop" data-browser="safari15_2"><a href="#safari15_2" class="browser-name"><abbr title="Safari 15.2">SF&#xA0;15.2</abbr></a></th>
 <th class="platform safaritp desktop unstable" data-browser="safaritp"><a href="#safaritp" class="browser-name"><abbr title="Safari Technology Preview Release 133">SF TP</abbr></a></th>
 <th class="platform webkit desktop unstable" data-browser="webkit"><a href="#webkit" class="browser-name"><abbr title="Webkit Nightly">WK</abbr></a></th>
-<th class="platform opera73 desktop obsolete" data-browser="opera73"><a href="#opera73" class="browser-name"><abbr title="Opera 73">OP 73</abbr></a></th>
-<th class="platform opera74 desktop obsolete" data-browser="opera74"><a href="#opera74" class="browser-name"><abbr title="Opera 74">OP 74</abbr></a></th>
-<th class="platform opera75 desktop obsolete" data-browser="opera75"><a href="#opera75" class="browser-name"><abbr title="Opera 75">OP 75</abbr></a></th>
-<th class="platform opera76 desktop obsolete" data-browser="opera76"><a href="#opera76" class="browser-name"><abbr title="Opera 76">OP 76</abbr></a></th>
-<th class="platform opera77 desktop obsolete" data-browser="opera77"><a href="#opera77" class="browser-name"><abbr title="Opera 77">OP 77</abbr></a></th>
-<th class="platform opera78 desktop obsolete" data-browser="opera78"><a href="#opera78" class="browser-name"><abbr title="Opera 78">OP 78</abbr></a></th>
-<th class="platform opera79 desktop" data-browser="opera79"><a href="#opera79" class="browser-name"><abbr title="Opera 79">OP 79</abbr></a></th>
-<th class="platform opera80 desktop" data-browser="opera80"><a href="#opera80" class="browser-name"><abbr title="Opera 80">OP 80</abbr></a></th>
-<th class="platform opera81 desktop unstable" data-browser="opera81"><a href="#opera81" class="browser-name"><abbr title="Opera 81">OP 81</abbr></a></th>
+<th class="platform opera79 desktop obsolete" data-browser="opera79"><a href="#opera79" class="browser-name"><abbr title="Opera 79">OP 79</abbr></a></th>
+<th class="platform opera80 desktop obsolete" data-browser="opera80"><a href="#opera80" class="browser-name"><abbr title="Opera 80">OP 80</abbr></a></th>
+<th class="platform opera81 desktop obsolete" data-browser="opera81"><a href="#opera81" class="browser-name"><abbr title="Opera 81">OP 82</abbr></a></th>
+<th class="platform opera82 desktop obsolete" data-browser="opera82"><a href="#opera82" class="browser-name"><abbr title="Opera 82">OP 82</abbr></a></th>
+<th class="platform opera83 desktop obsolete" data-browser="opera83"><a href="#opera83" class="browser-name"><abbr title="Opera 83">OP 83</abbr></a></th>
+<th class="platform opera84 desktop obsolete" data-browser="opera84"><a href="#opera84" class="browser-name"><abbr title="Opera 84">OP 84</abbr></a></th>
+<th class="platform opera85 desktop obsolete" data-browser="opera85"><a href="#opera85" class="browser-name"><abbr title="Opera 85">OP 85</abbr></a></th>
+<th class="platform opera86 desktop obsolete" data-browser="opera86"><a href="#opera86" class="browser-name"><abbr title="Opera 86">OP 86</abbr></a></th>
+<th class="platform opera87 desktop" data-browser="opera87"><a href="#opera87" class="browser-name"><abbr title="Opera 87">OP 87</abbr></a></th>
+<th class="platform opera88 desktop" data-browser="opera88"><a href="#opera88" class="browser-name"><abbr title="Opera 88">OP 88</abbr></a></th>
+<th class="platform opera89 desktop unstable" data-browser="opera89"><a href="#opera89" class="browser-name"><abbr title="Opera 89">OP 89</abbr></a></th>
 <th class="platform rhino1_7_13 engine obsolete" data-browser="rhino1_7_13"><a href="#rhino1_7_13" class="browser-name"><abbr title="Rhino 1.7.13">Rhino 1.7.13</abbr></a></th>
 <th class="platform rhino1_7_14 engine obsolete" data-browser="rhino1_7_14"><a href="#rhino1_7_14" class="browser-name"><abbr title="Rhino 1.7.14">Rhino 1.7.14</abbr></a></th>
 <th class="platform besen engine" data-browser="besen"><a href="#besen" class="browser-name"><abbr title="Bero&apos;s EcmaScript Engine (version 1.0.0.489)">BESEN</abbr></a></th>
@@ -303,11 +303,6 @@
 <td class="tally unstable" data-browser="firefox102" data-tally="1">5/5</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">5/5</td>
@@ -316,9 +311,12 @@
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">5/5</td>
-<td class="tally" data-browser="chrome99" data-tally="1">5/5</td>
-<td class="tally" data-browser="chrome100" data-tally="1">5/5</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">5/5</td>
+<td class="tally" data-browser="chrome101" data-tally="1">5/5</td>
+<td class="tally" data-browser="chrome102" data-tally="1">5/5</td>
+<td class="tally" data-browser="chrome103" data-tally="1">5/5</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="1">5/5</td>
@@ -338,15 +336,17 @@
 <td class="tally" data-browser="safari15_2" data-tally="1">5/5</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">5/5</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">5/5</td>
-<td class="tally" data-browser="opera79" data-tally="1">5/5</td>
-<td class="tally" data-browser="opera80" data-tally="1">5/5</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">5/5</td>
+<td class="tally" data-browser="opera87" data-tally="1">5/5</td>
+<td class="tally" data-browser="opera88" data-tally="1">5/5</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="1">5/5</td>
 <td class="tally" data-browser="besen" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
@@ -455,11 +455,6 @@ return ({ get x(){ return 1 } }).x === 1;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -468,9 +463,12 @@ return ({ get x(){ return 1 } }).x === 1;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -490,15 +488,17 @@ return ({ get x(){ return 1 } }).x === 1;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -609,11 +609,6 @@ return value === 1;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -622,9 +617,12 @@ return value === 1;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -644,15 +642,17 @@ return value === 1;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -761,11 +761,6 @@ return { a: true, }.a === true;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -774,9 +769,12 @@ return { a: true, }.a === true;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -796,15 +794,17 @@ return { a: true, }.a === true;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -913,11 +913,6 @@ return [1,].length === 1;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -926,9 +921,12 @@ return [1,].length === 1;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -948,15 +946,17 @@ return [1,].length === 1;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -1065,11 +1065,6 @@ return ({ if: 1 }).if === 1;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -1078,9 +1073,12 @@ return ({ if: 1 }).if === 1;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -1100,15 +1098,17 @@ return ({ if: 1 }).if === 1;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -1216,11 +1216,6 @@ return ({ if: 1 }).if === 1;
 <td class="tally unstable" data-browser="firefox102" data-tally="1">13/13</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="1">13/13</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="1">13/13</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="1">13/13</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="1">13/13</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="1">13/13</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">13/13</td>
@@ -1229,9 +1224,12 @@ return ({ if: 1 }).if === 1;
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">13/13</td>
-<td class="tally" data-browser="chrome99" data-tally="1">13/13</td>
-<td class="tally" data-browser="chrome100" data-tally="1">13/13</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">13/13</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">13/13</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">13/13</td>
+<td class="tally" data-browser="chrome101" data-tally="1">13/13</td>
+<td class="tally" data-browser="chrome102" data-tally="1">13/13</td>
+<td class="tally" data-browser="chrome103" data-tally="1">13/13</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="1">13/13</td>
@@ -1251,15 +1249,17 @@ return ({ if: 1 }).if === 1;
 <td class="tally" data-browser="safari15_2" data-tally="1">13/13</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">13/13</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">13/13</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="1">13/13</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="1">13/13</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="1">13/13</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="1">13/13</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="1">13/13</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">13/13</td>
-<td class="tally" data-browser="opera79" data-tally="1">13/13</td>
-<td class="tally" data-browser="opera80" data-tally="1">13/13</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">13/13</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">13/13</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">13/13</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">13/13</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">13/13</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">13/13</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">13/13</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">13/13</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">13/13</td>
+<td class="tally" data-browser="opera87" data-tally="1">13/13</td>
+<td class="tally" data-browser="opera88" data-tally="1">13/13</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="1">13/13</td>
 <td class="tally" data-browser="besen" data-tally="1">13/13</td>
@@ -1370,11 +1370,6 @@ return typeof Object.create === 'function';
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -1383,9 +1378,12 @@ return typeof Object.create === 'function';
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -1405,15 +1403,17 @@ return typeof Object.create === 'function';
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -1524,11 +1524,6 @@ return typeof Object.defineProperty === 'function';
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -1537,9 +1532,12 @@ return typeof Object.defineProperty === 'function';
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -1559,15 +1557,17 @@ return typeof Object.defineProperty === 'function';
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -1678,11 +1678,6 @@ return typeof Object.defineProperties === 'function';
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -1691,9 +1686,12 @@ return typeof Object.defineProperties === 'function';
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -1713,15 +1711,17 @@ return typeof Object.defineProperties === 'function';
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -1832,11 +1832,6 @@ return typeof Object.getPrototypeOf === 'function';
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -1845,9 +1840,12 @@ return typeof Object.getPrototypeOf === 'function';
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -1867,15 +1865,17 @@ return typeof Object.getPrototypeOf === 'function';
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -1986,11 +1986,6 @@ return typeof Object.keys === 'function';
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -1999,9 +1994,12 @@ return typeof Object.keys === 'function';
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -2021,15 +2019,17 @@ return typeof Object.keys === 'function';
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -2140,11 +2140,6 @@ return typeof Object.seal === 'function';
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -2153,9 +2148,12 @@ return typeof Object.seal === 'function';
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -2175,15 +2173,17 @@ return typeof Object.seal === 'function';
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -2294,11 +2294,6 @@ return typeof Object.freeze === 'function';
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -2307,9 +2302,12 @@ return typeof Object.freeze === 'function';
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -2329,15 +2327,17 @@ return typeof Object.freeze === 'function';
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -2448,11 +2448,6 @@ return typeof Object.preventExtensions === 'function';
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -2461,9 +2456,12 @@ return typeof Object.preventExtensions === 'function';
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -2483,15 +2481,17 @@ return typeof Object.preventExtensions === 'function';
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -2602,11 +2602,6 @@ return typeof Object.isSealed === 'function';
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -2615,9 +2610,12 @@ return typeof Object.isSealed === 'function';
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -2637,15 +2635,17 @@ return typeof Object.isSealed === 'function';
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -2756,11 +2756,6 @@ return typeof Object.isFrozen === 'function';
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -2769,9 +2764,12 @@ return typeof Object.isFrozen === 'function';
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -2791,15 +2789,17 @@ return typeof Object.isFrozen === 'function';
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -2910,11 +2910,6 @@ return typeof Object.isExtensible === 'function';
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -2923,9 +2918,12 @@ return typeof Object.isExtensible === 'function';
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -2945,15 +2943,17 @@ return typeof Object.isExtensible === 'function';
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -3064,11 +3064,6 @@ return typeof Object.getOwnPropertyDescriptor === 'function';
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -3077,9 +3072,12 @@ return typeof Object.getOwnPropertyDescriptor === 'function';
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -3099,15 +3097,17 @@ return typeof Object.getOwnPropertyDescriptor === 'function';
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -3218,11 +3218,6 @@ return typeof Object.getOwnPropertyNames === 'function';
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -3231,9 +3226,12 @@ return typeof Object.getOwnPropertyNames === 'function';
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -3253,15 +3251,17 @@ return typeof Object.getOwnPropertyNames === 'function';
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -3367,11 +3367,6 @@ return typeof Object.getOwnPropertyNames === 'function';
 <td class="tally unstable" data-browser="firefox102" data-tally="1">13/13</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="1">13/13</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="1">13/13</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="1">13/13</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="1">13/13</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="1">13/13</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">13/13</td>
@@ -3380,9 +3375,12 @@ return typeof Object.getOwnPropertyNames === 'function';
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">13/13</td>
-<td class="tally" data-browser="chrome99" data-tally="1">13/13</td>
-<td class="tally" data-browser="chrome100" data-tally="1">13/13</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">13/13</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">13/13</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">13/13</td>
+<td class="tally" data-browser="chrome101" data-tally="1">13/13</td>
+<td class="tally" data-browser="chrome102" data-tally="1">13/13</td>
+<td class="tally" data-browser="chrome103" data-tally="1">13/13</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="1">13/13</td>
@@ -3402,15 +3400,17 @@ return typeof Object.getOwnPropertyNames === 'function';
 <td class="tally" data-browser="safari15_2" data-tally="1">13/13</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">13/13</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">13/13</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="1">13/13</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="1">13/13</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="1">13/13</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="1">13/13</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="1">13/13</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">13/13</td>
-<td class="tally" data-browser="opera79" data-tally="1">13/13</td>
-<td class="tally" data-browser="opera80" data-tally="1">13/13</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">13/13</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">13/13</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">13/13</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">13/13</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">13/13</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">13/13</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">13/13</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">13/13</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">13/13</td>
+<td class="tally" data-browser="opera87" data-tally="1">13/13</td>
+<td class="tally" data-browser="opera88" data-tally="1">13/13</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0.9230769230769231" style="background-color:hsl(110,45%,50%)">12/13</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0.9230769230769231" style="background-color:hsl(110,45%,50%)">12/13</td>
 <td class="tally" data-browser="besen" data-tally="0.7692307692307693" style="background-color:hsl(92,52%,50%)">10/13</td>
@@ -3521,11 +3521,6 @@ return typeof Array.isArray === 'function';
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -3534,9 +3529,12 @@ return typeof Array.isArray === 'function';
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -3556,15 +3554,17 @@ return typeof Array.isArray === 'function';
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -3675,11 +3675,6 @@ return typeof Array.prototype.indexOf === 'function';
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -3688,9 +3683,12 @@ return typeof Array.prototype.indexOf === 'function';
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -3710,15 +3708,17 @@ return typeof Array.prototype.indexOf === 'function';
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -3829,11 +3829,6 @@ return typeof Array.prototype.lastIndexOf === 'function';
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -3842,9 +3837,12 @@ return typeof Array.prototype.lastIndexOf === 'function';
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -3864,15 +3862,17 @@ return typeof Array.prototype.lastIndexOf === 'function';
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -3983,11 +3983,6 @@ return typeof Array.prototype.every === 'function';
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -3996,9 +3991,12 @@ return typeof Array.prototype.every === 'function';
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -4018,15 +4016,17 @@ return typeof Array.prototype.every === 'function';
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -4137,11 +4137,6 @@ return typeof Array.prototype.some === 'function';
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -4150,9 +4145,12 @@ return typeof Array.prototype.some === 'function';
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -4172,15 +4170,17 @@ return typeof Array.prototype.some === 'function';
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -4291,11 +4291,6 @@ return typeof Array.prototype.forEach === 'function';
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -4304,9 +4299,12 @@ return typeof Array.prototype.forEach === 'function';
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -4326,15 +4324,17 @@ return typeof Array.prototype.forEach === 'function';
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -4445,11 +4445,6 @@ return typeof Array.prototype.map === 'function';
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -4458,9 +4453,12 @@ return typeof Array.prototype.map === 'function';
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -4480,15 +4478,17 @@ return typeof Array.prototype.map === 'function';
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -4599,11 +4599,6 @@ return typeof Array.prototype.filter === 'function';
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -4612,9 +4607,12 @@ return typeof Array.prototype.filter === 'function';
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -4634,15 +4632,17 @@ return typeof Array.prototype.filter === 'function';
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -4753,11 +4753,6 @@ return typeof Array.prototype.reduce === 'function';
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -4766,9 +4761,12 @@ return typeof Array.prototype.reduce === 'function';
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -4788,15 +4786,17 @@ return typeof Array.prototype.reduce === 'function';
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -4907,11 +4907,6 @@ return typeof Array.prototype.reduceRight === 'function';
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -4920,9 +4915,12 @@ return typeof Array.prototype.reduceRight === 'function';
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -4942,15 +4940,17 @@ return typeof Array.prototype.reduceRight === 'function';
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -5101,11 +5101,6 @@ return true;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -5114,9 +5109,12 @@ return true;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -5136,15 +5134,17 @@ return true;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -5265,11 +5265,6 @@ try {
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -5278,9 +5273,12 @@ try {
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -5300,15 +5298,17 @@ try {
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -5419,11 +5419,6 @@ return [].unshift(0) === 1;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -5432,9 +5427,12 @@ return [].unshift(0) === 1;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -5454,15 +5452,17 @@ return [].unshift(0) === 1;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="unknown obsolete" data-browser="rhino1_7_13">?</td>
 <td class="unknown obsolete" data-browser="rhino1_7_14">?</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -5568,11 +5568,6 @@ return [].unshift(0) === 1;
 <td class="tally unstable" data-browser="firefox102" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">4/4</td>
@@ -5581,9 +5576,12 @@ return [].unshift(0) === 1;
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">4/4</td>
-<td class="tally" data-browser="chrome99" data-tally="1">4/4</td>
-<td class="tally" data-browser="chrome100" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">4/4</td>
+<td class="tally" data-browser="chrome101" data-tally="1">4/4</td>
+<td class="tally" data-browser="chrome102" data-tally="1">4/4</td>
+<td class="tally" data-browser="chrome103" data-tally="1">4/4</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="1">4/4</td>
@@ -5603,15 +5601,17 @@ return [].unshift(0) === 1;
 <td class="tally" data-browser="safari15_2" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally unstable" data-browser="webkit" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">4/4</td>
-<td class="tally" data-browser="opera79" data-tally="1">4/4</td>
-<td class="tally" data-browser="opera80" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">4/4</td>
+<td class="tally" data-browser="opera87" data-tally="1">4/4</td>
+<td class="tally" data-browser="opera88" data-tally="1">4/4</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally" data-browser="besen" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
@@ -5722,11 +5722,6 @@ return "foobar"[3] === "b";
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -5735,9 +5730,12 @@ return "foobar"[3] === "b";
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -5757,15 +5755,17 @@ return "foobar"[3] === "b";
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -5900,11 +5900,6 @@ return typeof String.prototype.split === 'function'
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -5913,9 +5908,12 @@ return typeof String.prototype.split === 'function'
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -5935,15 +5933,17 @@ return typeof String.prototype.split === 'function'
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -6054,11 +6054,6 @@ return '0b'.substr(-1) === 'b';
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -6067,9 +6062,12 @@ return '0b'.substr(-1) === 'b';
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -6089,15 +6087,17 @@ return '0b'.substr(-1) === 'b';
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="unknown obsolete" data-browser="rhino1_7_13">?</td>
 <td class="unknown obsolete" data-browser="rhino1_7_14">?</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -6208,11 +6208,6 @@ return typeof String.prototype.trim === 'function';
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -6221,9 +6216,12 @@ return typeof String.prototype.trim === 'function';
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -6243,15 +6241,17 @@ return typeof String.prototype.trim === 'function';
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -6357,11 +6357,6 @@ return typeof String.prototype.trim === 'function';
 <td class="tally unstable" data-browser="firefox102" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">3/3</td>
@@ -6370,9 +6365,12 @@ return typeof String.prototype.trim === 'function';
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">3/3</td>
-<td class="tally" data-browser="chrome99" data-tally="1">3/3</td>
-<td class="tally" data-browser="chrome100" data-tally="1">3/3</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">3/3</td>
+<td class="tally" data-browser="chrome101" data-tally="1">3/3</td>
+<td class="tally" data-browser="chrome102" data-tally="1">3/3</td>
+<td class="tally" data-browser="chrome103" data-tally="1">3/3</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="1">3/3</td>
@@ -6392,15 +6390,17 @@ return typeof String.prototype.trim === 'function';
 <td class="tally" data-browser="safari15_2" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">3/3</td>
-<td class="tally" data-browser="opera79" data-tally="1">3/3</td>
-<td class="tally" data-browser="opera80" data-tally="1">3/3</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">3/3</td>
+<td class="tally" data-browser="opera87" data-tally="1">3/3</td>
+<td class="tally" data-browser="opera88" data-tally="1">3/3</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="1">3/3</td>
 <td class="tally" data-browser="besen" data-tally="1">3/3</td>
@@ -6511,11 +6511,6 @@ return typeof Date.prototype.toISOString === 'function';
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -6524,9 +6519,12 @@ return typeof Date.prototype.toISOString === 'function';
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -6546,15 +6544,17 @@ return typeof Date.prototype.toISOString === 'function';
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -6665,11 +6665,6 @@ return typeof Date.now === 'function';
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -6678,9 +6673,12 @@ return typeof Date.now === 'function';
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -6700,15 +6698,17 @@ return typeof Date.now === 'function';
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -6827,11 +6827,6 @@ try {
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -6840,9 +6835,12 @@ try {
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -6862,15 +6860,17 @@ try {
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -6981,11 +6981,6 @@ return typeof Function.prototype.bind === 'function';
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -6994,9 +6989,12 @@ return typeof Function.prototype.bind === 'function';
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -7016,15 +7014,17 @@ return typeof Function.prototype.bind === 'function';
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -7135,11 +7135,6 @@ return typeof JSON === 'object';
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -7148,9 +7143,12 @@ return typeof JSON === 'object';
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -7170,15 +7168,17 @@ return typeof JSON === 'object';
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -7286,11 +7286,6 @@ return typeof JSON === 'object';
 <td class="tally unstable" data-browser="firefox102" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">3/3</td>
@@ -7299,9 +7294,12 @@ return typeof JSON === 'object';
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">3/3</td>
-<td class="tally" data-browser="chrome99" data-tally="1">3/3</td>
-<td class="tally" data-browser="chrome100" data-tally="1">3/3</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">3/3</td>
+<td class="tally" data-browser="chrome101" data-tally="1">3/3</td>
+<td class="tally" data-browser="chrome102" data-tally="1">3/3</td>
+<td class="tally" data-browser="chrome103" data-tally="1">3/3</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="1">3/3</td>
@@ -7321,15 +7319,17 @@ return typeof JSON === 'object';
 <td class="tally" data-browser="safari15_2" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">3/3</td>
-<td class="tally" data-browser="opera79" data-tally="1">3/3</td>
-<td class="tally" data-browser="opera80" data-tally="1">3/3</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">3/3</td>
+<td class="tally" data-browser="opera87" data-tally="1">3/3</td>
+<td class="tally" data-browser="opera88" data-tally="1">3/3</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="1">3/3</td>
 <td class="tally" data-browser="besen" data-tally="1">3/3</td>
@@ -7441,11 +7441,6 @@ return result;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -7454,9 +7449,12 @@ return result;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -7476,15 +7474,17 @@ return result;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -7596,11 +7596,6 @@ return result;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -7609,9 +7604,12 @@ return result;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -7631,15 +7629,17 @@ return result;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -7751,11 +7751,6 @@ return result;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -7764,9 +7759,12 @@ return result;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -7786,15 +7784,17 @@ return result;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -7900,11 +7900,6 @@ return result;
 <td class="tally unstable" data-browser="firefox102" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">3/3</td>
@@ -7913,9 +7908,12 @@ return result;
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">3/3</td>
-<td class="tally" data-browser="chrome99" data-tally="1">3/3</td>
-<td class="tally" data-browser="chrome100" data-tally="1">3/3</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">3/3</td>
+<td class="tally" data-browser="chrome101" data-tally="1">3/3</td>
+<td class="tally" data-browser="chrome102" data-tally="1">3/3</td>
+<td class="tally" data-browser="chrome103" data-tally="1">3/3</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="1">3/3</td>
@@ -7935,15 +7933,17 @@ return result;
 <td class="tally" data-browser="safari15_2" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">3/3</td>
-<td class="tally" data-browser="opera79" data-tally="1">3/3</td>
-<td class="tally" data-browser="opera80" data-tally="1">3/3</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">3/3</td>
+<td class="tally" data-browser="opera87" data-tally="1">3/3</td>
+<td class="tally" data-browser="opera88" data-tally="1">3/3</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="1">3/3</td>
 <td class="tally" data-browser="besen" data-tally="0">0/3</td>
@@ -8058,11 +8058,6 @@ return (-6.9e-11).toExponential(4) === '-6.9000e-11' // Edge <= 17
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -8071,9 +8066,12 @@ return (-6.9e-11).toExponential(4) === '-6.9000e-11' // Edge <= 17
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -8093,15 +8091,17 @@ return (-6.9e-11).toExponential(4) === '-6.9000e-11' // Edge <= 17
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="unknown obsolete" data-browser="rhino1_7_13">?</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -8224,11 +8224,6 @@ try {
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -8237,9 +8232,12 @@ try {
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -8259,15 +8257,17 @@ try {
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="unknown obsolete" data-browser="rhino1_7_13">?</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -8390,11 +8390,6 @@ try {
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -8403,9 +8398,12 @@ try {
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -8425,15 +8423,17 @@ try {
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="unknown obsolete" data-browser="rhino1_7_13">?</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -8539,11 +8539,6 @@ try {
 <td class="tally unstable" data-browser="firefox102" data-tally="1">8/8</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="1">8/8</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="1">8/8</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="1">8/8</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="1">8/8</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">8/8</td>
@@ -8552,9 +8547,12 @@ try {
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">8/8</td>
-<td class="tally" data-browser="chrome99" data-tally="1">8/8</td>
-<td class="tally" data-browser="chrome100" data-tally="1">8/8</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">8/8</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">8/8</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">8/8</td>
+<td class="tally" data-browser="chrome101" data-tally="1">8/8</td>
+<td class="tally" data-browser="chrome102" data-tally="1">8/8</td>
+<td class="tally" data-browser="chrome103" data-tally="1">8/8</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="1">8/8</td>
@@ -8574,15 +8572,17 @@ try {
 <td class="tally" data-browser="safari15_2" data-tally="1">8/8</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">8/8</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">8/8</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="1">8/8</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="1">8/8</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="1">8/8</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="1">8/8</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="1">8/8</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">8/8</td>
-<td class="tally" data-browser="opera79" data-tally="1">8/8</td>
-<td class="tally" data-browser="opera80" data-tally="1">8/8</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">8/8</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">8/8</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">8/8</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">8/8</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">8/8</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">8/8</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">8/8</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">8/8</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">8/8</td>
+<td class="tally" data-browser="opera87" data-tally="1">8/8</td>
+<td class="tally" data-browser="opera88" data-tally="1">8/8</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally" data-browser="besen" data-tally="0.25" style="background-color:hsl(30,75%,50%)">2/8</td>
@@ -8701,11 +8701,6 @@ try {
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -8714,9 +8709,12 @@ try {
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -8736,15 +8734,17 @@ try {
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -8855,11 +8855,6 @@ return parseInt('010') === 10;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -8868,9 +8863,12 @@ return parseInt('010') === 10;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -8890,15 +8888,17 @@ return parseInt('010') === 10;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -9007,11 +9007,6 @@ return !Function().propertyIsEnumerable(&apos;prototype&apos;);
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -9020,9 +9015,12 @@ return !Function().propertyIsEnumerable(&apos;prototype&apos;);
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -9042,15 +9040,17 @@ return !Function().propertyIsEnumerable(&apos;prototype&apos;);
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -9159,11 +9159,6 @@ return (function(){ return Object.prototype.toString.call(arguments) === &apos;[
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -9172,9 +9167,12 @@ return (function(){ return Object.prototype.toString.call(arguments) === &apos;[
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -9194,15 +9192,17 @@ return (function(){ return Object.prototype.toString.call(arguments) === &apos;[
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -9312,11 +9312,6 @@ return _\u200c\u200d;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -9325,9 +9320,12 @@ return _\u200c\u200d;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -9347,15 +9345,17 @@ return _\u200c\u200d;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -9466,11 +9466,6 @@ return true;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -9479,9 +9474,12 @@ return true;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -9501,15 +9499,17 @@ return true;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -9626,11 +9626,6 @@ return result;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -9639,9 +9634,12 @@ return result;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -9661,15 +9659,17 @@ return result;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -9784,11 +9784,6 @@ catch(e) {
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -9797,9 +9792,12 @@ catch(e) {
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -9819,15 +9817,17 @@ catch(e) {
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -9933,11 +9933,6 @@ catch(e) {
 <td class="tally unstable" data-browser="firefox102" data-tally="1">19/19</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="1">19/19</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="1">19/19</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="1">19/19</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="1">19/19</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="1">19/19</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">19/19</td>
@@ -9946,9 +9941,12 @@ catch(e) {
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">19/19</td>
-<td class="tally" data-browser="chrome99" data-tally="1">19/19</td>
-<td class="tally" data-browser="chrome100" data-tally="1">19/19</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">19/19</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">19/19</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">19/19</td>
+<td class="tally" data-browser="chrome101" data-tally="1">19/19</td>
+<td class="tally" data-browser="chrome102" data-tally="1">19/19</td>
+<td class="tally" data-browser="chrome103" data-tally="1">19/19</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="1">19/19</td>
@@ -9968,15 +9966,17 @@ catch(e) {
 <td class="tally" data-browser="safari15_2" data-tally="1">19/19</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">19/19</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">19/19</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="1">19/19</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="1">19/19</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="1">19/19</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="1">19/19</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="1">19/19</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">19/19</td>
-<td class="tally" data-browser="opera79" data-tally="1">19/19</td>
-<td class="tally" data-browser="opera80" data-tally="1">19/19</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">19/19</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">19/19</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">19/19</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">19/19</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">19/19</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">19/19</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">19/19</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">19/19</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">19/19</td>
+<td class="tally" data-browser="opera87" data-tally="1">19/19</td>
+<td class="tally" data-browser="opera88" data-tally="1">19/19</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0.5263157894736842" style="background-color:hsl(63,62%,50%)">10/19</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0.5263157894736842" style="background-color:hsl(63,62%,50%)">10/19</td>
 <td class="tally" data-browser="besen" data-tally="1">19/19</td>
@@ -10090,11 +10090,6 @@ return true;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -10103,9 +10098,12 @@ return true;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -10125,15 +10123,17 @@ return true;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -10243,11 +10243,6 @@ return this === void undefined &amp;&amp; (function(){ return this === void unde
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -10256,9 +10251,12 @@ return this === void undefined &amp;&amp; (function(){ return this === void unde
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes<a href="#strict-mode-ie10-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -10278,15 +10276,17 @@ return this === void undefined &amp;&amp; (function(){ return this === void unde
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -10398,11 +10398,6 @@ return (function(){ return typeof this === &apos;string&apos; }).call(&apos;&apo
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -10411,9 +10406,12 @@ return (function(){ return typeof this === &apos;string&apos; }).call(&apos;&apo
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -10433,15 +10431,17 @@ return (function(){ return typeof this === &apos;string&apos; }).call(&apos;&apo
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -10567,11 +10567,6 @@ return test(String, &apos;&apos;)
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -10580,9 +10575,12 @@ return test(String, &apos;&apos;)
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -10602,15 +10600,17 @@ return test(String, &apos;&apos;)
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -10722,11 +10722,6 @@ return true;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -10735,9 +10730,12 @@ return true;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -10757,15 +10755,17 @@ return true;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -10875,11 +10875,6 @@ try { eval(&apos;__i_dont_exist = 1&apos;); } catch (err) { return err instanceo
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -10888,9 +10883,12 @@ try { eval(&apos;__i_dont_exist = 1&apos;); } catch (err) { return err instanceo
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -10910,15 +10908,17 @@ try { eval(&apos;__i_dont_exist = 1&apos;); } catch (err) { return err instanceo
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -11032,11 +11032,6 @@ return true;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -11045,9 +11040,12 @@ return true;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -11067,15 +11065,17 @@ return true;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -11189,11 +11189,6 @@ return true;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -11202,9 +11197,12 @@ return true;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -11224,15 +11222,17 @@ return true;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -11348,11 +11348,6 @@ return true;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -11361,9 +11356,12 @@ return true;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -11383,15 +11381,17 @@ return true;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -11504,11 +11504,6 @@ return true;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -11517,9 +11512,12 @@ return true;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -11539,15 +11537,17 @@ return true;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -11658,11 +11658,6 @@ return true;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -11671,9 +11666,12 @@ return true;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -11693,15 +11691,17 @@ return true;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -11813,11 +11813,6 @@ return true;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -11826,9 +11821,12 @@ return true;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -11848,15 +11846,17 @@ return true;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -11972,11 +11972,6 @@ return (function(x){
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -11985,9 +11980,12 @@ return (function(x){
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -12007,15 +12005,17 @@ return (function(x){
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -12125,11 +12125,6 @@ try { eval(&apos;var __some_unique_variable;&apos;); __some_unique_variable; } c
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -12138,9 +12133,12 @@ try { eval(&apos;var __some_unique_variable;&apos;); __some_unique_variable; } c
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -12160,15 +12158,17 @@ try { eval(&apos;var __some_unique_variable;&apos;); __some_unique_variable; } c
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -12278,11 +12278,6 @@ try { eval(&apos;var x; delete x;&apos;); } catch (err) { return err instanceof 
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -12291,9 +12286,12 @@ try { eval(&apos;var x; delete x;&apos;); } catch (err) { return err instanceof 
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -12313,15 +12311,17 @@ try { eval(&apos;var x; delete x;&apos;); } catch (err) { return err instanceof 
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -12431,11 +12431,6 @@ try { delete Object.prototype; } catch (err) { return err instanceof TypeError; 
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -12444,9 +12439,12 @@ try { delete Object.prototype; } catch (err) { return err instanceof TypeError; 
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -12466,15 +12464,17 @@ try { delete Object.prototype; } catch (err) { return err instanceof TypeError; 
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -12584,11 +12584,6 @@ try { eval(&apos;with({}){}&apos;); } catch (err) { return err instanceof Syntax
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -12597,9 +12592,12 @@ try { eval(&apos;with({}){}&apos;); } catch (err) { return err instanceof Syntax
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -12619,15 +12617,17 @@ try { eval(&apos;with({}){}&apos;); } catch (err) { return err instanceof Syntax
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -12737,11 +12737,6 @@ try { eval(&apos;function f(x, x) { }&apos;); } catch (err) { return err instanc
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -12750,9 +12745,12 @@ try { eval(&apos;function f(x, x) { }&apos;); } catch (err) { return err instanc
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -12772,15 +12770,17 @@ try { eval(&apos;function f(x, x) { }&apos;); } catch (err) { return err instanc
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -12890,11 +12890,6 @@ return typeof foo === &apos;function&apos;;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -12903,9 +12898,12 @@ return typeof foo === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -12925,15 +12923,17 @@ return typeof foo === &apos;function&apos;;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>

--- a/es5/index.html
+++ b/es5/index.html
@@ -160,7 +160,7 @@
 <th class="platform chrome98 desktop obsolete" data-browser="chrome98"><a href="#chrome98" class="browser-name"><abbr title="Chrome 98">CH 98</abbr></a></th>
 <th class="platform chrome99 desktop obsolete" data-browser="chrome99"><a href="#chrome99" class="browser-name"><abbr title="Chrome 99">CH 99</abbr></a></th>
 <th class="platform chrome100 desktop obsolete" data-browser="chrome100"><a href="#chrome100" class="browser-name"><abbr title="Chrome 100">CH 100</abbr></a></th>
-<th class="platform chrome101 desktop" data-browser="chrome101"><a href="#chrome101" class="browser-name"><abbr title="Chrome 101">CH 101</abbr></a></th>
+<th class="platform chrome101 desktop obsolete" data-browser="chrome101"><a href="#chrome101" class="browser-name"><abbr title="Chrome 101">CH 101</abbr></a></th>
 <th class="platform chrome102 desktop" data-browser="chrome102"><a href="#chrome102" class="browser-name"><abbr title="Chrome 102">CH 102</abbr></a></th>
 <th class="platform chrome103 desktop" data-browser="chrome103"><a href="#chrome103" class="browser-name"><abbr title="Chrome 103">CH 103</abbr></a></th>
 <th class="platform chrome104 desktop unstable" data-browser="chrome104"><a href="#chrome104" class="browser-name"><abbr title="Chrome 104 Beta">CH 104</abbr></a></th>
@@ -313,7 +313,7 @@
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">5/5</td>
-<td class="tally" data-browser="chrome101" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">5/5</td>
 <td class="tally" data-browser="chrome102" data-tally="1">5/5</td>
 <td class="tally" data-browser="chrome103" data-tally="1">5/5</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">5/5</td>
@@ -465,7 +465,7 @@ return ({ get x(){ return 1 } }).x === 1;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -619,7 +619,7 @@ return value === 1;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -771,7 +771,7 @@ return { a: true, }.a === true;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -923,7 +923,7 @@ return [1,].length === 1;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -1075,7 +1075,7 @@ return ({ if: 1 }).if === 1;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -1226,7 +1226,7 @@ return ({ if: 1 }).if === 1;
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">13/13</td>
-<td class="tally" data-browser="chrome101" data-tally="1">13/13</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">13/13</td>
 <td class="tally" data-browser="chrome102" data-tally="1">13/13</td>
 <td class="tally" data-browser="chrome103" data-tally="1">13/13</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">13/13</td>
@@ -1380,7 +1380,7 @@ return typeof Object.create === 'function';
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -1534,7 +1534,7 @@ return typeof Object.defineProperty === 'function';
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -1688,7 +1688,7 @@ return typeof Object.defineProperties === 'function';
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -1842,7 +1842,7 @@ return typeof Object.getPrototypeOf === 'function';
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -1996,7 +1996,7 @@ return typeof Object.keys === 'function';
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -2150,7 +2150,7 @@ return typeof Object.seal === 'function';
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -2304,7 +2304,7 @@ return typeof Object.freeze === 'function';
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -2458,7 +2458,7 @@ return typeof Object.preventExtensions === 'function';
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -2612,7 +2612,7 @@ return typeof Object.isSealed === 'function';
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -2766,7 +2766,7 @@ return typeof Object.isFrozen === 'function';
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -2920,7 +2920,7 @@ return typeof Object.isExtensible === 'function';
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -3074,7 +3074,7 @@ return typeof Object.getOwnPropertyDescriptor === 'function';
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -3228,7 +3228,7 @@ return typeof Object.getOwnPropertyNames === 'function';
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -3377,7 +3377,7 @@ return typeof Object.getOwnPropertyNames === 'function';
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">13/13</td>
-<td class="tally" data-browser="chrome101" data-tally="1">13/13</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">13/13</td>
 <td class="tally" data-browser="chrome102" data-tally="1">13/13</td>
 <td class="tally" data-browser="chrome103" data-tally="1">13/13</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">13/13</td>
@@ -3531,7 +3531,7 @@ return typeof Array.isArray === 'function';
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -3685,7 +3685,7 @@ return typeof Array.prototype.indexOf === 'function';
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -3839,7 +3839,7 @@ return typeof Array.prototype.lastIndexOf === 'function';
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -3993,7 +3993,7 @@ return typeof Array.prototype.every === 'function';
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -4147,7 +4147,7 @@ return typeof Array.prototype.some === 'function';
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -4301,7 +4301,7 @@ return typeof Array.prototype.forEach === 'function';
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -4455,7 +4455,7 @@ return typeof Array.prototype.map === 'function';
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -4609,7 +4609,7 @@ return typeof Array.prototype.filter === 'function';
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -4763,7 +4763,7 @@ return typeof Array.prototype.reduce === 'function';
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -4917,7 +4917,7 @@ return typeof Array.prototype.reduceRight === 'function';
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -5111,7 +5111,7 @@ return true;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -5275,7 +5275,7 @@ try {
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -5429,7 +5429,7 @@ return [].unshift(0) === 1;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -5578,7 +5578,7 @@ return [].unshift(0) === 1;
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">4/4</td>
-<td class="tally" data-browser="chrome101" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">4/4</td>
 <td class="tally" data-browser="chrome102" data-tally="1">4/4</td>
 <td class="tally" data-browser="chrome103" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">4/4</td>
@@ -5732,7 +5732,7 @@ return "foobar"[3] === "b";
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -5910,7 +5910,7 @@ return typeof String.prototype.split === 'function'
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -6064,7 +6064,7 @@ return '0b'.substr(-1) === 'b';
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -6218,7 +6218,7 @@ return typeof String.prototype.trim === 'function';
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -6367,7 +6367,7 @@ return typeof String.prototype.trim === 'function';
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">3/3</td>
-<td class="tally" data-browser="chrome101" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">3/3</td>
 <td class="tally" data-browser="chrome102" data-tally="1">3/3</td>
 <td class="tally" data-browser="chrome103" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">3/3</td>
@@ -6521,7 +6521,7 @@ return typeof Date.prototype.toISOString === 'function';
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -6675,7 +6675,7 @@ return typeof Date.now === 'function';
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -6837,7 +6837,7 @@ try {
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -6991,7 +6991,7 @@ return typeof Function.prototype.bind === 'function';
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -7145,7 +7145,7 @@ return typeof JSON === 'object';
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -7296,7 +7296,7 @@ return typeof JSON === 'object';
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">3/3</td>
-<td class="tally" data-browser="chrome101" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">3/3</td>
 <td class="tally" data-browser="chrome102" data-tally="1">3/3</td>
 <td class="tally" data-browser="chrome103" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">3/3</td>
@@ -7451,7 +7451,7 @@ return result;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -7606,7 +7606,7 @@ return result;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -7761,7 +7761,7 @@ return result;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -7910,7 +7910,7 @@ return result;
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">3/3</td>
-<td class="tally" data-browser="chrome101" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">3/3</td>
 <td class="tally" data-browser="chrome102" data-tally="1">3/3</td>
 <td class="tally" data-browser="chrome103" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">3/3</td>
@@ -8068,7 +8068,7 @@ return (-6.9e-11).toExponential(4) === '-6.9000e-11' // Edge <= 17
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -8234,7 +8234,7 @@ try {
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -8400,7 +8400,7 @@ try {
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -8549,7 +8549,7 @@ try {
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">8/8</td>
-<td class="tally" data-browser="chrome101" data-tally="1">8/8</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">8/8</td>
 <td class="tally" data-browser="chrome102" data-tally="1">8/8</td>
 <td class="tally" data-browser="chrome103" data-tally="1">8/8</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">8/8</td>
@@ -8711,7 +8711,7 @@ try {
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -8865,7 +8865,7 @@ return parseInt('010') === 10;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -9017,7 +9017,7 @@ return !Function().propertyIsEnumerable(&apos;prototype&apos;);
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -9169,7 +9169,7 @@ return (function(){ return Object.prototype.toString.call(arguments) === &apos;[
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -9322,7 +9322,7 @@ return _\u200c\u200d;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -9476,7 +9476,7 @@ return true;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -9636,7 +9636,7 @@ return result;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -9794,7 +9794,7 @@ catch(e) {
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -9943,7 +9943,7 @@ catch(e) {
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">19/19</td>
-<td class="tally" data-browser="chrome101" data-tally="1">19/19</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">19/19</td>
 <td class="tally" data-browser="chrome102" data-tally="1">19/19</td>
 <td class="tally" data-browser="chrome103" data-tally="1">19/19</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">19/19</td>
@@ -10100,7 +10100,7 @@ return true;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -10253,7 +10253,7 @@ return this === void undefined &amp;&amp; (function(){ return this === void unde
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -10408,7 +10408,7 @@ return (function(){ return typeof this === &apos;string&apos; }).call(&apos;&apo
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -10577,7 +10577,7 @@ return test(String, &apos;&apos;)
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -10732,7 +10732,7 @@ return true;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -10885,7 +10885,7 @@ try { eval(&apos;__i_dont_exist = 1&apos;); } catch (err) { return err instanceo
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -11042,7 +11042,7 @@ return true;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -11199,7 +11199,7 @@ return true;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -11358,7 +11358,7 @@ return true;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -11514,7 +11514,7 @@ return true;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -11668,7 +11668,7 @@ return true;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -11823,7 +11823,7 @@ return true;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -11982,7 +11982,7 @@ return (function(x){
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -12135,7 +12135,7 @@ try { eval(&apos;var __some_unique_variable;&apos;); __some_unique_variable; } c
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -12288,7 +12288,7 @@ try { eval(&apos;var x; delete x;&apos;); } catch (err) { return err instanceof 
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -12441,7 +12441,7 @@ try { delete Object.prototype; } catch (err) { return err instanceof TypeError; 
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -12594,7 +12594,7 @@ try { eval(&apos;with({}){}&apos;); } catch (err) { return err instanceof Syntax
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -12747,7 +12747,7 @@ try { eval(&apos;function f(x, x) { }&apos;); } catch (err) { return err instanc
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -12900,7 +12900,7 @@ return typeof foo === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>

--- a/esintl/index.html
+++ b/esintl/index.html
@@ -154,11 +154,6 @@
 <th class="platform firefox102 desktop unstable" data-browser="firefox102"><a href="#firefox102" class="browser-name"><abbr title="Firefox 102 Beta">FF 102</abbr></a></th>
 <th class="platform firefox103 desktop unstable" data-browser="firefox103"><a href="#firefox103" class="browser-name"><abbr title="Firefox 103 Nightly">FF 103</abbr></a></th>
 <th class="platform opera12_10 desktop obsolete" data-browser="opera12_10"><a href="#opera12_10" class="browser-name"><abbr title="Opera 12.10">OP 12.10</abbr></a></th>
-<th class="platform chrome86 desktop obsolete" data-browser="chrome86"><a href="#chrome86" class="browser-name"><abbr title="Chrome 86">CH 86</abbr></a></th>
-<th class="platform chrome87 desktop obsolete" data-browser="chrome87"><a href="#chrome87" class="browser-name"><abbr title="Chrome 87">CH 87</abbr></a></th>
-<th class="platform chrome88 desktop obsolete" data-browser="chrome88"><a href="#chrome88" class="browser-name"><abbr title="Chrome 88">CH 88</abbr></a></th>
-<th class="platform chrome89 desktop obsolete" data-browser="chrome89"><a href="#chrome89" class="browser-name"><abbr title="Chrome 89">CH 89</abbr></a></th>
-<th class="platform chrome90 desktop obsolete" data-browser="chrome90"><a href="#chrome90" class="browser-name"><abbr title="Chrome 90">CH 90</abbr></a></th>
 <th class="platform chrome91 desktop obsolete" data-browser="chrome91"><a href="#chrome91" class="browser-name"><abbr title="Chrome 91">CH 91</abbr></a></th>
 <th class="platform chrome92 desktop obsolete" data-browser="chrome92"><a href="#chrome92" class="browser-name"><abbr title="Chrome 92">CH 92</abbr></a></th>
 <th class="platform chrome93 desktop obsolete" data-browser="chrome93"><a href="#chrome93" class="browser-name"><abbr title="Chrome 93">CH 93</abbr></a></th>
@@ -167,9 +162,12 @@
 <th class="platform chrome96 desktop obsolete" data-browser="chrome96"><a href="#chrome96" class="browser-name"><abbr title="Chrome 96">CH 96</abbr></a></th>
 <th class="platform chrome97 desktop obsolete" data-browser="chrome97"><a href="#chrome97" class="browser-name"><abbr title="Chrome 97">CH 97</abbr></a></th>
 <th class="platform chrome98 desktop obsolete" data-browser="chrome98"><a href="#chrome98" class="browser-name"><abbr title="Chrome 98">CH 98</abbr></a></th>
-<th class="platform chrome99 desktop" data-browser="chrome99"><a href="#chrome99" class="browser-name"><abbr title="Chrome 99">CH 99</abbr></a></th>
-<th class="platform chrome100 desktop" data-browser="chrome100"><a href="#chrome100" class="browser-name"><abbr title="Chrome 100">CH 100</abbr></a></th>
-<th class="platform chrome101 desktop unstable" data-browser="chrome101"><a href="#chrome101" class="browser-name"><abbr title="Chrome 101 Beta">CH 101</abbr></a></th>
+<th class="platform chrome99 desktop obsolete" data-browser="chrome99"><a href="#chrome99" class="browser-name"><abbr title="Chrome 99">CH 99</abbr></a></th>
+<th class="platform chrome100 desktop obsolete" data-browser="chrome100"><a href="#chrome100" class="browser-name"><abbr title="Chrome 100">CH 100</abbr></a></th>
+<th class="platform chrome101 desktop" data-browser="chrome101"><a href="#chrome101" class="browser-name"><abbr title="Chrome 101">CH 101</abbr></a></th>
+<th class="platform chrome102 desktop" data-browser="chrome102"><a href="#chrome102" class="browser-name"><abbr title="Chrome 102">CH 102</abbr></a></th>
+<th class="platform chrome103 desktop" data-browser="chrome103"><a href="#chrome103" class="browser-name"><abbr title="Chrome 103">CH 103</abbr></a></th>
+<th class="platform chrome104 desktop unstable" data-browser="chrome104"><a href="#chrome104" class="browser-name"><abbr title="Chrome 104 Beta">CH 104</abbr></a></th>
 <th class="platform edge18 desktop obsolete" data-browser="edge18"><a href="#edge18" class="browser-name"><abbr title="Microsoft Edge 18">Edge 18</abbr></a></th>
 <th class="platform edge87 desktop obsolete" data-browser="edge87"><a href="#edge87" class="browser-name"><abbr title="Microsoft Edge 87">Edge 87</abbr></a></th>
 <th class="platform edge88 desktop obsolete" data-browser="edge88"><a href="#edge88" class="browser-name"><abbr title="Microsoft Edge 88">Edge 88</abbr></a></th>
@@ -189,15 +187,17 @@
 <th class="platform safari15_2 desktop" data-browser="safari15_2"><a href="#safari15_2" class="browser-name"><abbr title="Safari 15.2">SF&#xA0;15.2</abbr></a></th>
 <th class="platform safaritp desktop unstable" data-browser="safaritp"><a href="#safaritp" class="browser-name"><abbr title="Safari Technology Preview Release 133">SF TP</abbr></a></th>
 <th class="platform webkit desktop unstable" data-browser="webkit"><a href="#webkit" class="browser-name"><abbr title="Webkit Nightly">WK</abbr></a></th>
-<th class="platform opera73 desktop obsolete" data-browser="opera73"><a href="#opera73" class="browser-name"><abbr title="Opera 73">OP 73</abbr></a></th>
-<th class="platform opera74 desktop obsolete" data-browser="opera74"><a href="#opera74" class="browser-name"><abbr title="Opera 74">OP 74</abbr></a></th>
-<th class="platform opera75 desktop obsolete" data-browser="opera75"><a href="#opera75" class="browser-name"><abbr title="Opera 75">OP 75</abbr></a></th>
-<th class="platform opera76 desktop obsolete" data-browser="opera76"><a href="#opera76" class="browser-name"><abbr title="Opera 76">OP 76</abbr></a></th>
-<th class="platform opera77 desktop obsolete" data-browser="opera77"><a href="#opera77" class="browser-name"><abbr title="Opera 77">OP 77</abbr></a></th>
-<th class="platform opera78 desktop obsolete" data-browser="opera78"><a href="#opera78" class="browser-name"><abbr title="Opera 78">OP 78</abbr></a></th>
-<th class="platform opera79 desktop" data-browser="opera79"><a href="#opera79" class="browser-name"><abbr title="Opera 79">OP 79</abbr></a></th>
-<th class="platform opera80 desktop" data-browser="opera80"><a href="#opera80" class="browser-name"><abbr title="Opera 80">OP 80</abbr></a></th>
-<th class="platform opera81 desktop unstable" data-browser="opera81"><a href="#opera81" class="browser-name"><abbr title="Opera 81">OP 81</abbr></a></th>
+<th class="platform opera79 desktop obsolete" data-browser="opera79"><a href="#opera79" class="browser-name"><abbr title="Opera 79">OP 79</abbr></a></th>
+<th class="platform opera80 desktop obsolete" data-browser="opera80"><a href="#opera80" class="browser-name"><abbr title="Opera 80">OP 80</abbr></a></th>
+<th class="platform opera81 desktop obsolete" data-browser="opera81"><a href="#opera81" class="browser-name"><abbr title="Opera 81">OP 82</abbr></a></th>
+<th class="platform opera82 desktop obsolete" data-browser="opera82"><a href="#opera82" class="browser-name"><abbr title="Opera 82">OP 82</abbr></a></th>
+<th class="platform opera83 desktop obsolete" data-browser="opera83"><a href="#opera83" class="browser-name"><abbr title="Opera 83">OP 83</abbr></a></th>
+<th class="platform opera84 desktop obsolete" data-browser="opera84"><a href="#opera84" class="browser-name"><abbr title="Opera 84">OP 84</abbr></a></th>
+<th class="platform opera85 desktop obsolete" data-browser="opera85"><a href="#opera85" class="browser-name"><abbr title="Opera 85">OP 85</abbr></a></th>
+<th class="platform opera86 desktop obsolete" data-browser="opera86"><a href="#opera86" class="browser-name"><abbr title="Opera 86">OP 86</abbr></a></th>
+<th class="platform opera87 desktop" data-browser="opera87"><a href="#opera87" class="browser-name"><abbr title="Opera 87">OP 87</abbr></a></th>
+<th class="platform opera88 desktop" data-browser="opera88"><a href="#opera88" class="browser-name"><abbr title="Opera 88">OP 88</abbr></a></th>
+<th class="platform opera89 desktop unstable" data-browser="opera89"><a href="#opera89" class="browser-name"><abbr title="Opera 89">OP 89</abbr></a></th>
 <th class="platform rhino1_7_13 engine obsolete" data-browser="rhino1_7_13"><a href="#rhino1_7_13" class="browser-name"><abbr title="Rhino 1.7.13">Rhino 1.7.13</abbr></a></th>
 <th class="platform rhino1_7_14 engine obsolete" data-browser="rhino1_7_14"><a href="#rhino1_7_14" class="browser-name"><abbr title="Rhino 1.7.14">Rhino 1.7.14</abbr></a></th>
 <th class="platform phantom2_1 engine obsolete" data-browser="phantom2_1"><a href="#phantom2_1" class="browser-name"><abbr title="PhantomJS 2.1">PJS</abbr></a></th>
@@ -292,11 +292,6 @@
 <td class="tally unstable" data-browser="firefox102" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">2/2</td>
@@ -305,9 +300,12 @@
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">2/2</td>
-<td class="tally" data-browser="chrome99" data-tally="1">2/2</td>
-<td class="tally" data-browser="chrome100" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">2/2</td>
+<td class="tally" data-browser="chrome101" data-tally="1">2/2</td>
+<td class="tally" data-browser="chrome102" data-tally="1">2/2</td>
+<td class="tally" data-browser="chrome103" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="1">2/2</td>
@@ -327,15 +325,17 @@
 <td class="tally" data-browser="safari15_2" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">2/2</td>
-<td class="tally" data-browser="opera79" data-tally="1">2/2</td>
-<td class="tally" data-browser="opera80" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">2/2</td>
+<td class="tally" data-browser="opera87" data-tally="1">2/2</td>
+<td class="tally" data-browser="opera88" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/2</td>
@@ -429,11 +429,6 @@ return typeof Intl === &apos;object&apos;;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -442,9 +437,12 @@ return typeof Intl === &apos;object&apos;;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -464,15 +462,17 @@ return typeof Intl === &apos;object&apos;;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -566,11 +566,6 @@ return Intl.constructor === Object;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -579,9 +574,12 @@ return Intl.constructor === Object;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -601,15 +599,17 @@ return Intl.constructor === Object;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -700,11 +700,6 @@ return Intl.constructor === Object;
 <td class="tally unstable" data-browser="firefox102" data-tally="1">5/5</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">5/5</td>
@@ -713,9 +708,12 @@ return Intl.constructor === Object;
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">5/5</td>
-<td class="tally" data-browser="chrome99" data-tally="1">5/5</td>
-<td class="tally" data-browser="chrome100" data-tally="1">5/5</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">5/5</td>
+<td class="tally" data-browser="chrome101" data-tally="1">5/5</td>
+<td class="tally" data-browser="chrome102" data-tally="1">5/5</td>
+<td class="tally" data-browser="chrome103" data-tally="1">5/5</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="1">5/5</td>
@@ -735,15 +733,17 @@ return Intl.constructor === Object;
 <td class="tally" data-browser="safari15_2" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td class="tally unstable" data-browser="webkit" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">5/5</td>
-<td class="tally" data-browser="opera79" data-tally="1">5/5</td>
-<td class="tally" data-browser="opera80" data-tally="1">5/5</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">5/5</td>
+<td class="tally" data-browser="opera87" data-tally="1">5/5</td>
+<td class="tally" data-browser="opera88" data-tally="1">5/5</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/5</td>
@@ -837,11 +837,6 @@ return typeof Intl.Collator === &apos;function&apos;;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -850,9 +845,12 @@ return typeof Intl.Collator === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -872,15 +870,17 @@ return typeof Intl.Collator === &apos;function&apos;;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -974,11 +974,6 @@ return new Intl.Collator() instanceof Intl.Collator;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -987,9 +982,12 @@ return new Intl.Collator() instanceof Intl.Collator;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -1009,15 +1007,17 @@ return new Intl.Collator() instanceof Intl.Collator;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -1111,11 +1111,6 @@ return Intl.Collator() instanceof Intl.Collator;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -1124,9 +1119,12 @@ return Intl.Collator() instanceof Intl.Collator;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -1146,15 +1144,17 @@ return Intl.Collator() instanceof Intl.Collator;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -1270,11 +1270,6 @@ try {
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -1283,9 +1278,12 @@ try {
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -1305,15 +1303,17 @@ try {
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -1424,11 +1424,6 @@ try {
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -1437,9 +1432,12 @@ try {
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -1459,15 +1457,17 @@ try {
 <td class="no" data-browser="safari15_2">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -1558,11 +1558,6 @@ try {
 <td class="tally unstable" data-browser="firefox102" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/1</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">1/1</td>
@@ -1571,9 +1566,12 @@ try {
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">1/1</td>
-<td class="tally" data-browser="chrome99" data-tally="1">1/1</td>
-<td class="tally" data-browser="chrome100" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">1/1</td>
+<td class="tally" data-browser="chrome101" data-tally="1">1/1</td>
+<td class="tally" data-browser="chrome102" data-tally="1">1/1</td>
+<td class="tally" data-browser="chrome103" data-tally="1">1/1</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="1">1/1</td>
@@ -1593,15 +1591,17 @@ try {
 <td class="tally" data-browser="safari15_2" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">1/1</td>
-<td class="tally" data-browser="opera79" data-tally="1">1/1</td>
-<td class="tally" data-browser="opera80" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">1/1</td>
+<td class="tally" data-browser="opera87" data-tally="1">1/1</td>
+<td class="tally" data-browser="opera88" data-tally="1">1/1</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/1</td>
@@ -1695,11 +1695,6 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -1708,9 +1703,12 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -1730,15 +1728,17 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -1829,11 +1829,6 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="tally unstable" data-browser="firefox102" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/1</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">1/1</td>
@@ -1842,9 +1837,12 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">1/1</td>
-<td class="tally" data-browser="chrome99" data-tally="1">1/1</td>
-<td class="tally" data-browser="chrome100" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">1/1</td>
+<td class="tally" data-browser="chrome101" data-tally="1">1/1</td>
+<td class="tally" data-browser="chrome102" data-tally="1">1/1</td>
+<td class="tally" data-browser="chrome103" data-tally="1">1/1</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="1">1/1</td>
@@ -1864,15 +1862,17 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="tally" data-browser="safari15_2" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">1/1</td>
-<td class="tally" data-browser="opera79" data-tally="1">1/1</td>
-<td class="tally" data-browser="opera80" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">1/1</td>
+<td class="tally" data-browser="opera87" data-tally="1">1/1</td>
+<td class="tally" data-browser="opera88" data-tally="1">1/1</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/1</td>
@@ -1966,11 +1966,6 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -1979,9 +1974,12 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -2001,15 +1999,17 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -2100,11 +2100,6 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="tally unstable" data-browser="firefox102" data-tally="1">6/6</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">6/6</td>
@@ -2113,9 +2108,12 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">6/6</td>
-<td class="tally" data-browser="chrome99" data-tally="1">6/6</td>
-<td class="tally" data-browser="chrome100" data-tally="1">6/6</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">6/6</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">6/6</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">6/6</td>
+<td class="tally" data-browser="chrome101" data-tally="1">6/6</td>
+<td class="tally" data-browser="chrome102" data-tally="1">6/6</td>
+<td class="tally" data-browser="chrome103" data-tally="1">6/6</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="1">6/6</td>
@@ -2135,15 +2133,17 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="tally" data-browser="safari15_2" data-tally="1">6/6</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">6/6</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">6/6</td>
-<td class="tally" data-browser="opera79" data-tally="1">6/6</td>
-<td class="tally" data-browser="opera80" data-tally="1">6/6</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">6/6</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">6/6</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">6/6</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">6/6</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">6/6</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">6/6</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">6/6</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">6/6</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">6/6</td>
+<td class="tally" data-browser="opera87" data-tally="1">6/6</td>
+<td class="tally" data-browser="opera88" data-tally="1">6/6</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/6</td>
@@ -2237,11 +2237,6 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -2250,9 +2245,12 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -2272,15 +2270,17 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -2374,11 +2374,6 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -2387,9 +2382,12 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -2409,15 +2407,17 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -2511,11 +2511,6 @@ return new Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -2524,9 +2519,12 @@ return new Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -2546,15 +2544,17 @@ return new Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -2648,11 +2648,6 @@ return Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -2661,9 +2656,12 @@ return Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -2683,15 +2681,17 @@ return Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -2807,11 +2807,6 @@ try {
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -2820,9 +2815,12 @@ try {
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -2842,15 +2840,17 @@ try {
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -2961,11 +2961,6 @@ try {
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -2974,9 +2969,12 @@ try {
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -2996,15 +2994,17 @@ try {
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -3095,11 +3095,6 @@ try {
 <td class="tally unstable" data-browser="firefox102" data-tally="1">7/7</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">7/7</td>
@@ -3108,9 +3103,12 @@ try {
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">7/7</td>
-<td class="tally" data-browser="chrome99" data-tally="1">7/7</td>
-<td class="tally" data-browser="chrome100" data-tally="1">7/7</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">7/7</td>
+<td class="tally" data-browser="chrome101" data-tally="1">7/7</td>
+<td class="tally" data-browser="chrome102" data-tally="1">7/7</td>
+<td class="tally" data-browser="chrome103" data-tally="1">7/7</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="1">7/7</td>
@@ -3130,15 +3128,17 @@ try {
 <td class="tally" data-browser="safari15_2" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
 <td class="tally unstable" data-browser="webkit" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">7/7</td>
-<td class="tally" data-browser="opera79" data-tally="1">7/7</td>
-<td class="tally" data-browser="opera80" data-tally="1">7/7</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">7/7</td>
+<td class="tally" data-browser="opera87" data-tally="1">7/7</td>
+<td class="tally" data-browser="opera88" data-tally="1">7/7</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/7</td>
@@ -3232,11 +3232,6 @@ return typeof Intl.DateTimeFormat === &apos;function&apos;;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -3245,9 +3240,12 @@ return typeof Intl.DateTimeFormat === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -3267,15 +3265,17 @@ return typeof Intl.DateTimeFormat === &apos;function&apos;;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -3369,11 +3369,6 @@ return new Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -3382,9 +3377,12 @@ return new Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -3404,15 +3402,17 @@ return new Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -3506,11 +3506,6 @@ return Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -3519,9 +3514,12 @@ return Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -3541,15 +3539,17 @@ return Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -3665,11 +3665,6 @@ try {
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -3678,9 +3673,12 @@ try {
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -3700,15 +3698,17 @@ try {
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -3819,11 +3819,6 @@ try {
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -3832,9 +3827,12 @@ try {
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -3854,15 +3852,17 @@ try {
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -3957,11 +3957,6 @@ return tz !== void undefined &amp;&amp; tz.length &gt; 0;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -3970,9 +3965,12 @@ return tz !== void undefined &amp;&amp; tz.length &gt; 0;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -3992,15 +3990,17 @@ return tz !== void undefined &amp;&amp; tz.length &gt; 0;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -4102,11 +4102,6 @@ try {
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -4115,9 +4110,12 @@ try {
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -4137,15 +4135,17 @@ try {
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -4236,11 +4236,6 @@ try {
 <td class="tally unstable" data-browser="firefox102" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">1/1</td>
@@ -4249,9 +4244,12 @@ try {
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">1/1</td>
-<td class="tally" data-browser="chrome99" data-tally="1">1/1</td>
-<td class="tally" data-browser="chrome100" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">1/1</td>
+<td class="tally" data-browser="chrome101" data-tally="1">1/1</td>
+<td class="tally" data-browser="chrome102" data-tally="1">1/1</td>
+<td class="tally" data-browser="chrome103" data-tally="1">1/1</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="1">1/1</td>
@@ -4271,15 +4269,17 @@ try {
 <td class="tally" data-browser="safari15_2" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">1/1</td>
-<td class="tally" data-browser="opera79" data-tally="1">1/1</td>
-<td class="tally" data-browser="opera80" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">1/1</td>
+<td class="tally" data-browser="opera87" data-tally="1">1/1</td>
+<td class="tally" data-browser="opera88" data-tally="1">1/1</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="1">1/1</td>
@@ -4373,11 +4373,6 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -4386,9 +4381,12 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -4408,15 +4406,17 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
@@ -4507,11 +4507,6 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="tally unstable" data-browser="firefox102" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">1/1</td>
@@ -4520,9 +4515,12 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">1/1</td>
-<td class="tally" data-browser="chrome99" data-tally="1">1/1</td>
-<td class="tally" data-browser="chrome100" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">1/1</td>
+<td class="tally" data-browser="chrome101" data-tally="1">1/1</td>
+<td class="tally" data-browser="chrome102" data-tally="1">1/1</td>
+<td class="tally" data-browser="chrome103" data-tally="1">1/1</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="1">1/1</td>
@@ -4542,15 +4540,17 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="tally" data-browser="safari15_2" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">1/1</td>
-<td class="tally" data-browser="opera79" data-tally="1">1/1</td>
-<td class="tally" data-browser="opera80" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">1/1</td>
+<td class="tally" data-browser="opera87" data-tally="1">1/1</td>
+<td class="tally" data-browser="opera88" data-tally="1">1/1</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="1">1/1</td>
@@ -4644,11 +4644,6 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -4657,9 +4652,12 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -4679,15 +4677,17 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
@@ -4778,11 +4778,6 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally unstable" data-browser="firefox102" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">1/1</td>
@@ -4791,9 +4786,12 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">1/1</td>
-<td class="tally" data-browser="chrome99" data-tally="1">1/1</td>
-<td class="tally" data-browser="chrome100" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">1/1</td>
+<td class="tally" data-browser="chrome101" data-tally="1">1/1</td>
+<td class="tally" data-browser="chrome102" data-tally="1">1/1</td>
+<td class="tally" data-browser="chrome103" data-tally="1">1/1</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="1">1/1</td>
@@ -4813,15 +4811,17 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally" data-browser="safari15_2" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">1/1</td>
-<td class="tally" data-browser="opera79" data-tally="1">1/1</td>
-<td class="tally" data-browser="opera80" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">1/1</td>
+<td class="tally" data-browser="opera87" data-tally="1">1/1</td>
+<td class="tally" data-browser="opera88" data-tally="1">1/1</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="1">1/1</td>
@@ -4915,11 +4915,6 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -4928,9 +4923,12 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -4950,15 +4948,17 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
@@ -5049,11 +5049,6 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally unstable" data-browser="firefox102" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">1/1</td>
@@ -5062,9 +5057,12 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">1/1</td>
-<td class="tally" data-browser="chrome99" data-tally="1">1/1</td>
-<td class="tally" data-browser="chrome100" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">1/1</td>
+<td class="tally" data-browser="chrome101" data-tally="1">1/1</td>
+<td class="tally" data-browser="chrome102" data-tally="1">1/1</td>
+<td class="tally" data-browser="chrome103" data-tally="1">1/1</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="1">1/1</td>
@@ -5084,15 +5082,17 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally" data-browser="safari15_2" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">1/1</td>
-<td class="tally" data-browser="opera79" data-tally="1">1/1</td>
-<td class="tally" data-browser="opera80" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">1/1</td>
+<td class="tally" data-browser="opera87" data-tally="1">1/1</td>
+<td class="tally" data-browser="opera88" data-tally="1">1/1</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="1">1/1</td>
@@ -5186,11 +5186,6 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -5199,9 +5194,12 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -5221,15 +5219,17 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
@@ -5320,11 +5320,6 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally unstable" data-browser="firefox102" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">1/1</td>
@@ -5333,9 +5328,12 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">1/1</td>
-<td class="tally" data-browser="chrome99" data-tally="1">1/1</td>
-<td class="tally" data-browser="chrome100" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">1/1</td>
+<td class="tally" data-browser="chrome101" data-tally="1">1/1</td>
+<td class="tally" data-browser="chrome102" data-tally="1">1/1</td>
+<td class="tally" data-browser="chrome103" data-tally="1">1/1</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="1">1/1</td>
@@ -5355,15 +5353,17 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally" data-browser="safari15_2" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">1/1</td>
-<td class="tally" data-browser="opera79" data-tally="1">1/1</td>
-<td class="tally" data-browser="opera80" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">1/1</td>
+<td class="tally" data-browser="opera87" data-tally="1">1/1</td>
+<td class="tally" data-browser="opera88" data-tally="1">1/1</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="1">1/1</td>
@@ -5457,11 +5457,6 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -5470,9 +5465,12 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -5492,15 +5490,17 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
@@ -5591,11 +5591,6 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally unstable" data-browser="firefox102" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">1/1</td>
@@ -5604,9 +5599,12 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">1/1</td>
-<td class="tally" data-browser="chrome99" data-tally="1">1/1</td>
-<td class="tally" data-browser="chrome100" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">1/1</td>
+<td class="tally" data-browser="chrome101" data-tally="1">1/1</td>
+<td class="tally" data-browser="chrome102" data-tally="1">1/1</td>
+<td class="tally" data-browser="chrome103" data-tally="1">1/1</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="1">1/1</td>
@@ -5626,15 +5624,17 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally" data-browser="safari15_2" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">1/1</td>
-<td class="tally" data-browser="opera79" data-tally="1">1/1</td>
-<td class="tally" data-browser="opera80" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">1/1</td>
+<td class="tally" data-browser="opera87" data-tally="1">1/1</td>
+<td class="tally" data-browser="opera88" data-tally="1">1/1</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="1">1/1</td>
@@ -5728,11 +5728,6 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -5741,9 +5736,12 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -5763,15 +5761,17 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
@@ -5862,11 +5862,6 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="tally unstable" data-browser="firefox102" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">1/1</td>
@@ -5875,9 +5870,12 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">1/1</td>
-<td class="tally" data-browser="chrome99" data-tally="1">1/1</td>
-<td class="tally" data-browser="chrome100" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">1/1</td>
+<td class="tally" data-browser="chrome101" data-tally="1">1/1</td>
+<td class="tally" data-browser="chrome102" data-tally="1">1/1</td>
+<td class="tally" data-browser="chrome103" data-tally="1">1/1</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="1">1/1</td>
@@ -5897,15 +5895,17 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="tally" data-browser="safari15_2" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">1/1</td>
-<td class="tally" data-browser="opera79" data-tally="1">1/1</td>
-<td class="tally" data-browser="opera80" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">1/1</td>
+<td class="tally" data-browser="opera87" data-tally="1">1/1</td>
+<td class="tally" data-browser="opera88" data-tally="1">1/1</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="1">1/1</td>
@@ -5999,11 +5999,6 @@ return typeof Date.prototype.toLocaleTimeString === &apos;function&apos;;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -6012,9 +6007,12 @@ return typeof Date.prototype.toLocaleTimeString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -6034,15 +6032,17 @@ return typeof Date.prototype.toLocaleTimeString === &apos;function&apos;;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>

--- a/esintl/index.html
+++ b/esintl/index.html
@@ -164,7 +164,7 @@
 <th class="platform chrome98 desktop obsolete" data-browser="chrome98"><a href="#chrome98" class="browser-name"><abbr title="Chrome 98">CH 98</abbr></a></th>
 <th class="platform chrome99 desktop obsolete" data-browser="chrome99"><a href="#chrome99" class="browser-name"><abbr title="Chrome 99">CH 99</abbr></a></th>
 <th class="platform chrome100 desktop obsolete" data-browser="chrome100"><a href="#chrome100" class="browser-name"><abbr title="Chrome 100">CH 100</abbr></a></th>
-<th class="platform chrome101 desktop" data-browser="chrome101"><a href="#chrome101" class="browser-name"><abbr title="Chrome 101">CH 101</abbr></a></th>
+<th class="platform chrome101 desktop obsolete" data-browser="chrome101"><a href="#chrome101" class="browser-name"><abbr title="Chrome 101">CH 101</abbr></a></th>
 <th class="platform chrome102 desktop" data-browser="chrome102"><a href="#chrome102" class="browser-name"><abbr title="Chrome 102">CH 102</abbr></a></th>
 <th class="platform chrome103 desktop" data-browser="chrome103"><a href="#chrome103" class="browser-name"><abbr title="Chrome 103">CH 103</abbr></a></th>
 <th class="platform chrome104 desktop unstable" data-browser="chrome104"><a href="#chrome104" class="browser-name"><abbr title="Chrome 104 Beta">CH 104</abbr></a></th>
@@ -302,7 +302,7 @@
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">2/2</td>
-<td class="tally" data-browser="chrome101" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">2/2</td>
 <td class="tally" data-browser="chrome102" data-tally="1">2/2</td>
 <td class="tally" data-browser="chrome103" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">2/2</td>
@@ -439,7 +439,7 @@ return typeof Intl === &apos;object&apos;;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -576,7 +576,7 @@ return Intl.constructor === Object;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -710,7 +710,7 @@ return Intl.constructor === Object;
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">5/5</td>
-<td class="tally" data-browser="chrome101" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">5/5</td>
 <td class="tally" data-browser="chrome102" data-tally="1">5/5</td>
 <td class="tally" data-browser="chrome103" data-tally="1">5/5</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">5/5</td>
@@ -847,7 +847,7 @@ return typeof Intl.Collator === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -984,7 +984,7 @@ return new Intl.Collator() instanceof Intl.Collator;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -1121,7 +1121,7 @@ return Intl.Collator() instanceof Intl.Collator;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -1280,7 +1280,7 @@ try {
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -1434,7 +1434,7 @@ try {
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -1568,7 +1568,7 @@ try {
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">1/1</td>
-<td class="tally" data-browser="chrome101" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">1/1</td>
 <td class="tally" data-browser="chrome102" data-tally="1">1/1</td>
 <td class="tally" data-browser="chrome103" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">1/1</td>
@@ -1705,7 +1705,7 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -1839,7 +1839,7 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">1/1</td>
-<td class="tally" data-browser="chrome101" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">1/1</td>
 <td class="tally" data-browser="chrome102" data-tally="1">1/1</td>
 <td class="tally" data-browser="chrome103" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">1/1</td>
@@ -1976,7 +1976,7 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -2110,7 +2110,7 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">6/6</td>
-<td class="tally" data-browser="chrome101" data-tally="1">6/6</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">6/6</td>
 <td class="tally" data-browser="chrome102" data-tally="1">6/6</td>
 <td class="tally" data-browser="chrome103" data-tally="1">6/6</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">6/6</td>
@@ -2247,7 +2247,7 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -2384,7 +2384,7 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -2521,7 +2521,7 @@ return new Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -2658,7 +2658,7 @@ return Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -2817,7 +2817,7 @@ try {
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -2971,7 +2971,7 @@ try {
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -3105,7 +3105,7 @@ try {
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">7/7</td>
-<td class="tally" data-browser="chrome101" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">7/7</td>
 <td class="tally" data-browser="chrome102" data-tally="1">7/7</td>
 <td class="tally" data-browser="chrome103" data-tally="1">7/7</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">7/7</td>
@@ -3242,7 +3242,7 @@ return typeof Intl.DateTimeFormat === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -3379,7 +3379,7 @@ return new Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -3516,7 +3516,7 @@ return Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -3675,7 +3675,7 @@ try {
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -3829,7 +3829,7 @@ try {
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -3967,7 +3967,7 @@ return tz !== void undefined &amp;&amp; tz.length &gt; 0;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -4112,7 +4112,7 @@ try {
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -4246,7 +4246,7 @@ try {
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">1/1</td>
-<td class="tally" data-browser="chrome101" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">1/1</td>
 <td class="tally" data-browser="chrome102" data-tally="1">1/1</td>
 <td class="tally" data-browser="chrome103" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">1/1</td>
@@ -4383,7 +4383,7 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -4517,7 +4517,7 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">1/1</td>
-<td class="tally" data-browser="chrome101" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">1/1</td>
 <td class="tally" data-browser="chrome102" data-tally="1">1/1</td>
 <td class="tally" data-browser="chrome103" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">1/1</td>
@@ -4654,7 +4654,7 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -4788,7 +4788,7 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">1/1</td>
-<td class="tally" data-browser="chrome101" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">1/1</td>
 <td class="tally" data-browser="chrome102" data-tally="1">1/1</td>
 <td class="tally" data-browser="chrome103" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">1/1</td>
@@ -4925,7 +4925,7 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -5059,7 +5059,7 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">1/1</td>
-<td class="tally" data-browser="chrome101" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">1/1</td>
 <td class="tally" data-browser="chrome102" data-tally="1">1/1</td>
 <td class="tally" data-browser="chrome103" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">1/1</td>
@@ -5196,7 +5196,7 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -5330,7 +5330,7 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">1/1</td>
-<td class="tally" data-browser="chrome101" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">1/1</td>
 <td class="tally" data-browser="chrome102" data-tally="1">1/1</td>
 <td class="tally" data-browser="chrome103" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">1/1</td>
@@ -5467,7 +5467,7 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -5601,7 +5601,7 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">1/1</td>
-<td class="tally" data-browser="chrome101" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">1/1</td>
 <td class="tally" data-browser="chrome102" data-tally="1">1/1</td>
 <td class="tally" data-browser="chrome103" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">1/1</td>
@@ -5738,7 +5738,7 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -5872,7 +5872,7 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">1/1</td>
-<td class="tally" data-browser="chrome101" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">1/1</td>
 <td class="tally" data-browser="chrome102" data-tally="1">1/1</td>
 <td class="tally" data-browser="chrome103" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">1/1</td>
@@ -6009,7 +6009,7 @@ return typeof Date.prototype.toLocaleTimeString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -167,11 +167,6 @@
 <th class="platform firefox102 desktop unstable" data-browser="firefox102"><a href="#firefox102" class="browser-name"><abbr title="Firefox 102 Beta">FF 102</abbr></a></th>
 <th class="platform firefox103 desktop unstable" data-browser="firefox103"><a href="#firefox103" class="browser-name"><abbr title="Firefox 103 Nightly">FF 103</abbr></a></th>
 <th class="platform opera12_10 desktop obsolete" data-browser="opera12_10"><a href="#opera12_10" class="browser-name"><abbr title="Opera 12.10">OP 12.10</abbr></a></th>
-<th class="platform chrome86 desktop obsolete" data-browser="chrome86"><a href="#chrome86" class="browser-name"><abbr title="Chrome 86">CH 86</abbr></a></th>
-<th class="platform chrome87 desktop obsolete" data-browser="chrome87"><a href="#chrome87" class="browser-name"><abbr title="Chrome 87">CH 87</abbr></a></th>
-<th class="platform chrome88 desktop obsolete" data-browser="chrome88"><a href="#chrome88" class="browser-name"><abbr title="Chrome 88">CH 88</abbr></a></th>
-<th class="platform chrome89 desktop obsolete" data-browser="chrome89"><a href="#chrome89" class="browser-name"><abbr title="Chrome 89">CH 89</abbr></a></th>
-<th class="platform chrome90 desktop obsolete" data-browser="chrome90"><a href="#chrome90" class="browser-name"><abbr title="Chrome 90">CH 90</abbr></a></th>
 <th class="platform chrome91 desktop obsolete" data-browser="chrome91"><a href="#chrome91" class="browser-name"><abbr title="Chrome 91">CH 91</abbr></a></th>
 <th class="platform chrome92 desktop obsolete" data-browser="chrome92"><a href="#chrome92" class="browser-name"><abbr title="Chrome 92">CH 92</abbr></a></th>
 <th class="platform chrome93 desktop obsolete" data-browser="chrome93"><a href="#chrome93" class="browser-name"><abbr title="Chrome 93">CH 93</abbr></a></th>
@@ -180,9 +175,12 @@
 <th class="platform chrome96 desktop obsolete" data-browser="chrome96"><a href="#chrome96" class="browser-name"><abbr title="Chrome 96">CH 96</abbr></a></th>
 <th class="platform chrome97 desktop obsolete" data-browser="chrome97"><a href="#chrome97" class="browser-name"><abbr title="Chrome 97">CH 97</abbr></a></th>
 <th class="platform chrome98 desktop obsolete" data-browser="chrome98"><a href="#chrome98" class="browser-name"><abbr title="Chrome 98">CH 98</abbr></a></th>
-<th class="platform chrome99 desktop" data-browser="chrome99"><a href="#chrome99" class="browser-name"><abbr title="Chrome 99">CH 99</abbr></a></th>
-<th class="platform chrome100 desktop" data-browser="chrome100"><a href="#chrome100" class="browser-name"><abbr title="Chrome 100">CH 100</abbr></a></th>
-<th class="platform chrome101 desktop unstable" data-browser="chrome101"><a href="#chrome101" class="browser-name"><abbr title="Chrome 101 Beta">CH 101</abbr></a></th>
+<th class="platform chrome99 desktop obsolete" data-browser="chrome99"><a href="#chrome99" class="browser-name"><abbr title="Chrome 99">CH 99</abbr></a></th>
+<th class="platform chrome100 desktop obsolete" data-browser="chrome100"><a href="#chrome100" class="browser-name"><abbr title="Chrome 100">CH 100</abbr></a></th>
+<th class="platform chrome101 desktop" data-browser="chrome101"><a href="#chrome101" class="browser-name"><abbr title="Chrome 101">CH 101</abbr></a></th>
+<th class="platform chrome102 desktop" data-browser="chrome102"><a href="#chrome102" class="browser-name"><abbr title="Chrome 102">CH 102</abbr></a></th>
+<th class="platform chrome103 desktop" data-browser="chrome103"><a href="#chrome103" class="browser-name"><abbr title="Chrome 103">CH 103</abbr></a></th>
+<th class="platform chrome104 desktop unstable" data-browser="chrome104"><a href="#chrome104" class="browser-name"><abbr title="Chrome 104 Beta">CH 104</abbr></a></th>
 <th class="platform edge18 desktop obsolete" data-browser="edge18"><a href="#edge18" class="browser-name"><abbr title="Microsoft Edge 18">Edge 18</abbr></a></th>
 <th class="platform edge87 desktop obsolete" data-browser="edge87"><a href="#edge87" class="browser-name"><abbr title="Microsoft Edge 87">Edge 87</abbr></a></th>
 <th class="platform edge88 desktop obsolete" data-browser="edge88"><a href="#edge88" class="browser-name"><abbr title="Microsoft Edge 88">Edge 88</abbr></a></th>
@@ -202,15 +200,17 @@
 <th class="platform safari15_2 desktop" data-browser="safari15_2"><a href="#safari15_2" class="browser-name"><abbr title="Safari 15.2">SF&#xA0;15.2</abbr></a></th>
 <th class="platform safaritp desktop unstable" data-browser="safaritp"><a href="#safaritp" class="browser-name"><abbr title="Safari Technology Preview Release 133">SF TP</abbr></a></th>
 <th class="platform webkit desktop unstable" data-browser="webkit"><a href="#webkit" class="browser-name"><abbr title="Webkit Nightly">WK</abbr></a></th>
-<th class="platform opera73 desktop obsolete" data-browser="opera73"><a href="#opera73" class="browser-name"><abbr title="Opera 73">OP 73</abbr></a></th>
-<th class="platform opera74 desktop obsolete" data-browser="opera74"><a href="#opera74" class="browser-name"><abbr title="Opera 74">OP 74</abbr></a></th>
-<th class="platform opera75 desktop obsolete" data-browser="opera75"><a href="#opera75" class="browser-name"><abbr title="Opera 75">OP 75</abbr></a></th>
-<th class="platform opera76 desktop obsolete" data-browser="opera76"><a href="#opera76" class="browser-name"><abbr title="Opera 76">OP 76</abbr></a></th>
-<th class="platform opera77 desktop obsolete" data-browser="opera77"><a href="#opera77" class="browser-name"><abbr title="Opera 77">OP 77</abbr></a></th>
-<th class="platform opera78 desktop obsolete" data-browser="opera78"><a href="#opera78" class="browser-name"><abbr title="Opera 78">OP 78</abbr></a></th>
-<th class="platform opera79 desktop" data-browser="opera79"><a href="#opera79" class="browser-name"><abbr title="Opera 79">OP 79</abbr></a></th>
-<th class="platform opera80 desktop" data-browser="opera80"><a href="#opera80" class="browser-name"><abbr title="Opera 80">OP 80</abbr></a></th>
-<th class="platform opera81 desktop unstable" data-browser="opera81"><a href="#opera81" class="browser-name"><abbr title="Opera 81">OP 81</abbr></a></th>
+<th class="platform opera79 desktop obsolete" data-browser="opera79"><a href="#opera79" class="browser-name"><abbr title="Opera 79">OP 79</abbr></a></th>
+<th class="platform opera80 desktop obsolete" data-browser="opera80"><a href="#opera80" class="browser-name"><abbr title="Opera 80">OP 80</abbr></a></th>
+<th class="platform opera81 desktop obsolete" data-browser="opera81"><a href="#opera81" class="browser-name"><abbr title="Opera 81">OP 82</abbr></a></th>
+<th class="platform opera82 desktop obsolete" data-browser="opera82"><a href="#opera82" class="browser-name"><abbr title="Opera 82">OP 82</abbr></a></th>
+<th class="platform opera83 desktop obsolete" data-browser="opera83"><a href="#opera83" class="browser-name"><abbr title="Opera 83">OP 83</abbr></a></th>
+<th class="platform opera84 desktop obsolete" data-browser="opera84"><a href="#opera84" class="browser-name"><abbr title="Opera 84">OP 84</abbr></a></th>
+<th class="platform opera85 desktop obsolete" data-browser="opera85"><a href="#opera85" class="browser-name"><abbr title="Opera 85">OP 85</abbr></a></th>
+<th class="platform opera86 desktop obsolete" data-browser="opera86"><a href="#opera86" class="browser-name"><abbr title="Opera 86">OP 86</abbr></a></th>
+<th class="platform opera87 desktop" data-browser="opera87"><a href="#opera87" class="browser-name"><abbr title="Opera 87">OP 87</abbr></a></th>
+<th class="platform opera88 desktop" data-browser="opera88"><a href="#opera88" class="browser-name"><abbr title="Opera 88">OP 88</abbr></a></th>
+<th class="platform opera89 desktop unstable" data-browser="opera89"><a href="#opera89" class="browser-name"><abbr title="Opera 89">OP 89</abbr></a></th>
 <th class="platform rhino1_7_13 engine obsolete" data-browser="rhino1_7_13"><a href="#rhino1_7_13" class="browser-name"><abbr title="Rhino 1.7.13">Rhino 1.7.13</abbr></a></th>
 <th class="platform rhino1_7_14 engine obsolete" data-browser="rhino1_7_14"><a href="#rhino1_7_14" class="browser-name"><abbr title="Rhino 1.7.14">Rhino 1.7.14</abbr></a></th>
 <th class="platform phantom2_1 engine obsolete" data-browser="phantom2_1"><a href="#phantom2_1" class="browser-name"><abbr title="PhantomJS 2.1">PJS</abbr></a></th>
@@ -329,11 +329,6 @@ return typeof Realm === &quot;function&quot;
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -342,9 +337,12 @@ return typeof Realm === &quot;function&quot;
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -364,15 +362,17 @@ return typeof Realm === &quot;function&quot;
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -479,11 +479,6 @@ return typeof Realm === &quot;function&quot;
 <td class="tally unstable" data-browser="firefox102" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="1">2/2</td>
@@ -492,9 +487,12 @@ return typeof Realm === &quot;function&quot;
 <td class="tally obsolete" data-browser="chrome96" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">2/2</td>
-<td class="tally" data-browser="chrome99" data-tally="1">2/2</td>
-<td class="tally" data-browser="chrome100" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">2/2</td>
+<td class="tally" data-browser="chrome101" data-tally="1">2/2</td>
+<td class="tally" data-browser="chrome102" data-tally="1">2/2</td>
+<td class="tally" data-browser="chrome103" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="1">2/2</td>
@@ -514,15 +512,17 @@ return typeof Realm === &quot;function&quot;
 <td class="tally" data-browser="safari15_2" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="1">2/2</td>
-<td class="tally" data-browser="opera79" data-tally="1">2/2</td>
-<td class="tally" data-browser="opera80" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="opera81" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">2/2</td>
+<td class="tally" data-browser="opera87" data-tally="1">2/2</td>
+<td class="tally" data-browser="opera88" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="1">2/2</td>
@@ -638,11 +638,6 @@ return RegExp.lastMatch === 'x';
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -651,9 +646,12 @@ return RegExp.lastMatch === 'x';
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -673,15 +671,17 @@ return RegExp.lastMatch === 'x';
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
@@ -799,11 +799,6 @@ return true;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -812,9 +807,12 @@ return true;
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -834,15 +832,17 @@ return true;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
@@ -956,11 +956,6 @@ try {
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -969,9 +964,12 @@ try {
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -991,15 +989,17 @@ try {
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="no obsolete" data-browser="phantom2_1">No</td>
@@ -1106,11 +1106,6 @@ try {
 <td class="tally unstable" data-browser="firefox102" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="0" data-flagged-tally="1">0/2</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="0">0/2</td>
@@ -1119,9 +1114,12 @@ try {
 <td class="tally obsolete" data-browser="chrome96" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">2/2</td>
-<td class="tally" data-browser="chrome99" data-tally="1">2/2</td>
-<td class="tally" data-browser="chrome100" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="1">2/2</td>
+<td class="tally" data-browser="chrome101" data-tally="1">2/2</td>
+<td class="tally" data-browser="chrome102" data-tally="1">2/2</td>
+<td class="tally" data-browser="chrome103" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="0">0/2</td>
@@ -1141,15 +1139,17 @@ try {
 <td class="tally" data-browser="safari15_2" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="0">0/2</td>
-<td class="tally" data-browser="opera79" data-tally="0">0/2</td>
-<td class="tally" data-browser="opera80" data-tally="0">0/2</td>
-<td class="tally unstable" data-browser="opera81" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="1">2/2</td>
+<td class="tally" data-browser="opera87" data-tally="1">2/2</td>
+<td class="tally" data-browser="opera88" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="opera89" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/2</td>
@@ -1260,11 +1260,6 @@ return arr.findLast(function (o) { return o.x === 1; }) === arr[2];
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no flagged unstable" data-browser="firefox103">Flag<a href="#firefox-arrayfindfromlast-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -1273,9 +1268,12 @@ return arr.findLast(function (o) { return o.x === 1; }) === arr[2];
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -1295,15 +1293,17 @@ return arr.findLast(function (o) { return o.x === 1; }) === arr[2];
 <td class="no" data-browser="safari15_2">No</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -1414,11 +1414,6 @@ return arr.findLastIndex(function (o) { return o.x === 1; }) === 2;
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no flagged unstable" data-browser="firefox103">Flag<a href="#firefox-arrayfindfromlast-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -1427,9 +1422,12 @@ return arr.findLastIndex(function (o) { return o.x === 1; }) === 2;
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -1449,15 +1447,17 @@ return arr.findLastIndex(function (o) { return o.x === 1; }) === 2;
 <td class="no" data-browser="safari15_2">No</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -1575,11 +1575,6 @@ return result === &apos;tromple&apos;;
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -1588,9 +1583,12 @@ return result === &apos;tromple&apos;;
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -1610,15 +1608,17 @@ return result === &apos;tromple&apos;;
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -1725,11 +1725,6 @@ return result === &apos;tromple&apos;;
 <td class="tally unstable" data-browser="firefox102" data-tally="0">0/1</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/1</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="0">0/1</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="0">0/1</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="0">0/1</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="0">0/1</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="0">0/1</td>
@@ -1738,9 +1733,12 @@ return result === &apos;tromple&apos;;
 <td class="tally obsolete" data-browser="chrome96" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="0">0/1</td>
-<td class="tally" data-browser="chrome99" data-tally="0">0/1</td>
-<td class="tally" data-browser="chrome100" data-tally="0">0/1</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="0">0/1</td>
+<td class="tally" data-browser="chrome101" data-tally="0">0/1</td>
+<td class="tally" data-browser="chrome102" data-tally="0">0/1</td>
+<td class="tally" data-browser="chrome103" data-tally="0">0/1</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="0">0/1</td>
@@ -1760,15 +1758,17 @@ return result === &apos;tromple&apos;;
 <td class="tally" data-browser="safari15_2" data-tally="0">0/1</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="0">0/1</td>
 <td class="tally unstable" data-browser="webkit" data-tally="0">0/1</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="0">0/1</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="0">0/1</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="0">0/1</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="0">0/1</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="0">0/1</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="0">0/1</td>
-<td class="tally" data-browser="opera79" data-tally="0">0/1</td>
-<td class="tally" data-browser="opera80" data-tally="0">0/1</td>
-<td class="tally unstable" data-browser="opera81" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="0">0/1</td>
+<td class="tally" data-browser="opera87" data-tally="0">0/1</td>
+<td class="tally" data-browser="opera88" data-tally="0">0/1</td>
+<td class="tally unstable" data-browser="opera89" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/1</td>
@@ -1886,11 +1886,6 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -1899,9 +1894,12 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -1921,15 +1919,17 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -2036,11 +2036,6 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="tally unstable" data-browser="firefox102" data-tally="0">0/4</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="0">0/4</td>
@@ -2049,9 +2044,12 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="tally obsolete" data-browser="chrome96" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="0">0/4</td>
-<td class="tally" data-browser="chrome99" data-tally="0">0/4</td>
-<td class="tally" data-browser="chrome100" data-tally="0">0/4</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="0">0/4</td>
+<td class="tally" data-browser="chrome101" data-tally="0">0/4</td>
+<td class="tally" data-browser="chrome102" data-tally="0">0/4</td>
+<td class="tally" data-browser="chrome103" data-tally="0">0/4</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="0">0/4</td>
@@ -2071,15 +2069,17 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="tally" data-browser="safari15_2" data-tally="0">0/4</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="0">0/4</td>
 <td class="tally unstable" data-browser="webkit" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="0">0/4</td>
-<td class="tally" data-browser="opera79" data-tally="0">0/4</td>
-<td class="tally" data-browser="opera80" data-tally="0">0/4</td>
-<td class="tally unstable" data-browser="opera81" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="0">0/4</td>
+<td class="tally" data-browser="opera87" data-tally="0">0/4</td>
+<td class="tally" data-browser="opera88" data-tally="0">0/4</td>
+<td class="tally unstable" data-browser="opera89" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/4</td>
@@ -2195,11 +2195,6 @@ try {
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -2208,9 +2203,12 @@ try {
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -2230,15 +2228,17 @@ try {
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -2358,11 +2358,6 @@ try {
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -2371,9 +2366,12 @@ try {
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -2393,15 +2391,17 @@ try {
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -2516,11 +2516,6 @@ try {
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -2529,9 +2524,12 @@ try {
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -2551,15 +2549,17 @@ try {
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -2674,11 +2674,6 @@ try {
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -2687,9 +2682,12 @@ try {
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -2709,15 +2707,17 @@ try {
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -2824,11 +2824,6 @@ try {
 <td class="tally unstable" data-browser="firefox102" data-tally="0">0/7</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="0">0/7</td>
@@ -2837,9 +2832,12 @@ try {
 <td class="tally obsolete" data-browser="chrome96" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="0">0/7</td>
-<td class="tally" data-browser="chrome99" data-tally="0">0/7</td>
-<td class="tally" data-browser="chrome100" data-tally="0">0/7</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="0">0/7</td>
+<td class="tally" data-browser="chrome101" data-tally="0">0/7</td>
+<td class="tally" data-browser="chrome102" data-tally="0">0/7</td>
+<td class="tally" data-browser="chrome103" data-tally="0">0/7</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="0">0/7</td>
@@ -2859,15 +2857,17 @@ try {
 <td class="tally" data-browser="safari15_2" data-tally="0">0/7</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="0">0/7</td>
 <td class="tally unstable" data-browser="webkit" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="0">0/7</td>
-<td class="tally" data-browser="opera79" data-tally="0">0/7</td>
-<td class="tally" data-browser="opera80" data-tally="0">0/7</td>
-<td class="tally unstable" data-browser="opera81" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="0">0/7</td>
+<td class="tally" data-browser="opera87" data-tally="0">0/7</td>
+<td class="tally" data-browser="opera88" data-tally="0">0/7</td>
+<td class="tally unstable" data-browser="opera89" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/7</td>
@@ -2980,11 +2980,6 @@ return set.size === 2
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -2993,9 +2988,12 @@ return set.size === 2
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -3015,15 +3013,17 @@ return set.size === 2
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -3137,11 +3137,6 @@ return set.size === 3
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -3150,9 +3145,12 @@ return set.size === 3
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -3172,15 +3170,17 @@ return set.size === 3
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -3293,11 +3293,6 @@ return set.size === 2
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -3306,9 +3301,12 @@ return set.size === 2
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -3328,15 +3326,17 @@ return set.size === 2
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -3449,11 +3449,6 @@ return set.size === 2
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -3462,9 +3457,12 @@ return set.size === 2
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -3484,15 +3482,17 @@ return set.size === 2
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -3602,11 +3602,6 @@ return new Set([1, 2, 3]).isDisjointFrom([4, 5, 6]);
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -3615,9 +3610,12 @@ return new Set([1, 2, 3]).isDisjointFrom([4, 5, 6]);
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -3637,15 +3635,17 @@ return new Set([1, 2, 3]).isDisjointFrom([4, 5, 6]);
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -3755,11 +3755,6 @@ return new Set([1, 2, 3]).isSubsetOf([5, 4, 3, 2, 1]);
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -3768,9 +3763,12 @@ return new Set([1, 2, 3]).isSubsetOf([5, 4, 3, 2, 1]);
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -3790,15 +3788,17 @@ return new Set([1, 2, 3]).isSubsetOf([5, 4, 3, 2, 1]);
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -3908,11 +3908,6 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -3921,9 +3916,12 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -3943,15 +3941,17 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -4058,11 +4058,6 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
 <td class="tally unstable" data-browser="firefox102" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="0">0/2</td>
@@ -4071,9 +4066,12 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
 <td class="tally obsolete" data-browser="chrome96" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="0">0/2</td>
-<td class="tally" data-browser="chrome99" data-tally="0">0/2</td>
-<td class="tally" data-browser="chrome100" data-tally="0">0/2</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="0">0/2</td>
+<td class="tally" data-browser="chrome101" data-tally="0">0/2</td>
+<td class="tally" data-browser="chrome102" data-tally="0">0/2</td>
+<td class="tally" data-browser="chrome103" data-tally="0">0/2</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="0">0/2</td>
@@ -4093,15 +4091,17 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
 <td class="tally" data-browser="safari15_2" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="webkit" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="0">0/2</td>
-<td class="tally" data-browser="opera79" data-tally="0">0/2</td>
-<td class="tally" data-browser="opera80" data-tally="0">0/2</td>
-<td class="tally unstable" data-browser="opera81" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="0">0/2</td>
+<td class="tally" data-browser="opera87" data-tally="0">0/2</td>
+<td class="tally" data-browser="opera88" data-tally="0">0/2</td>
+<td class="tally unstable" data-browser="opera89" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/2</td>
@@ -4214,11 +4214,6 @@ return buffer1.byteLength === 0
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -4227,9 +4222,12 @@ return buffer1.byteLength === 0
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -4249,15 +4247,17 @@ return buffer1.byteLength === 0
 <td class="no" data-browser="safari15_2">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -4370,11 +4370,6 @@ return buffer1.byteLength === 0
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -4383,9 +4378,12 @@ return buffer1.byteLength === 0
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -4405,15 +4403,17 @@ return buffer1.byteLength === 0
 <td class="no" data-browser="safari15_2">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -4520,11 +4520,6 @@ return buffer1.byteLength === 0
 <td class="tally unstable" data-browser="firefox102" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="0">0/2</td>
@@ -4533,9 +4528,12 @@ return buffer1.byteLength === 0
 <td class="tally obsolete" data-browser="chrome96" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="0">0/2</td>
-<td class="tally" data-browser="chrome99" data-tally="0">0/2</td>
-<td class="tally" data-browser="chrome100" data-tally="0">0/2</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="0">0/2</td>
+<td class="tally" data-browser="chrome101" data-tally="0">0/2</td>
+<td class="tally" data-browser="chrome102" data-tally="0">0/2</td>
+<td class="tally" data-browser="chrome103" data-tally="0">0/2</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="0">0/2</td>
@@ -4555,15 +4553,17 @@ return buffer1.byteLength === 0
 <td class="tally" data-browser="safari15_2" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="webkit" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="0">0/2</td>
-<td class="tally" data-browser="opera79" data-tally="0">0/2</td>
-<td class="tally" data-browser="opera80" data-tally="0">0/2</td>
-<td class="tally unstable" data-browser="opera81" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="0">0/2</td>
+<td class="tally" data-browser="opera87" data-tally="0">0/2</td>
+<td class="tally" data-browser="opera88" data-tally="0">0/2</td>
+<td class="tally unstable" data-browser="opera89" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/2</td>
@@ -4676,11 +4676,6 @@ return Array.from(map).join() === &apos;a,2,b,3&apos;;
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -4689,9 +4684,12 @@ return Array.from(map).join() === &apos;a,2,b,3&apos;;
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -4711,15 +4709,17 @@ return Array.from(map).join() === &apos;a,2,b,3&apos;;
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -4833,11 +4833,6 @@ return map.get(a) === 2 &amp;&amp; map.get(b) === 3;
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -4846,9 +4841,12 @@ return map.get(a) === 2 &amp;&amp; map.get(b) === 3;
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -4868,15 +4866,17 @@ return map.get(a) === 2 &amp;&amp; map.get(b) === 3;
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -4987,11 +4987,6 @@ return !Array.isTemplateObject([])
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -5000,9 +4995,12 @@ return !Array.isTemplateObject([])
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -5022,15 +5020,17 @@ return !Array.isTemplateObject([])
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -5137,11 +5137,6 @@ return !Array.isTemplateObject([])
 <td class="tally unstable" data-browser="firefox102" data-tally="0">0/35</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="0">0/35</td>
@@ -5150,9 +5145,12 @@ return !Array.isTemplateObject([])
 <td class="tally obsolete" data-browser="chrome96" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="0">0/35</td>
-<td class="tally" data-browser="chrome99" data-tally="0">0/35</td>
-<td class="tally" data-browser="chrome100" data-tally="0">0/35</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="0">0/35</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="0">0/35</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="0">0/35</td>
+<td class="tally" data-browser="chrome101" data-tally="0">0/35</td>
+<td class="tally" data-browser="chrome102" data-tally="0">0/35</td>
+<td class="tally" data-browser="chrome103" data-tally="0">0/35</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="0">0/35</td>
@@ -5172,15 +5170,17 @@ return !Array.isTemplateObject([])
 <td class="tally" data-browser="safari15_2" data-tally="0">0/35</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="0">0/35</td>
 <td class="tally unstable" data-browser="webkit" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="0">0/35</td>
-<td class="tally" data-browser="opera79" data-tally="0">0/35</td>
-<td class="tally" data-browser="opera80" data-tally="0">0/35</td>
-<td class="tally unstable" data-browser="opera81" data-tally="0">0/35</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="0">0/35</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="0">0/35</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="0">0/35</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="0">0/35</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="0">0/35</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="0">0/35</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="0">0/35</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="0">0/35</td>
+<td class="tally" data-browser="opera87" data-tally="0">0/35</td>
+<td class="tally" data-browser="opera88" data-tally="0">0/35</td>
+<td class="tally unstable" data-browser="opera89" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/35</td>
@@ -5290,11 +5290,6 @@ return [1, 2, 3].values() instanceof Iterator;
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -5303,9 +5298,12 @@ return [1, 2, 3].values() instanceof Iterator;
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -5325,15 +5323,17 @@ return [1, 2, 3].values() instanceof Iterator;
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -5445,11 +5445,6 @@ return instance[Symbol.iterator]() === instance;
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -5458,9 +5453,12 @@ return instance[Symbol.iterator]() === instance;
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -5480,15 +5478,17 @@ return instance[Symbol.iterator]() === instance;
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -5601,11 +5601,6 @@ return &apos;next&apos; in iterator
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -5614,9 +5609,12 @@ return &apos;next&apos; in iterator
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -5636,15 +5634,17 @@ return &apos;next&apos; in iterator
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -5762,11 +5762,6 @@ return &apos;next&apos; in iterator
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -5775,9 +5770,12 @@ return &apos;next&apos; in iterator
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -5797,15 +5795,17 @@ return &apos;next&apos; in iterator
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -5915,11 +5915,6 @@ return Array.from([1, 2, 3].values().asIndexedPairs()).join() === &apos;0,1,1,2,
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -5928,9 +5923,12 @@ return Array.from([1, 2, 3].values().asIndexedPairs()).join() === &apos;0,1,1,2,
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -5950,15 +5948,17 @@ return Array.from([1, 2, 3].values().asIndexedPairs()).join() === &apos;0,1,1,2,
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -6068,11 +6068,6 @@ return Array.from([1, 2, 3].values().drop(1)).join() === &apos;2,3&apos;;
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -6081,9 +6076,12 @@ return Array.from([1, 2, 3].values().drop(1)).join() === &apos;2,3&apos;;
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -6103,15 +6101,17 @@ return Array.from([1, 2, 3].values().drop(1)).join() === &apos;2,3&apos;;
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -6221,11 +6221,6 @@ return [1, 2, 3].values().every(it =&gt; typeof it === &apos;number&apos;);
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -6234,9 +6229,12 @@ return [1, 2, 3].values().every(it =&gt; typeof it === &apos;number&apos;);
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -6256,15 +6254,17 @@ return [1, 2, 3].values().every(it =&gt; typeof it === &apos;number&apos;);
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -6374,11 +6374,6 @@ return Array.from([1, 2, 3].values().filter(it =&gt; it % 2)).join() === &apos;1
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -6387,9 +6382,12 @@ return Array.from([1, 2, 3].values().filter(it =&gt; it % 2)).join() === &apos;1
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -6409,15 +6407,17 @@ return Array.from([1, 2, 3].values().filter(it =&gt; it % 2)).join() === &apos;1
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -6527,11 +6527,6 @@ return [1, 2, 3].values().find(it =&gt; it % 2) === 1;
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -6540,9 +6535,12 @@ return [1, 2, 3].values().find(it =&gt; it % 2) === 1;
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -6562,15 +6560,17 @@ return [1, 2, 3].values().find(it =&gt; it % 2) === 1;
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -6680,11 +6680,6 @@ return Array.from([1, 2, 3].values().flatMap(it =&gt; [it, 0])).join() === &apos
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -6693,9 +6688,12 @@ return Array.from([1, 2, 3].values().flatMap(it =&gt; [it, 0])).join() === &apos
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -6715,15 +6713,17 @@ return Array.from([1, 2, 3].values().flatMap(it =&gt; [it, 0])).join() === &apos
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -6835,11 +6835,6 @@ return result === &apos;123&apos;;
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -6848,9 +6843,12 @@ return result === &apos;123&apos;;
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -6870,15 +6868,17 @@ return result === &apos;123&apos;;
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -6988,11 +6988,6 @@ return Array.from([1, 2, 3].values().map(it =&gt; it * it)).join() === &apos;1,4
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -7001,9 +6996,12 @@ return Array.from([1, 2, 3].values().map(it =&gt; it * it)).join() === &apos;1,4
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -7023,15 +7021,17 @@ return Array.from([1, 2, 3].values().map(it =&gt; it * it)).join() === &apos;1,4
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -7141,11 +7141,6 @@ return [1, 2, 3].values().reduce((a, b) =&gt; a + b) === 6;
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -7154,9 +7149,12 @@ return [1, 2, 3].values().reduce((a, b) =&gt; a + b) === 6;
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -7176,15 +7174,17 @@ return [1, 2, 3].values().reduce((a, b) =&gt; a + b) === 6;
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -7294,11 +7294,6 @@ return [1, 2, 3].values().some(it =&gt; typeof it === &apos;number&apos;);
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -7307,9 +7302,12 @@ return [1, 2, 3].values().some(it =&gt; typeof it === &apos;number&apos;);
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -7329,15 +7327,17 @@ return [1, 2, 3].values().some(it =&gt; typeof it === &apos;number&apos;);
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -7447,11 +7447,6 @@ return Array.from([1, 2, 3].values().take(2)).join() === &apos;1,2&apos;;
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -7460,9 +7455,12 @@ return Array.from([1, 2, 3].values().take(2)).join() === &apos;1,2&apos;;
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -7482,15 +7480,17 @@ return Array.from([1, 2, 3].values().take(2)).join() === &apos;1,2&apos;;
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -7601,11 +7601,6 @@ return Array.isArray(array) &amp;&amp; array.join() === &apos;1,2,3&apos;;
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -7614,9 +7609,12 @@ return Array.isArray(array) &amp;&amp; array.join() === &apos;1,2,3&apos;;
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -7636,15 +7634,17 @@ return Array.isArray(array) &amp;&amp; array.join() === &apos;1,2,3&apos;;
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -7754,11 +7754,6 @@ return Iterator.prototype[Symbol.toStringTag] === &apos;Iterator&apos;;
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -7767,9 +7762,12 @@ return Iterator.prototype[Symbol.toStringTag] === &apos;Iterator&apos;;
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -7789,15 +7787,17 @@ return Iterator.prototype[Symbol.toStringTag] === &apos;Iterator&apos;;
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -7907,11 +7907,6 @@ return (async function*() {})() instanceof AsyncIterator;
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -7920,9 +7915,12 @@ return (async function*() {})() instanceof AsyncIterator;
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -7942,15 +7940,17 @@ return (async function*() {})() instanceof AsyncIterator;
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -8062,11 +8062,6 @@ return instance[Symbol.asyncIterator]() === instance;
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -8075,9 +8070,12 @@ return instance[Symbol.asyncIterator]() === instance;
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -8097,15 +8095,17 @@ return instance[Symbol.asyncIterator]() === instance;
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -8227,11 +8227,6 @@ toArray(iterator).then(it =&gt; {
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -8240,9 +8235,12 @@ toArray(iterator).then(it =&gt; {
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -8262,15 +8260,17 @@ toArray(iterator).then(it =&gt; {
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -8392,11 +8392,6 @@ toArray(iterator).then(it =&gt; {
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -8405,9 +8400,12 @@ toArray(iterator).then(it =&gt; {
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -8427,15 +8425,17 @@ toArray(iterator).then(it =&gt; {
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -8557,11 +8557,6 @@ toArray(iterator).then(it =&gt; {
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -8570,9 +8565,12 @@ toArray(iterator).then(it =&gt; {
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -8592,15 +8590,17 @@ toArray(iterator).then(it =&gt; {
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -8718,11 +8718,6 @@ toArray((async function*() { yield * [1, 2, 3] })().asIndexedPairs()).then(it =&
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -8731,9 +8726,12 @@ toArray((async function*() { yield * [1, 2, 3] })().asIndexedPairs()).then(it =&
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -8753,15 +8751,17 @@ toArray((async function*() { yield * [1, 2, 3] })().asIndexedPairs()).then(it =&
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -8879,11 +8879,6 @@ toArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it =&gt; {
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -8892,9 +8887,12 @@ toArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it =&gt; {
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -8914,15 +8912,17 @@ toArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it =&gt; {
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -9034,11 +9034,6 @@ toArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it =&gt; {
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -9047,9 +9042,12 @@ toArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it =&gt; {
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -9069,15 +9067,17 @@ toArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it =&gt; {
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -9195,11 +9195,6 @@ toArray(async function*() { yield * [1, 2, 3] }().filter(it =&gt; it % 2)).then(
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -9208,9 +9203,12 @@ toArray(async function*() { yield * [1, 2, 3] }().filter(it =&gt; it % 2)).then(
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -9230,15 +9228,17 @@ toArray(async function*() { yield * [1, 2, 3] }().filter(it =&gt; it % 2)).then(
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -9350,11 +9350,6 @@ toArray(async function*() { yield * [1, 2, 3] }().filter(it =&gt; it % 2)).then(
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -9363,9 +9358,12 @@ toArray(async function*() { yield * [1, 2, 3] }().filter(it =&gt; it % 2)).then(
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -9385,15 +9383,17 @@ toArray(async function*() { yield * [1, 2, 3] }().filter(it =&gt; it % 2)).then(
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -9511,11 +9511,6 @@ toArray(async function*() { yield * [1, 2, 3] }().flatMap(it =&gt; [it, 0])).the
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -9524,9 +9519,12 @@ toArray(async function*() { yield * [1, 2, 3] }().flatMap(it =&gt; [it, 0])).the
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -9546,15 +9544,17 @@ toArray(async function*() { yield * [1, 2, 3] }().flatMap(it =&gt; [it, 0])).the
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -9667,11 +9667,6 @@ let result = &apos;&apos;;
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -9680,9 +9675,12 @@ let result = &apos;&apos;;
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -9702,15 +9700,17 @@ let result = &apos;&apos;;
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -9828,11 +9828,6 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -9841,9 +9836,12 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -9863,15 +9861,17 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -9983,11 +9983,6 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -9996,9 +9991,12 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -10018,15 +10016,17 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -10138,11 +10138,6 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -10151,9 +10146,12 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -10173,15 +10171,17 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -10299,11 +10299,6 @@ toArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it =&gt; {
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -10312,9 +10307,12 @@ toArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it =&gt; {
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -10334,15 +10332,17 @@ toArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it =&gt; {
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -10454,11 +10454,6 @@ toArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it =&gt; {
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -10467,9 +10462,12 @@ toArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it =&gt; {
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -10489,15 +10487,17 @@ toArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it =&gt; {
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
@@ -10607,11 +10607,6 @@ return AsyncIterator.prototype[Symbol.toStringTag] === &apos;AsyncIterator&apos;
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -10620,9 +10615,12 @@ return AsyncIterator.prototype[Symbol.toStringTag] === &apos;AsyncIterator&apos;
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -10642,15 +10640,17 @@ return AsyncIterator.prototype[Symbol.toStringTag] === &apos;AsyncIterator&apos;
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -177,7 +177,7 @@
 <th class="platform chrome98 desktop obsolete" data-browser="chrome98"><a href="#chrome98" class="browser-name"><abbr title="Chrome 98">CH 98</abbr></a></th>
 <th class="platform chrome99 desktop obsolete" data-browser="chrome99"><a href="#chrome99" class="browser-name"><abbr title="Chrome 99">CH 99</abbr></a></th>
 <th class="platform chrome100 desktop obsolete" data-browser="chrome100"><a href="#chrome100" class="browser-name"><abbr title="Chrome 100">CH 100</abbr></a></th>
-<th class="platform chrome101 desktop" data-browser="chrome101"><a href="#chrome101" class="browser-name"><abbr title="Chrome 101">CH 101</abbr></a></th>
+<th class="platform chrome101 desktop obsolete" data-browser="chrome101"><a href="#chrome101" class="browser-name"><abbr title="Chrome 101">CH 101</abbr></a></th>
 <th class="platform chrome102 desktop" data-browser="chrome102"><a href="#chrome102" class="browser-name"><abbr title="Chrome 102">CH 102</abbr></a></th>
 <th class="platform chrome103 desktop" data-browser="chrome103"><a href="#chrome103" class="browser-name"><abbr title="Chrome 103">CH 103</abbr></a></th>
 <th class="platform chrome104 desktop unstable" data-browser="chrome104"><a href="#chrome104" class="browser-name"><abbr title="Chrome 104 Beta">CH 104</abbr></a></th>
@@ -339,7 +339,7 @@ return typeof Realm === &quot;function&quot;
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -489,7 +489,7 @@ return typeof Realm === &quot;function&quot;
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">2/2</td>
-<td class="tally" data-browser="chrome101" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">2/2</td>
 <td class="tally" data-browser="chrome102" data-tally="1">2/2</td>
 <td class="tally" data-browser="chrome103" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">2/2</td>
@@ -648,7 +648,7 @@ return RegExp.lastMatch === 'x';
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -809,7 +809,7 @@ return true;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -966,7 +966,7 @@ try {
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -1116,7 +1116,7 @@ try {
 <td class="tally obsolete" data-browser="chrome98" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="1">2/2</td>
-<td class="tally" data-browser="chrome101" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="1">2/2</td>
 <td class="tally" data-browser="chrome102" data-tally="1">2/2</td>
 <td class="tally" data-browser="chrome103" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="1">2/2</td>
@@ -1270,7 +1270,7 @@ return arr.findLast(function (o) { return o.x === 1; }) === arr[2];
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -1424,7 +1424,7 @@ return arr.findLastIndex(function (o) { return o.x === 1; }) === 2;
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -1585,7 +1585,7 @@ return result === &apos;tromple&apos;;
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -1735,7 +1735,7 @@ return result === &apos;tromple&apos;;
 <td class="tally obsolete" data-browser="chrome98" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="0">0/1</td>
-<td class="tally" data-browser="chrome101" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="0">0/1</td>
 <td class="tally" data-browser="chrome102" data-tally="0">0/1</td>
 <td class="tally" data-browser="chrome103" data-tally="0">0/1</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="0">0/1</td>
@@ -1896,7 +1896,7 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -2046,7 +2046,7 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="tally obsolete" data-browser="chrome98" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="0">0/4</td>
-<td class="tally" data-browser="chrome101" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="0">0/4</td>
 <td class="tally" data-browser="chrome102" data-tally="0">0/4</td>
 <td class="tally" data-browser="chrome103" data-tally="0">0/4</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="0">0/4</td>
@@ -2205,7 +2205,7 @@ try {
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -2368,7 +2368,7 @@ try {
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -2526,7 +2526,7 @@ try {
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -2684,7 +2684,7 @@ try {
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -2834,7 +2834,7 @@ try {
 <td class="tally obsolete" data-browser="chrome98" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="0">0/7</td>
-<td class="tally" data-browser="chrome101" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="0">0/7</td>
 <td class="tally" data-browser="chrome102" data-tally="0">0/7</td>
 <td class="tally" data-browser="chrome103" data-tally="0">0/7</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="0">0/7</td>
@@ -2990,7 +2990,7 @@ return set.size === 2
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -3147,7 +3147,7 @@ return set.size === 3
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -3303,7 +3303,7 @@ return set.size === 2
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -3459,7 +3459,7 @@ return set.size === 2
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -3612,7 +3612,7 @@ return new Set([1, 2, 3]).isDisjointFrom([4, 5, 6]);
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -3765,7 +3765,7 @@ return new Set([1, 2, 3]).isSubsetOf([5, 4, 3, 2, 1]);
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -3918,7 +3918,7 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -4068,7 +4068,7 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
 <td class="tally obsolete" data-browser="chrome98" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="0">0/2</td>
-<td class="tally" data-browser="chrome101" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="0">0/2</td>
 <td class="tally" data-browser="chrome102" data-tally="0">0/2</td>
 <td class="tally" data-browser="chrome103" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="0">0/2</td>
@@ -4224,7 +4224,7 @@ return buffer1.byteLength === 0
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -4380,7 +4380,7 @@ return buffer1.byteLength === 0
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -4530,7 +4530,7 @@ return buffer1.byteLength === 0
 <td class="tally obsolete" data-browser="chrome98" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="0">0/2</td>
-<td class="tally" data-browser="chrome101" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="0">0/2</td>
 <td class="tally" data-browser="chrome102" data-tally="0">0/2</td>
 <td class="tally" data-browser="chrome103" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="0">0/2</td>
@@ -4686,7 +4686,7 @@ return Array.from(map).join() === &apos;a,2,b,3&apos;;
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -4843,7 +4843,7 @@ return map.get(a) === 2 &amp;&amp; map.get(b) === 3;
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -4997,7 +4997,7 @@ return !Array.isTemplateObject([])
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -5147,7 +5147,7 @@ return !Array.isTemplateObject([])
 <td class="tally obsolete" data-browser="chrome98" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="0">0/35</td>
-<td class="tally" data-browser="chrome101" data-tally="0">0/35</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="0">0/35</td>
 <td class="tally" data-browser="chrome102" data-tally="0">0/35</td>
 <td class="tally" data-browser="chrome103" data-tally="0">0/35</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="0">0/35</td>
@@ -5300,7 +5300,7 @@ return [1, 2, 3].values() instanceof Iterator;
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -5455,7 +5455,7 @@ return instance[Symbol.iterator]() === instance;
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -5611,7 +5611,7 @@ return &apos;next&apos; in iterator
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -5772,7 +5772,7 @@ return &apos;next&apos; in iterator
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -5925,7 +5925,7 @@ return Array.from([1, 2, 3].values().asIndexedPairs()).join() === &apos;0,1,1,2,
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -6078,7 +6078,7 @@ return Array.from([1, 2, 3].values().drop(1)).join() === &apos;2,3&apos;;
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -6231,7 +6231,7 @@ return [1, 2, 3].values().every(it =&gt; typeof it === &apos;number&apos;);
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -6384,7 +6384,7 @@ return Array.from([1, 2, 3].values().filter(it =&gt; it % 2)).join() === &apos;1
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -6537,7 +6537,7 @@ return [1, 2, 3].values().find(it =&gt; it % 2) === 1;
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -6690,7 +6690,7 @@ return Array.from([1, 2, 3].values().flatMap(it =&gt; [it, 0])).join() === &apos
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -6845,7 +6845,7 @@ return result === &apos;123&apos;;
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -6998,7 +6998,7 @@ return Array.from([1, 2, 3].values().map(it =&gt; it * it)).join() === &apos;1,4
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -7151,7 +7151,7 @@ return [1, 2, 3].values().reduce((a, b) =&gt; a + b) === 6;
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -7304,7 +7304,7 @@ return [1, 2, 3].values().some(it =&gt; typeof it === &apos;number&apos;);
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -7457,7 +7457,7 @@ return Array.from([1, 2, 3].values().take(2)).join() === &apos;1,2&apos;;
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -7611,7 +7611,7 @@ return Array.isArray(array) &amp;&amp; array.join() === &apos;1,2,3&apos;;
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -7764,7 +7764,7 @@ return Iterator.prototype[Symbol.toStringTag] === &apos;Iterator&apos;;
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -7917,7 +7917,7 @@ return (async function*() {})() instanceof AsyncIterator;
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -8072,7 +8072,7 @@ return instance[Symbol.asyncIterator]() === instance;
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -8237,7 +8237,7 @@ toArray(iterator).then(it =&gt; {
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -8402,7 +8402,7 @@ toArray(iterator).then(it =&gt; {
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -8567,7 +8567,7 @@ toArray(iterator).then(it =&gt; {
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -8728,7 +8728,7 @@ toArray((async function*() { yield * [1, 2, 3] })().asIndexedPairs()).then(it =&
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -8889,7 +8889,7 @@ toArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it =&gt; {
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -9044,7 +9044,7 @@ toArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it =&gt; {
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -9205,7 +9205,7 @@ toArray(async function*() { yield * [1, 2, 3] }().filter(it =&gt; it % 2)).then(
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -9360,7 +9360,7 @@ toArray(async function*() { yield * [1, 2, 3] }().filter(it =&gt; it % 2)).then(
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -9521,7 +9521,7 @@ toArray(async function*() { yield * [1, 2, 3] }().flatMap(it =&gt; [it, 0])).the
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -9677,7 +9677,7 @@ let result = &apos;&apos;;
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -9838,7 +9838,7 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -9993,7 +9993,7 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -10148,7 +10148,7 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -10309,7 +10309,7 @@ toArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it =&gt; {
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -10464,7 +10464,7 @@ toArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it =&gt; {
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -10617,7 +10617,7 @@ return AsyncIterator.prototype[Symbol.toStringTag] === &apos;AsyncIterator&apos;
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -139,11 +139,6 @@
 <th class="platform firefox102 desktop unstable" data-browser="firefox102"><a href="#firefox102" class="browser-name"><abbr title="Firefox 102 Beta">FF 102</abbr></a></th>
 <th class="platform firefox103 desktop unstable" data-browser="firefox103"><a href="#firefox103" class="browser-name"><abbr title="Firefox 103 Nightly">FF 103</abbr></a></th>
 <th class="platform opera12_10 desktop obsolete" data-browser="opera12_10"><a href="#opera12_10" class="browser-name"><abbr title="Opera 12.10">OP 12.10</abbr></a></th>
-<th class="platform chrome86 desktop obsolete" data-browser="chrome86"><a href="#chrome86" class="browser-name"><abbr title="Chrome 86">CH 86</abbr></a></th>
-<th class="platform chrome87 desktop obsolete" data-browser="chrome87"><a href="#chrome87" class="browser-name"><abbr title="Chrome 87">CH 87</abbr></a></th>
-<th class="platform chrome88 desktop obsolete" data-browser="chrome88"><a href="#chrome88" class="browser-name"><abbr title="Chrome 88">CH 88</abbr></a></th>
-<th class="platform chrome89 desktop obsolete" data-browser="chrome89"><a href="#chrome89" class="browser-name"><abbr title="Chrome 89">CH 89</abbr></a></th>
-<th class="platform chrome90 desktop obsolete" data-browser="chrome90"><a href="#chrome90" class="browser-name"><abbr title="Chrome 90">CH 90</abbr></a></th>
 <th class="platform chrome91 desktop obsolete" data-browser="chrome91"><a href="#chrome91" class="browser-name"><abbr title="Chrome 91">CH 91</abbr></a></th>
 <th class="platform chrome92 desktop obsolete" data-browser="chrome92"><a href="#chrome92" class="browser-name"><abbr title="Chrome 92">CH 92</abbr></a></th>
 <th class="platform chrome93 desktop obsolete" data-browser="chrome93"><a href="#chrome93" class="browser-name"><abbr title="Chrome 93">CH 93</abbr></a></th>
@@ -152,9 +147,12 @@
 <th class="platform chrome96 desktop obsolete" data-browser="chrome96"><a href="#chrome96" class="browser-name"><abbr title="Chrome 96">CH 96</abbr></a></th>
 <th class="platform chrome97 desktop obsolete" data-browser="chrome97"><a href="#chrome97" class="browser-name"><abbr title="Chrome 97">CH 97</abbr></a></th>
 <th class="platform chrome98 desktop obsolete" data-browser="chrome98"><a href="#chrome98" class="browser-name"><abbr title="Chrome 98">CH 98</abbr></a></th>
-<th class="platform chrome99 desktop" data-browser="chrome99"><a href="#chrome99" class="browser-name"><abbr title="Chrome 99">CH 99</abbr></a></th>
-<th class="platform chrome100 desktop" data-browser="chrome100"><a href="#chrome100" class="browser-name"><abbr title="Chrome 100">CH 100</abbr></a></th>
-<th class="platform chrome101 desktop unstable" data-browser="chrome101"><a href="#chrome101" class="browser-name"><abbr title="Chrome 101 Beta">CH 101</abbr></a></th>
+<th class="platform chrome99 desktop obsolete" data-browser="chrome99"><a href="#chrome99" class="browser-name"><abbr title="Chrome 99">CH 99</abbr></a></th>
+<th class="platform chrome100 desktop obsolete" data-browser="chrome100"><a href="#chrome100" class="browser-name"><abbr title="Chrome 100">CH 100</abbr></a></th>
+<th class="platform chrome101 desktop" data-browser="chrome101"><a href="#chrome101" class="browser-name"><abbr title="Chrome 101">CH 101</abbr></a></th>
+<th class="platform chrome102 desktop" data-browser="chrome102"><a href="#chrome102" class="browser-name"><abbr title="Chrome 102">CH 102</abbr></a></th>
+<th class="platform chrome103 desktop" data-browser="chrome103"><a href="#chrome103" class="browser-name"><abbr title="Chrome 103">CH 103</abbr></a></th>
+<th class="platform chrome104 desktop unstable" data-browser="chrome104"><a href="#chrome104" class="browser-name"><abbr title="Chrome 104 Beta">CH 104</abbr></a></th>
 <th class="platform edge18 desktop obsolete" data-browser="edge18"><a href="#edge18" class="browser-name"><abbr title="Microsoft Edge 18">Edge 18</abbr></a></th>
 <th class="platform edge87 desktop obsolete" data-browser="edge87"><a href="#edge87" class="browser-name"><abbr title="Microsoft Edge 87">Edge 87</abbr></a></th>
 <th class="platform edge88 desktop obsolete" data-browser="edge88"><a href="#edge88" class="browser-name"><abbr title="Microsoft Edge 88">Edge 88</abbr></a></th>
@@ -174,15 +172,17 @@
 <th class="platform safari15_2 desktop" data-browser="safari15_2"><a href="#safari15_2" class="browser-name"><abbr title="Safari 15.2">SF&#xA0;15.2</abbr></a></th>
 <th class="platform safaritp desktop unstable" data-browser="safaritp"><a href="#safaritp" class="browser-name"><abbr title="Safari Technology Preview Release 133">SF TP</abbr></a></th>
 <th class="platform webkit desktop unstable" data-browser="webkit"><a href="#webkit" class="browser-name"><abbr title="Webkit Nightly">WK</abbr></a></th>
-<th class="platform opera73 desktop obsolete" data-browser="opera73"><a href="#opera73" class="browser-name"><abbr title="Opera 73">OP 73</abbr></a></th>
-<th class="platform opera74 desktop obsolete" data-browser="opera74"><a href="#opera74" class="browser-name"><abbr title="Opera 74">OP 74</abbr></a></th>
-<th class="platform opera75 desktop obsolete" data-browser="opera75"><a href="#opera75" class="browser-name"><abbr title="Opera 75">OP 75</abbr></a></th>
-<th class="platform opera76 desktop obsolete" data-browser="opera76"><a href="#opera76" class="browser-name"><abbr title="Opera 76">OP 76</abbr></a></th>
-<th class="platform opera77 desktop obsolete" data-browser="opera77"><a href="#opera77" class="browser-name"><abbr title="Opera 77">OP 77</abbr></a></th>
-<th class="platform opera78 desktop obsolete" data-browser="opera78"><a href="#opera78" class="browser-name"><abbr title="Opera 78">OP 78</abbr></a></th>
-<th class="platform opera79 desktop" data-browser="opera79"><a href="#opera79" class="browser-name"><abbr title="Opera 79">OP 79</abbr></a></th>
-<th class="platform opera80 desktop" data-browser="opera80"><a href="#opera80" class="browser-name"><abbr title="Opera 80">OP 80</abbr></a></th>
-<th class="platform opera81 desktop unstable" data-browser="opera81"><a href="#opera81" class="browser-name"><abbr title="Opera 81">OP 81</abbr></a></th>
+<th class="platform opera79 desktop obsolete" data-browser="opera79"><a href="#opera79" class="browser-name"><abbr title="Opera 79">OP 79</abbr></a></th>
+<th class="platform opera80 desktop obsolete" data-browser="opera80"><a href="#opera80" class="browser-name"><abbr title="Opera 80">OP 80</abbr></a></th>
+<th class="platform opera81 desktop obsolete" data-browser="opera81"><a href="#opera81" class="browser-name"><abbr title="Opera 81">OP 82</abbr></a></th>
+<th class="platform opera82 desktop obsolete" data-browser="opera82"><a href="#opera82" class="browser-name"><abbr title="Opera 82">OP 82</abbr></a></th>
+<th class="platform opera83 desktop obsolete" data-browser="opera83"><a href="#opera83" class="browser-name"><abbr title="Opera 83">OP 83</abbr></a></th>
+<th class="platform opera84 desktop obsolete" data-browser="opera84"><a href="#opera84" class="browser-name"><abbr title="Opera 84">OP 84</abbr></a></th>
+<th class="platform opera85 desktop obsolete" data-browser="opera85"><a href="#opera85" class="browser-name"><abbr title="Opera 85">OP 85</abbr></a></th>
+<th class="platform opera86 desktop obsolete" data-browser="opera86"><a href="#opera86" class="browser-name"><abbr title="Opera 86">OP 86</abbr></a></th>
+<th class="platform opera87 desktop" data-browser="opera87"><a href="#opera87" class="browser-name"><abbr title="Opera 87">OP 87</abbr></a></th>
+<th class="platform opera88 desktop" data-browser="opera88"><a href="#opera88" class="browser-name"><abbr title="Opera 88">OP 88</abbr></a></th>
+<th class="platform opera89 desktop unstable" data-browser="opera89"><a href="#opera89" class="browser-name"><abbr title="Opera 89">OP 89</abbr></a></th>
 <th class="platform rhino1_7_13 engine obsolete" data-browser="rhino1_7_13"><a href="#rhino1_7_13" class="browser-name"><abbr title="Rhino 1.7.13">Rhino 1.7.13</abbr></a></th>
 <th class="platform rhino1_7_14 engine obsolete" data-browser="rhino1_7_14"><a href="#rhino1_7_14" class="browser-name"><abbr title="Rhino 1.7.14">Rhino 1.7.14</abbr></a></th>
 <th class="platform besen engine" data-browser="besen"><a href="#besen" class="browser-name"><abbr title="Bero&apos;s EcmaScript Engine (version 1.0.0.489)">BESEN</abbr></a></th>
@@ -280,11 +280,6 @@
 <td class="tally unstable" data-browser="firefox102" data-tally="0">0/57</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/57</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="0">0/57</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="0">0/57</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="0">0/57</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="0">0/57</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="0">0/57</td>
@@ -293,9 +288,12 @@
 <td class="tally obsolete" data-browser="chrome96" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="0">0/57</td>
-<td class="tally" data-browser="chrome99" data-tally="0">0/57</td>
-<td class="tally" data-browser="chrome100" data-tally="0">0/57</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="0">0/57</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="0">0/57</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="0">0/57</td>
+<td class="tally" data-browser="chrome101" data-tally="0">0/57</td>
+<td class="tally" data-browser="chrome102" data-tally="0">0/57</td>
+<td class="tally" data-browser="chrome103" data-tally="0">0/57</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="0">0/57</td>
@@ -315,15 +313,17 @@
 <td class="tally" data-browser="safari15_2" data-tally="0">0/57</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="0">0/57</td>
 <td class="tally unstable" data-browser="webkit" data-tally="0">0/57</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="0">0/57</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="0">0/57</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="0">0/57</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="0">0/57</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="0">0/57</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="0">0/57</td>
-<td class="tally" data-browser="opera79" data-tally="0">0/57</td>
-<td class="tally" data-browser="opera80" data-tally="0">0/57</td>
-<td class="tally unstable" data-browser="opera81" data-tally="0">0/57</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="0">0/57</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="0">0/57</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="0">0/57</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="0">0/57</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="0">0/57</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="0">0/57</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="0">0/57</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="0">0/57</td>
+<td class="tally" data-browser="opera87" data-tally="0">0/57</td>
+<td class="tally" data-browser="opera88" data-tally="0">0/57</td>
+<td class="tally unstable" data-browser="opera89" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0">0/57</td>
 <td class="tally" data-browser="besen" data-tally="0">0/57</td>
@@ -428,11 +428,6 @@ return typeof SIMD !== &apos;undefined&apos;;
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -441,9 +436,12 @@ return typeof SIMD !== &apos;undefined&apos;;
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -463,15 +461,17 @@ return typeof SIMD !== &apos;undefined&apos;;
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -568,11 +568,6 @@ return typeof SIMD.Float32x4 === &apos;function&apos;;
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -581,9 +576,12 @@ return typeof SIMD.Float32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -603,15 +601,17 @@ return typeof SIMD.Float32x4 === &apos;function&apos;;
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -708,11 +708,6 @@ return typeof SIMD.Int32x4 === &apos;function&apos;;
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -721,9 +716,12 @@ return typeof SIMD.Int32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -743,15 +741,17 @@ return typeof SIMD.Int32x4 === &apos;function&apos;;
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -848,11 +848,6 @@ return typeof SIMD.Int16x8 === &apos;function&apos;;
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -861,9 +856,12 @@ return typeof SIMD.Int16x8 === &apos;function&apos;;
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -883,15 +881,17 @@ return typeof SIMD.Int16x8 === &apos;function&apos;;
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -988,11 +988,6 @@ return typeof SIMD.Int8x16 === &apos;function&apos;;
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -1001,9 +996,12 @@ return typeof SIMD.Int8x16 === &apos;function&apos;;
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -1023,15 +1021,17 @@ return typeof SIMD.Int8x16 === &apos;function&apos;;
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -1128,11 +1128,6 @@ return typeof SIMD.Uint32x4 === &apos;function&apos;;
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -1141,9 +1136,12 @@ return typeof SIMD.Uint32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -1163,15 +1161,17 @@ return typeof SIMD.Uint32x4 === &apos;function&apos;;
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -1268,11 +1268,6 @@ return typeof SIMD.Uint16x8 === &apos;function&apos;;
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -1281,9 +1276,12 @@ return typeof SIMD.Uint16x8 === &apos;function&apos;;
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -1303,15 +1301,17 @@ return typeof SIMD.Uint16x8 === &apos;function&apos;;
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -1408,11 +1408,6 @@ return typeof SIMD.Uint8x16 === &apos;function&apos;;
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -1421,9 +1416,12 @@ return typeof SIMD.Uint8x16 === &apos;function&apos;;
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -1443,15 +1441,17 @@ return typeof SIMD.Uint8x16 === &apos;function&apos;;
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -1548,11 +1548,6 @@ return typeof SIMD.Bool32x4 === &apos;function&apos;;
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -1561,9 +1556,12 @@ return typeof SIMD.Bool32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -1583,15 +1581,17 @@ return typeof SIMD.Bool32x4 === &apos;function&apos;;
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -1688,11 +1688,6 @@ return typeof SIMD.Bool16x8 === &apos;function&apos;;
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -1701,9 +1696,12 @@ return typeof SIMD.Bool16x8 === &apos;function&apos;;
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -1723,15 +1721,17 @@ return typeof SIMD.Bool16x8 === &apos;function&apos;;
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -1828,11 +1828,6 @@ return typeof SIMD.Bool8x16 === &apos;function&apos;;
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -1841,9 +1836,12 @@ return typeof SIMD.Bool8x16 === &apos;function&apos;;
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -1863,15 +1861,17 @@ return typeof SIMD.Bool8x16 === &apos;function&apos;;
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -1970,11 +1970,6 @@ return simdFloatTypes.every(function(type){
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -1983,9 +1978,12 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -2005,15 +2003,17 @@ return simdFloatTypes.every(function(type){
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -2112,11 +2112,6 @@ return simdFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -2125,9 +2120,12 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -2147,15 +2145,17 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -2254,11 +2254,6 @@ return simdSmallIntTypes.every(function(type){
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -2267,9 +2262,12 @@ return simdSmallIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -2289,15 +2287,17 @@ return simdSmallIntTypes.every(function(type){
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -2396,11 +2396,6 @@ return simdBoolIntTypes.every(function(type){
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -2409,9 +2404,12 @@ return simdBoolIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -2431,15 +2429,17 @@ return simdBoolIntTypes.every(function(type){
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -2538,11 +2538,6 @@ return simdBoolTypes.every(function(type){
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -2551,9 +2546,12 @@ return simdBoolTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -2573,15 +2571,17 @@ return simdBoolTypes.every(function(type){
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -2680,11 +2680,6 @@ return simdBoolTypes.every(function(type){
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -2693,9 +2688,12 @@ return simdBoolTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -2715,15 +2713,17 @@ return simdBoolTypes.every(function(type){
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -2822,11 +2822,6 @@ return simdAllTypes.every(function(type){
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -2835,9 +2830,12 @@ return simdAllTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -2857,15 +2855,17 @@ return simdAllTypes.every(function(type){
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -2964,11 +2964,6 @@ return simdFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -2977,9 +2972,12 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -2999,15 +2997,17 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -3106,11 +3106,6 @@ return simdAllTypes.every(function(type){
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -3119,9 +3114,12 @@ return simdAllTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -3141,15 +3139,17 @@ return simdAllTypes.every(function(type){
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -3248,11 +3248,6 @@ return simdFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -3261,9 +3256,12 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -3283,15 +3281,17 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -3390,11 +3390,6 @@ return simdFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -3403,9 +3398,12 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -3425,15 +3423,17 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -3532,11 +3532,6 @@ return simdFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -3545,9 +3540,12 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -3567,15 +3565,17 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -3674,11 +3674,6 @@ return simdFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -3687,9 +3682,12 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -3709,15 +3707,17 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -3816,11 +3816,6 @@ return simdFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -3829,9 +3824,12 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -3851,15 +3849,17 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -3958,11 +3958,6 @@ return simdFloatTypes.every(function(type){
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -3971,9 +3966,12 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -3993,15 +3991,17 @@ return simdFloatTypes.every(function(type){
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -4100,11 +4100,6 @@ return simdFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -4113,9 +4108,12 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -4135,15 +4133,17 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -4242,11 +4242,6 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -4255,9 +4250,12 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -4277,15 +4275,17 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -4384,11 +4384,6 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -4397,9 +4392,12 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -4419,15 +4417,17 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -4526,11 +4526,6 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -4539,9 +4534,12 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -4561,15 +4559,17 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -4668,11 +4668,6 @@ return simdFloatTypes.every(function(type){
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -4681,9 +4676,12 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -4703,15 +4701,17 @@ return simdFloatTypes.every(function(type){
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -4810,11 +4810,6 @@ return simdFloatTypes.every(function(type){
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -4823,9 +4818,12 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -4845,15 +4843,17 @@ return simdFloatTypes.every(function(type){
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -4952,11 +4952,6 @@ return simdFloatTypes.every(function(type){
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -4965,9 +4960,12 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -4987,15 +4985,17 @@ return simdFloatTypes.every(function(type){
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -5094,11 +5094,6 @@ return simdFloatTypes.every(function(type){
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -5107,9 +5102,12 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -5129,15 +5127,17 @@ return simdFloatTypes.every(function(type){
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -5236,11 +5236,6 @@ return simdFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -5249,9 +5244,12 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -5271,15 +5269,17 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -5378,11 +5378,6 @@ return simdBoolTypes.every(function(type){
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -5391,9 +5386,12 @@ return simdBoolTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -5413,15 +5411,17 @@ return simdBoolTypes.every(function(type){
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -5520,11 +5520,6 @@ return simdFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -5533,9 +5528,12 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -5555,15 +5553,17 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -5662,11 +5662,6 @@ return simdBoolIntTypes.every(function(type){
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -5675,9 +5670,12 @@ return simdBoolIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -5697,15 +5695,17 @@ return simdBoolIntTypes.every(function(type){
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -5804,11 +5804,6 @@ return simdFloatTypes.every(function(type){
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -5817,9 +5812,12 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -5839,15 +5837,17 @@ return simdFloatTypes.every(function(type){
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -5946,11 +5946,6 @@ return simdFloatTypes.every(function(type){
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -5959,9 +5954,12 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -5981,15 +5979,17 @@ return simdFloatTypes.every(function(type){
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -6088,11 +6088,6 @@ return simdAllTypes.every(function(type){
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -6101,9 +6096,12 @@ return simdAllTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -6123,15 +6121,17 @@ return simdAllTypes.every(function(type){
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -6230,11 +6230,6 @@ return simdFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -6243,9 +6238,12 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -6265,15 +6263,17 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -6372,11 +6372,6 @@ return simdIntTypes.every(function(type){
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -6385,9 +6380,12 @@ return simdIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -6407,15 +6405,17 @@ return simdIntTypes.every(function(type){
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -6514,11 +6514,6 @@ return simdIntTypes.every(function(type){
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -6527,9 +6522,12 @@ return simdIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -6549,15 +6547,17 @@ return simdIntTypes.every(function(type){
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -6656,11 +6656,6 @@ return simdFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -6669,9 +6664,12 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -6691,15 +6689,17 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -6798,11 +6798,6 @@ return simdFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -6811,9 +6806,12 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -6833,15 +6831,17 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -6940,11 +6940,6 @@ return simdFloatTypes.every(function(type){
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -6953,9 +6948,12 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -6975,15 +6973,17 @@ return simdFloatTypes.every(function(type){
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -7082,11 +7082,6 @@ return simdFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -7095,9 +7090,12 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -7117,15 +7115,17 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -7224,11 +7224,6 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -7237,9 +7232,12 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -7259,15 +7257,17 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -7366,11 +7366,6 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -7379,9 +7374,12 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -7401,15 +7399,17 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -7508,11 +7508,6 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -7521,9 +7516,12 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -7543,15 +7541,17 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -7650,11 +7650,6 @@ return simdFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -7663,9 +7658,12 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -7685,15 +7683,17 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -7792,11 +7792,6 @@ return simdSmallIntTypes.every(function(type){
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -7805,9 +7800,12 @@ return simdSmallIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -7827,15 +7825,17 @@ return simdSmallIntTypes.every(function(type){
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -7934,11 +7934,6 @@ return simdFloatIntTypes.every(function(type){
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -7947,9 +7942,12 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -7969,15 +7967,17 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -8076,11 +8076,6 @@ return simdBoolIntTypes.every(function(type){
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -8089,9 +8084,12 @@ return simdBoolIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -8111,15 +8109,17 @@ return simdBoolIntTypes.every(function(type){
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -8218,11 +8218,6 @@ return [&apos;Float32x4&apos;,&apos;Int32x4&apos;,&apos;Int8x16&apos;,&apos;Uint
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -8231,9 +8226,12 @@ return [&apos;Float32x4&apos;,&apos;Int32x4&apos;,&apos;Int8x16&apos;,&apos;Uint
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -8253,15 +8251,17 @@ return [&apos;Float32x4&apos;,&apos;Int32x4&apos;,&apos;Int8x16&apos;,&apos;Uint
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -8358,11 +8358,6 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -8371,9 +8366,12 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -8393,15 +8391,17 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -8497,11 +8497,6 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="tally unstable" data-browser="firefox102" data-tally="0">0/4</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="0">0/4</td>
@@ -8510,9 +8505,12 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="tally obsolete" data-browser="chrome96" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="0">0/4</td>
-<td class="tally" data-browser="chrome99" data-tally="0">0/4</td>
-<td class="tally" data-browser="chrome100" data-tally="0">0/4</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="0">0/4</td>
+<td class="tally" data-browser="chrome101" data-tally="0">0/4</td>
+<td class="tally" data-browser="chrome102" data-tally="0">0/4</td>
+<td class="tally" data-browser="chrome103" data-tally="0">0/4</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="0">0/4</td>
@@ -8532,15 +8530,17 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="tally" data-browser="safari15_2" data-tally="0">0/4</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="0">0/4</td>
 <td class="tally unstable" data-browser="webkit" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="0">0/4</td>
-<td class="tally" data-browser="opera79" data-tally="0">0/4</td>
-<td class="tally" data-browser="opera80" data-tally="0">0/4</td>
-<td class="tally unstable" data-browser="opera81" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="0">0/4</td>
+<td class="tally" data-browser="opera87" data-tally="0">0/4</td>
+<td class="tally" data-browser="opera88" data-tally="0">0/4</td>
+<td class="tally unstable" data-browser="opera89" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0.75">3/4</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0.75">3/4</td>
 <td class="tally" data-browser="besen" data-tally="0.25">1/4</td>
@@ -8637,11 +8637,6 @@ return typeof uneval === &apos;function&apos;;
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -8650,9 +8645,12 @@ return typeof uneval === &apos;function&apos;;
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -8672,15 +8670,17 @@ return typeof uneval === &apos;function&apos;;
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -8785,11 +8785,6 @@ return &apos;toSource&apos; in Object.prototype
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -8798,9 +8793,12 @@ return &apos;toSource&apos; in Object.prototype
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -8820,15 +8818,17 @@ return &apos;toSource&apos; in Object.prototype
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -8925,11 +8925,6 @@ return uneval({ toSource: function() { return &quot;pwnd!&quot; } }) === &quot;p
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -8938,9 +8933,12 @@ return uneval({ toSource: function() { return &quot;pwnd!&quot; } }) === &quot;p
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -8960,15 +8958,17 @@ return uneval({ toSource: function() { return &quot;pwnd!&quot; } }) === &quot;p
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -9151,11 +9151,6 @@ return true;
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -9164,9 +9159,12 @@ return true;
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -9186,15 +9184,17 @@ return true;
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -9292,11 +9292,6 @@ return eval(&quot;x&quot;, { x: 2 }) === 2;
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -9305,9 +9300,12 @@ return eval(&quot;x&quot;, { x: 2 }) === 2;
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -9327,15 +9325,17 @@ return eval(&quot;x&quot;, { x: 2 }) === 2;
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -9436,11 +9436,6 @@ return 'caller' in function(){};
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -9449,9 +9444,12 @@ return 'caller' in function(){};
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -9471,15 +9469,17 @@ return 'caller' in function(){};
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="no" data-browser="besen">No</td>
@@ -9582,11 +9582,6 @@ return (function () {}).arity === 0 &&
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -9595,9 +9590,12 @@ return (function () {}).arity === 0 &&
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -9617,15 +9615,17 @@ return (function () {}).arity === 0 &&
 <td class="no" data-browser="safari15_2">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="no" data-browser="besen">No</td>
@@ -9730,11 +9730,6 @@ return f(1, 'boo');
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -9743,9 +9738,12 @@ return f(1, 'boo');
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -9765,15 +9763,17 @@ return f(1, 'boo');
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="no" data-browser="besen">No</td>
@@ -9872,11 +9872,6 @@ return typeof Function.prototype.isGenerator === 'function';
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -9885,9 +9880,12 @@ return typeof Function.prototype.isGenerator === 'function';
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -9907,15 +9905,17 @@ return typeof Function.prototype.isGenerator === 'function';
 <td class="no" data-browser="safari15_2">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="no" data-browser="besen">No</td>
@@ -10015,11 +10015,6 @@ return new C instanceof C;
 <td class="unknown unstable" data-browser="firefox102">?</td>
 <td class="unknown unstable" data-browser="firefox103">?</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -10028,9 +10023,12 @@ return new C instanceof C;
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -10050,15 +10048,17 @@ return new C instanceof C;
 <td class="no" data-browser="safari15_2">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -10159,11 +10159,6 @@ return typeof ({}).__count__ === 'number' &&
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -10172,9 +10167,12 @@ return typeof ({}).__count__ === 'number' &&
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -10194,15 +10192,17 @@ return typeof ({}).__count__ === 'number' &&
 <td class="no" data-browser="safari15_2">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="no" data-browser="besen">No</td>
@@ -10301,11 +10301,6 @@ return typeof ({}).__parent__ !== 'undefined';
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -10314,9 +10309,12 @@ return typeof ({}).__parent__ !== 'undefined';
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -10336,15 +10334,17 @@ return typeof ({}).__parent__ !== 'undefined';
 <td class="no" data-browser="safari15_2">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="no" data-browser="besen">No</td>
@@ -10453,11 +10453,6 @@ return executed;
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -10466,9 +10461,12 @@ return executed;
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -10488,15 +10486,17 @@ return executed;
 <td class="no" data-browser="safari15_2">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="no" data-browser="besen">No</td>
@@ -10595,11 +10595,6 @@ return typeof Array.slice === 'function' && Array.slice('abc').length === 3;
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -10608,9 +10603,12 @@ return typeof Array.slice === 'function' && Array.slice('abc').length === 3;
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -10630,15 +10628,17 @@ return typeof Array.slice === 'function' && Array.slice('abc').length === 3;
 <td class="no" data-browser="safari15_2">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="no" data-browser="besen">No</td>
@@ -10737,11 +10737,6 @@ return typeof String.slice === 'function' && String.slice(123, 1) === "23";
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -10750,9 +10745,12 @@ return typeof String.slice === 'function' && String.slice(123, 1) === "23";
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -10772,15 +10770,17 @@ return typeof String.slice === 'function' && String.slice(123, 1) === "23";
 <td class="no" data-browser="safari15_2">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="no" data-browser="besen">No</td>
@@ -10881,11 +10881,6 @@ return a instanceof Array &amp;&amp; a[0] === 4 &amp;&amp; a[1] === 8;
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -10894,9 +10889,12 @@ return a instanceof Array &amp;&amp; a[0] === 4 &amp;&amp; a[1] === 8;
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -10916,15 +10914,17 @@ return a instanceof Array &amp;&amp; a[0] === 4 &amp;&amp; a[1] === 8;
 <td class="no" data-browser="safari15_2">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="no" data-browser="besen">No</td>
@@ -11021,11 +11021,6 @@ return [for (a of [1, 2, 3]) a * a] + &apos;&apos; === &apos;1,4,9&apos;;
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -11034,9 +11029,12 @@ return [for (a of [1, 2, 3]) a * a] + &apos;&apos; === &apos;1,4,9&apos;;
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -11056,15 +11054,17 @@ return [for (a of [1, 2, 3]) a * a] + &apos;&apos; === &apos;1,4,9&apos;;
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -11161,11 +11161,6 @@ return (function(x)x)(1) === 1;
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -11174,9 +11169,12 @@ return (function(x)x)(1) === 1;
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -11196,15 +11194,17 @@ return (function(x)x)(1) === 1;
 <td class="no" data-browser="safari15_2">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -11301,11 +11301,6 @@ return typeof &lt;foo/&gt; === &quot;xml&quot;;
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -11314,9 +11309,12 @@ return typeof &lt;foo/&gt; === &quot;xml&quot;;
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -11336,15 +11334,17 @@ return typeof &lt;foo/&gt; === &quot;xml&quot;;
 <td class="no" data-browser="safari15_2">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="no" data-browser="besen">No</td>
@@ -11445,11 +11445,6 @@ return str === &quot;foobarbaz&quot;;
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -11458,9 +11453,12 @@ return str === &quot;foobarbaz&quot;;
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -11480,15 +11478,17 @@ return str === &quot;foobarbaz&quot;;
 <td class="no" data-browser="safari15_2">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="no" data-browser="besen">No</td>
@@ -11586,11 +11586,6 @@ return arr[1] === arr;
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -11599,9 +11594,12 @@ return arr[1] === arr;
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -11621,15 +11619,17 @@ return arr[1] === arr;
 <td class="no" data-browser="safari15_2">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -11760,11 +11760,6 @@ catch(e) {
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -11773,9 +11768,12 @@ catch(e) {
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -11795,15 +11793,17 @@ catch(e) {
 <td class="no" data-browser="safari15_2">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="no" data-browser="besen">No</td>
@@ -11940,11 +11940,6 @@ catch(e) {
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -11953,9 +11948,12 @@ catch(e) {
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -11975,15 +11973,17 @@ catch(e) {
 <td class="no" data-browser="safari15_2">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="no" data-browser="besen">No</td>
@@ -12119,11 +12119,6 @@ global.test((function () {
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -12132,9 +12127,12 @@ global.test((function () {
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -12154,15 +12152,17 @@ global.test((function () {
 <td class="no" data-browser="safari15_2">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="no" data-browser="besen">No</td>
@@ -12261,11 +12261,6 @@ return g.next() === 4 &amp;&amp; g.next() === 8;
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -12274,9 +12269,12 @@ return g.next() === 4 &amp;&amp; g.next() === 8;
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -12296,15 +12294,17 @@ return g.next() === 4 &amp;&amp; g.next() === 8;
 <td class="no" data-browser="safari15_2">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="no" data-browser="besen">No</td>
@@ -12408,11 +12408,6 @@ return passed;
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -12421,9 +12416,12 @@ return passed;
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -12443,15 +12441,17 @@ return passed;
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -12566,11 +12566,6 @@ try {
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -12579,9 +12574,12 @@ try {
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -12601,15 +12599,17 @@ try {
 <td class="no" data-browser="safari15_2">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="no" data-browser="besen">No</td>
@@ -12706,11 +12706,6 @@ return /\\w/(&quot;x&quot;)[0] === &quot;x&quot;;
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -12719,9 +12714,12 @@ return /\\w/(&quot;x&quot;)[0] === &quot;x&quot;;
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -12741,15 +12739,17 @@ return /\\w/(&quot;x&quot;)[0] === &quot;x&quot;;
 <td class="no" data-browser="safari15_2">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="no" data-browser="besen">No</td>
@@ -12847,11 +12847,6 @@ return /(?P&lt;name&gt;a)(?P=name)/.test(&quot;aa&quot;) &amp;&amp;
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -12860,9 +12855,12 @@ return /(?P&lt;name&gt;a)(?P=name)/.test(&quot;aa&quot;) &amp;&amp;
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -12882,15 +12880,17 @@ return /(?P&lt;name&gt;a)(?P=name)/.test(&quot;aa&quot;) &amp;&amp;
 <td class="no" data-browser="safari15_2">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -12987,11 +12987,6 @@ function () { return typeof String.prototype.quote === 'function' }())</script><
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -13000,9 +12995,12 @@ function () { return typeof String.prototype.quote === 'function' }())</script><
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -13022,15 +13020,17 @@ function () { return typeof String.prototype.quote === 'function' }())</script><
 <td class="no" data-browser="safari15_2">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -13125,11 +13125,6 @@ function () { return 'foofoo'.replace('foo', 'bar', 'g') === 'barbar' }())</scri
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -13138,9 +13133,12 @@ function () { return 'foofoo'.replace('foo', 'bar', 'g') === 'barbar' }())</scri
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -13160,15 +13158,17 @@ function () { return 'foofoo'.replace('foo', 'bar', 'g') === 'barbar' }())</scri
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -13265,11 +13265,6 @@ function () { return typeof Date.prototype.toLocaleFormat === 'function' }())</s
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -13278,9 +13273,12 @@ function () { return typeof Date.prototype.toLocaleFormat === 'function' }())</s
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -13300,15 +13298,17 @@ function () { return typeof Date.prototype.toLocaleFormat === 'function' }())</s
 <td class="no" data-browser="safari15_2">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="no" data-browser="besen">No</td>
@@ -13413,11 +13413,6 @@ return !brokenOnFirefox && !brokenOnIE10 && !brokenOnChrome;
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -13426,9 +13421,12 @@ return !brokenOnFirefox && !brokenOnIE10 && !brokenOnChrome;
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -13448,15 +13446,17 @@ return !brokenOnFirefox && !brokenOnIE10 && !brokenOnChrome;
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -13553,11 +13553,6 @@ function () { return typeof Object.prototype.watch === 'function' }())</script><
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -13566,9 +13561,12 @@ function () { return typeof Object.prototype.watch === 'function' }())</script><
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -13588,15 +13586,17 @@ function () { return typeof Object.prototype.watch === 'function' }())</script><
 <td class="no" data-browser="safari15_2">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="no" data-browser="besen">No</td>
@@ -13691,11 +13691,6 @@ function () { return typeof Object.prototype.unwatch === 'function' }())</script
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -13704,9 +13699,12 @@ function () { return typeof Object.prototype.unwatch === 'function' }())</script
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -13726,15 +13724,17 @@ function () { return typeof Object.prototype.unwatch === 'function' }())</script
 <td class="no" data-browser="safari15_2">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="no" data-browser="besen">No</td>
@@ -13829,11 +13829,6 @@ function () { return typeof Object.prototype.eval === 'function' }())</script></
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -13842,9 +13837,12 @@ function () { return typeof Object.prototype.eval === 'function' }())</script></
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -13864,15 +13862,17 @@ function () { return typeof Object.prototype.eval === 'function' }())</script></
 <td class="no" data-browser="safari15_2">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="yes" data-browser="besen">Yes</td>
@@ -13969,11 +13969,6 @@ return typeof Object.observe === &apos;function&apos;;
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -13982,9 +13977,12 @@ return typeof Object.observe === &apos;function&apos;;
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -14004,15 +14002,17 @@ return typeof Object.observe === &apos;function&apos;;
 <td class="unknown" data-browser="safari15_2">?</td>
 <td class="unknown unstable" data-browser="safaritp">?</td>
 <td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -14121,11 +14121,6 @@ try {
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
-<td class="yes obsolete" data-browser="chrome86">Yes</td>
-<td class="yes obsolete" data-browser="chrome87">Yes</td>
-<td class="yes obsolete" data-browser="chrome88">Yes</td>
-<td class="yes obsolete" data-browser="chrome89">Yes</td>
-<td class="yes obsolete" data-browser="chrome90">Yes</td>
 <td class="yes obsolete" data-browser="chrome91">Yes</td>
 <td class="yes obsolete" data-browser="chrome92">Yes</td>
 <td class="yes obsolete" data-browser="chrome93">Yes</td>
@@ -14134,9 +14129,12 @@ try {
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
 <td class="yes obsolete" data-browser="chrome97">Yes</td>
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
-<td class="yes" data-browser="chrome99">Yes</td>
-<td class="yes" data-browser="chrome100">Yes</td>
-<td class="yes unstable" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome99">Yes</td>
+<td class="yes obsolete" data-browser="chrome100">Yes</td>
+<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes" data-browser="chrome102">Yes</td>
+<td class="yes" data-browser="chrome103">Yes</td>
+<td class="yes unstable" data-browser="chrome104">Yes</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge87">Yes</td>
 <td class="yes obsolete" data-browser="edge88">Yes</td>
@@ -14156,15 +14154,17 @@ try {
 <td class="yes" data-browser="safari15_2">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera73">Yes</td>
-<td class="yes obsolete" data-browser="opera74">Yes</td>
-<td class="yes obsolete" data-browser="opera75">Yes</td>
-<td class="yes obsolete" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="opera77">Yes</td>
-<td class="yes obsolete" data-browser="opera78">Yes</td>
-<td class="yes" data-browser="opera79">Yes</td>
-<td class="yes" data-browser="opera80">Yes</td>
-<td class="yes unstable" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera79">Yes</td>
+<td class="yes obsolete" data-browser="opera80">Yes</td>
+<td class="yes obsolete" data-browser="opera81">Yes</td>
+<td class="yes obsolete" data-browser="opera82">Yes</td>
+<td class="yes obsolete" data-browser="opera83">Yes</td>
+<td class="yes obsolete" data-browser="opera84">Yes</td>
+<td class="yes obsolete" data-browser="opera85">Yes</td>
+<td class="yes obsolete" data-browser="opera86">Yes</td>
+<td class="yes" data-browser="opera87">Yes</td>
+<td class="yes" data-browser="opera88">Yes</td>
+<td class="yes unstable" data-browser="opera89">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="no" data-browser="besen">No</td>
@@ -14263,11 +14263,6 @@ return 'lineNumber' in new Error();
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -14276,9 +14271,12 @@ return 'lineNumber' in new Error();
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -14298,15 +14296,17 @@ return 'lineNumber' in new Error();
 <td class="no" data-browser="safari15_2">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="no" data-browser="besen">No</td>
@@ -14405,11 +14405,6 @@ return 'columnNumber' in new Error();
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -14418,9 +14413,12 @@ return 'columnNumber' in new Error();
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -14440,15 +14438,17 @@ return 'columnNumber' in new Error();
 <td class="no" data-browser="safari15_2">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="no" data-browser="besen">No</td>
@@ -14547,11 +14547,6 @@ return 'fileName' in new Error();
 <td class="yes unstable" data-browser="firefox102">Yes</td>
 <td class="yes unstable" data-browser="firefox103">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -14560,9 +14555,12 @@ return 'fileName' in new Error();
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -14582,15 +14580,17 @@ return 'fileName' in new Error();
 <td class="no" data-browser="safari15_2">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="rhino1_7_14">Yes</td>
 <td class="no" data-browser="besen">No</td>
@@ -14689,11 +14689,6 @@ return 'description' in new Error();
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -14702,9 +14697,12 @@ return 'description' in new Error();
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -14724,15 +14722,17 @@ return 'description' in new Error();
 <td class="no" data-browser="safari15_2">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="no" data-browser="besen">No</td>
@@ -14828,11 +14828,6 @@ return 'description' in new Error();
 <td class="tally unstable" data-browser="firefox102" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="firefox103" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="chrome86" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="chrome87" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="chrome88" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="chrome89" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="chrome90" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome91" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome92" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome93" data-tally="0">0/2</td>
@@ -14841,9 +14836,12 @@ return 'description' in new Error();
 <td class="tally obsolete" data-browser="chrome96" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome97" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome98" data-tally="0">0/2</td>
-<td class="tally" data-browser="chrome99" data-tally="0">0/2</td>
-<td class="tally" data-browser="chrome100" data-tally="0">0/2</td>
-<td class="tally unstable" data-browser="chrome101" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="chrome99" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="chrome100" data-tally="0">0/2</td>
+<td class="tally" data-browser="chrome101" data-tally="0">0/2</td>
+<td class="tally" data-browser="chrome102" data-tally="0">0/2</td>
+<td class="tally" data-browser="chrome103" data-tally="0">0/2</td>
+<td class="tally unstable" data-browser="chrome104" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge87" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge88" data-tally="0">0/2</td>
@@ -14863,15 +14861,17 @@ return 'description' in new Error();
 <td class="tally" data-browser="safari15_2" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="webkit" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="opera73" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="opera74" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="opera75" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="opera76" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="opera77" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="opera78" data-tally="0">0/2</td>
-<td class="tally" data-browser="opera79" data-tally="0">0/2</td>
-<td class="tally" data-browser="opera80" data-tally="0">0/2</td>
-<td class="tally unstable" data-browser="opera81" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="opera79" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="opera80" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="opera81" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="opera82" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="opera83" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="opera84" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="opera85" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="opera86" data-tally="0">0/2</td>
+<td class="tally" data-browser="opera87" data-tally="0">0/2</td>
+<td class="tally" data-browser="opera88" data-tally="0">0/2</td>
+<td class="tally unstable" data-browser="opera89" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0">0/2</td>
 <td class="tally" data-browser="besen" data-tally="0">0/2</td>
@@ -14970,11 +14970,6 @@ return typeof global === &apos;object&apos; &amp;&amp; global &amp;&amp; global 
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -14983,9 +14978,12 @@ return typeof global === &apos;object&apos; &amp;&amp; global &amp;&amp; global 
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -15005,15 +15003,17 @@ return typeof global === &apos;object&apos; &amp;&amp; global &amp;&amp; global 
 <td class="no" data-browser="safari15_2">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -15117,11 +15117,6 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -15130,9 +15125,12 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="no obsolete" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -15152,15 +15150,17 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="no" data-browser="safari15_2">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>
@@ -15262,11 +15262,6 @@ return Object.getOwnPropertyNames(P) + &apos;&apos; === &quot;a,a,b,b&quot;;
 <td class="no unstable" data-browser="firefox102">No</td>
 <td class="no unstable" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="no obsolete" data-browser="chrome86">No</td>
-<td class="no obsolete" data-browser="chrome87">No</td>
-<td class="no obsolete" data-browser="chrome88">No</td>
-<td class="no obsolete" data-browser="chrome89">No</td>
-<td class="no obsolete" data-browser="chrome90">No</td>
 <td class="no obsolete" data-browser="chrome91">No</td>
 <td class="no obsolete" data-browser="chrome92">No</td>
 <td class="no obsolete" data-browser="chrome93">No</td>
@@ -15275,9 +15270,12 @@ return Object.getOwnPropertyNames(P) + &apos;&apos; === &quot;a,a,b,b&quot;;
 <td class="no obsolete" data-browser="chrome96">No</td>
 <td class="no obsolete" data-browser="chrome97">No</td>
 <td class="no obsolete" data-browser="chrome98">No</td>
-<td class="no" data-browser="chrome99">No</td>
-<td class="no" data-browser="chrome100">No</td>
-<td class="no unstable" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome99">No</td>
+<td class="no obsolete" data-browser="chrome100">No</td>
+<td class="no" data-browser="chrome101">No</td>
+<td class="no" data-browser="chrome102">No</td>
+<td class="no" data-browser="chrome103">No</td>
+<td class="no unstable" data-browser="chrome104">No</td>
 <td class="yes obsolete" data-browser="edge18">Yes</td>
 <td class="no obsolete" data-browser="edge87">No</td>
 <td class="no obsolete" data-browser="edge88">No</td>
@@ -15297,15 +15295,17 @@ return Object.getOwnPropertyNames(P) + &apos;&apos; === &quot;a,a,b,b&quot;;
 <td class="no" data-browser="safari15_2">No</td>
 <td class="no unstable" data-browser="safaritp">No</td>
 <td class="no unstable" data-browser="webkit">No</td>
-<td class="no obsolete" data-browser="opera73">No</td>
-<td class="no obsolete" data-browser="opera74">No</td>
-<td class="no obsolete" data-browser="opera75">No</td>
-<td class="no obsolete" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="opera77">No</td>
-<td class="no obsolete" data-browser="opera78">No</td>
-<td class="no" data-browser="opera79">No</td>
-<td class="no" data-browser="opera80">No</td>
-<td class="no unstable" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera79">No</td>
+<td class="no obsolete" data-browser="opera80">No</td>
+<td class="no obsolete" data-browser="opera81">No</td>
+<td class="no obsolete" data-browser="opera82">No</td>
+<td class="no obsolete" data-browser="opera83">No</td>
+<td class="no obsolete" data-browser="opera84">No</td>
+<td class="no obsolete" data-browser="opera85">No</td>
+<td class="no obsolete" data-browser="opera86">No</td>
+<td class="no" data-browser="opera87">No</td>
+<td class="no" data-browser="opera88">No</td>
+<td class="no unstable" data-browser="opera89">No</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="unknown" data-browser="besen">?</td>

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -149,7 +149,7 @@
 <th class="platform chrome98 desktop obsolete" data-browser="chrome98"><a href="#chrome98" class="browser-name"><abbr title="Chrome 98">CH 98</abbr></a></th>
 <th class="platform chrome99 desktop obsolete" data-browser="chrome99"><a href="#chrome99" class="browser-name"><abbr title="Chrome 99">CH 99</abbr></a></th>
 <th class="platform chrome100 desktop obsolete" data-browser="chrome100"><a href="#chrome100" class="browser-name"><abbr title="Chrome 100">CH 100</abbr></a></th>
-<th class="platform chrome101 desktop" data-browser="chrome101"><a href="#chrome101" class="browser-name"><abbr title="Chrome 101">CH 101</abbr></a></th>
+<th class="platform chrome101 desktop obsolete" data-browser="chrome101"><a href="#chrome101" class="browser-name"><abbr title="Chrome 101">CH 101</abbr></a></th>
 <th class="platform chrome102 desktop" data-browser="chrome102"><a href="#chrome102" class="browser-name"><abbr title="Chrome 102">CH 102</abbr></a></th>
 <th class="platform chrome103 desktop" data-browser="chrome103"><a href="#chrome103" class="browser-name"><abbr title="Chrome 103">CH 103</abbr></a></th>
 <th class="platform chrome104 desktop unstable" data-browser="chrome104"><a href="#chrome104" class="browser-name"><abbr title="Chrome 104 Beta">CH 104</abbr></a></th>
@@ -290,7 +290,7 @@
 <td class="tally obsolete" data-browser="chrome98" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="0">0/57</td>
-<td class="tally" data-browser="chrome101" data-tally="0">0/57</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="0">0/57</td>
 <td class="tally" data-browser="chrome102" data-tally="0">0/57</td>
 <td class="tally" data-browser="chrome103" data-tally="0">0/57</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="0">0/57</td>
@@ -438,7 +438,7 @@ return typeof SIMD !== &apos;undefined&apos;;
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -578,7 +578,7 @@ return typeof SIMD.Float32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -718,7 +718,7 @@ return typeof SIMD.Int32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -858,7 +858,7 @@ return typeof SIMD.Int16x8 === &apos;function&apos;;
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -998,7 +998,7 @@ return typeof SIMD.Int8x16 === &apos;function&apos;;
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -1138,7 +1138,7 @@ return typeof SIMD.Uint32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -1278,7 +1278,7 @@ return typeof SIMD.Uint16x8 === &apos;function&apos;;
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -1418,7 +1418,7 @@ return typeof SIMD.Uint8x16 === &apos;function&apos;;
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -1558,7 +1558,7 @@ return typeof SIMD.Bool32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -1698,7 +1698,7 @@ return typeof SIMD.Bool16x8 === &apos;function&apos;;
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -1838,7 +1838,7 @@ return typeof SIMD.Bool8x16 === &apos;function&apos;;
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -1980,7 +1980,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -2122,7 +2122,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -2264,7 +2264,7 @@ return simdSmallIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -2406,7 +2406,7 @@ return simdBoolIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -2548,7 +2548,7 @@ return simdBoolTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -2690,7 +2690,7 @@ return simdBoolTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -2832,7 +2832,7 @@ return simdAllTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -2974,7 +2974,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -3116,7 +3116,7 @@ return simdAllTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -3258,7 +3258,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -3400,7 +3400,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -3542,7 +3542,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -3684,7 +3684,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -3826,7 +3826,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -3968,7 +3968,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -4110,7 +4110,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -4252,7 +4252,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -4394,7 +4394,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -4536,7 +4536,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -4678,7 +4678,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -4820,7 +4820,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -4962,7 +4962,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -5104,7 +5104,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -5246,7 +5246,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -5388,7 +5388,7 @@ return simdBoolTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -5530,7 +5530,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -5672,7 +5672,7 @@ return simdBoolIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -5814,7 +5814,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -5956,7 +5956,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -6098,7 +6098,7 @@ return simdAllTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -6240,7 +6240,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -6382,7 +6382,7 @@ return simdIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -6524,7 +6524,7 @@ return simdIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -6666,7 +6666,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -6808,7 +6808,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -6950,7 +6950,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -7092,7 +7092,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -7234,7 +7234,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -7376,7 +7376,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -7518,7 +7518,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -7660,7 +7660,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -7802,7 +7802,7 @@ return simdSmallIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -7944,7 +7944,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -8086,7 +8086,7 @@ return simdBoolIntTypes.every(function(type){
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -8228,7 +8228,7 @@ return [&apos;Float32x4&apos;,&apos;Int32x4&apos;,&apos;Int8x16&apos;,&apos;Uint
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -8368,7 +8368,7 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -8507,7 +8507,7 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="tally obsolete" data-browser="chrome98" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="0">0/4</td>
-<td class="tally" data-browser="chrome101" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="0">0/4</td>
 <td class="tally" data-browser="chrome102" data-tally="0">0/4</td>
 <td class="tally" data-browser="chrome103" data-tally="0">0/4</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="0">0/4</td>
@@ -8647,7 +8647,7 @@ return typeof uneval === &apos;function&apos;;
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -8795,7 +8795,7 @@ return &apos;toSource&apos; in Object.prototype
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -8935,7 +8935,7 @@ return uneval({ toSource: function() { return &quot;pwnd!&quot; } }) === &quot;p
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -9161,7 +9161,7 @@ return true;
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -9302,7 +9302,7 @@ return eval(&quot;x&quot;, { x: 2 }) === 2;
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -9446,7 +9446,7 @@ return 'caller' in function(){};
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -9592,7 +9592,7 @@ return (function () {}).arity === 0 &&
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -9740,7 +9740,7 @@ return f(1, 'boo');
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -9882,7 +9882,7 @@ return typeof Function.prototype.isGenerator === 'function';
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -10025,7 +10025,7 @@ return new C instanceof C;
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -10169,7 +10169,7 @@ return typeof ({}).__count__ === 'number' &&
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -10311,7 +10311,7 @@ return typeof ({}).__parent__ !== 'undefined';
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -10463,7 +10463,7 @@ return executed;
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -10605,7 +10605,7 @@ return typeof Array.slice === 'function' && Array.slice('abc').length === 3;
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -10747,7 +10747,7 @@ return typeof String.slice === 'function' && String.slice(123, 1) === "23";
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -10891,7 +10891,7 @@ return a instanceof Array &amp;&amp; a[0] === 4 &amp;&amp; a[1] === 8;
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -11031,7 +11031,7 @@ return [for (a of [1, 2, 3]) a * a] + &apos;&apos; === &apos;1,4,9&apos;;
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -11171,7 +11171,7 @@ return (function(x)x)(1) === 1;
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -11311,7 +11311,7 @@ return typeof &lt;foo/&gt; === &quot;xml&quot;;
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -11455,7 +11455,7 @@ return str === &quot;foobarbaz&quot;;
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -11596,7 +11596,7 @@ return arr[1] === arr;
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -11770,7 +11770,7 @@ catch(e) {
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -11950,7 +11950,7 @@ catch(e) {
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -12129,7 +12129,7 @@ global.test((function () {
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -12271,7 +12271,7 @@ return g.next() === 4 &amp;&amp; g.next() === 8;
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -12418,7 +12418,7 @@ return passed;
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -12576,7 +12576,7 @@ try {
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -12716,7 +12716,7 @@ return /\\w/(&quot;x&quot;)[0] === &quot;x&quot;;
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -12857,7 +12857,7 @@ return /(?P&lt;name&gt;a)(?P=name)/.test(&quot;aa&quot;) &amp;&amp;
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -12997,7 +12997,7 @@ function () { return typeof String.prototype.quote === 'function' }())</script><
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -13135,7 +13135,7 @@ function () { return 'foofoo'.replace('foo', 'bar', 'g') === 'barbar' }())</scri
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -13275,7 +13275,7 @@ function () { return typeof Date.prototype.toLocaleFormat === 'function' }())</s
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -13423,7 +13423,7 @@ return !brokenOnFirefox && !brokenOnIE10 && !brokenOnChrome;
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -13563,7 +13563,7 @@ function () { return typeof Object.prototype.watch === 'function' }())</script><
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -13701,7 +13701,7 @@ function () { return typeof Object.prototype.unwatch === 'function' }())</script
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -13839,7 +13839,7 @@ function () { return typeof Object.prototype.eval === 'function' }())</script></
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -13979,7 +13979,7 @@ return typeof Object.observe === &apos;function&apos;;
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -14131,7 +14131,7 @@ try {
 <td class="yes obsolete" data-browser="chrome98">Yes</td>
 <td class="yes obsolete" data-browser="chrome99">Yes</td>
 <td class="yes obsolete" data-browser="chrome100">Yes</td>
-<td class="yes" data-browser="chrome101">Yes</td>
+<td class="yes obsolete" data-browser="chrome101">Yes</td>
 <td class="yes" data-browser="chrome102">Yes</td>
 <td class="yes" data-browser="chrome103">Yes</td>
 <td class="yes unstable" data-browser="chrome104">Yes</td>
@@ -14273,7 +14273,7 @@ return 'lineNumber' in new Error();
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -14415,7 +14415,7 @@ return 'columnNumber' in new Error();
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -14557,7 +14557,7 @@ return 'fileName' in new Error();
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -14699,7 +14699,7 @@ return 'description' in new Error();
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -14838,7 +14838,7 @@ return 'description' in new Error();
 <td class="tally obsolete" data-browser="chrome98" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome99" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome100" data-tally="0">0/2</td>
-<td class="tally" data-browser="chrome101" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="chrome101" data-tally="0">0/2</td>
 <td class="tally" data-browser="chrome102" data-tally="0">0/2</td>
 <td class="tally" data-browser="chrome103" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="chrome104" data-tally="0">0/2</td>
@@ -14980,7 +14980,7 @@ return typeof global === &apos;object&apos; &amp;&amp; global &amp;&amp; global 
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -15127,7 +15127,7 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>
@@ -15272,7 +15272,7 @@ return Object.getOwnPropertyNames(P) + &apos;&apos; === &quot;a,a,b,b&quot;;
 <td class="no obsolete" data-browser="chrome98">No</td>
 <td class="no obsolete" data-browser="chrome99">No</td>
 <td class="no obsolete" data-browser="chrome100">No</td>
-<td class="no" data-browser="chrome101">No</td>
+<td class="no obsolete" data-browser="chrome101">No</td>
 <td class="no" data-browser="chrome102">No</td>
 <td class="no" data-browser="chrome103">No</td>
 <td class="no unstable" data-browser="chrome104">No</td>


### PR DESCRIPTION
Chrome: https://en.wikipedia.org/wiki/Google_Chrome_version_history

Opera: 
82: https://blogs.opera.com/desktop/2021/12/opera-82/
83: https://blogs.opera.com/desktop/2022/01/opera-83/
84: https://blogs.opera.com/desktop/2022/02/opera-84/
85: https://blogs.opera.com/desktop/2022/03/opera-85/
86: https://blogs.opera.com/desktop/2022/04/opera-86-stable/
87: https://blogs.opera.com/desktop/2022/05/opera-87-stable/
88: https://blogs.opera.com/desktop/2022/06/opera-88-stable/


I add in this commit also Chrome because without this I couldn't added Operas 88+