### PR TITLE
Update Closure Compiler to v20220719

### DIFF
--- a/data-es2016plus.js
+++ b/data-es2016plus.js
@@ -5992,6 +5992,7 @@ exports.tests = [
             note_id: 'closure-at-method',
             note_html: 'Requires native support for <code>Math.trunc</code>'
           },
+          closure20220719: true,
           ie11: false,
           firefox68: false,
           firefox85: firefox.nightly,
@@ -6030,6 +6031,7 @@ exports.tests = [
             val: false,
             note_id: 'closure-at-method'
           },
+          closure20220719: true,
           ie11: false,
           firefox68: false,
           firefox85: firefox.nightly,
@@ -6118,6 +6120,7 @@ exports.tests = [
       */},
         res: {
           babel7corejs3: babel.corejs,
+          closure20220719: true,
           typescript3_2corejs3: typescript.corejs,
           ie11: false,
           chrome1: false,
@@ -6148,6 +6151,7 @@ exports.tests = [
       */},
         res: {
           babel7corejs3: babel.corejs,
+          closure20220719: true,
           typescript3_2corejs3: typescript.corejs,
           ie11: false,
           chrome1: false,

--- a/environments.json
+++ b/environments.json
@@ -289,7 +289,7 @@
     "short": "Closure 2020.05",
     "family": "Closure",
     "platformtype": "compiler",
-    "obsolete": true,
+    "obsolete": "very",
     "test_suites": [
       "es6",
       "es2016plus",
@@ -371,6 +371,18 @@
   "closure20220502": {
     "full": "Closure Compiler >=v20220502",
     "short": "Closure 2022.05",
+    "family": "Closure",
+    "platformtype": "compiler",
+    "obsolete": true,
+    "test_suites": [
+      "es6",
+      "es2016plus",
+      "esnext"
+    ]
+  },
+  "closure20220719": {
+    "full": "Closure Compiler >=v20220719",
+    "short": "Closure 2022.07",
     "family": "Closure",
     "platformtype": "compiler",
     "obsolete": false,

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -128,14 +128,14 @@
 <th class="platform babel6corejs2 compiler obsolete" data-browser="babel6corejs2"><a href="#babel6corejs2" class="browser-name"><abbr title="Babel 6.5 + core-js 2.5">Babel 6 +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform babel7corejs2 compiler obsolete" data-browser="babel7corejs2"><a href="#babel7corejs2" class="browser-name"><abbr title="Babel 7 + core-js 2.5">Babel 7 +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform babel7corejs3 compiler" data-browser="babel7corejs3"><a href="#babel7corejs3" class="browser-name"><abbr title="Babel 7 + core-js 3">Babel 7 +<br><nobr>core-js 3</nobr></abbr></a></th>
-<th class="platform closure20200517 compiler obsolete" data-browser="closure20200517"><a href="#closure20200517" class="browser-name"><abbr title="Closure Compiler &gt;=v20200517 &lt;v20200614">Closure 2020.05</abbr></a></th>
 <th class="platform closure20200614 compiler obsolete" data-browser="closure20200614"><a href="#closure20200614" class="browser-name"><abbr title="Closure Compiler &gt;=v20200614 &lt;v20200927">Closure 2020.06</abbr></a></th>
 <th class="platform closure20200927 compiler obsolete" data-browser="closure20200927"><a href="#closure20200927" class="browser-name"><abbr title="Closure Compiler &gt;=v20200927 &lt;v20210808">Closure 2020.09</abbr></a></th>
 <th class="platform closure20210808 compiler obsolete" data-browser="closure20210808"><a href="#closure20210808" class="browser-name"><abbr title="Closure Compiler v20210808">Closure 2021.08</abbr></a></th>
 <th class="platform closure20210906 compiler obsolete" data-browser="closure20210906"><a href="#closure20210906" class="browser-name"><abbr title="Closure Compiler v20210906">Closure 2021.09</abbr></a></th>
 <th class="platform closure20211006 compiler obsolete" data-browser="closure20211006"><a href="#closure20211006" class="browser-name"><abbr title="Closure Compiler v20211006">Closure 2021.10</abbr></a></th>
 <th class="platform closure20211107 compiler obsolete" data-browser="closure20211107"><a href="#closure20211107" class="browser-name"><abbr title="Closure Compiler &gt;=v20211107">Closure 2021.11</abbr></a></th>
-<th class="platform closure20220502 compiler" data-browser="closure20220502"><a href="#closure20220502" class="browser-name"><abbr title="Closure Compiler &gt;=v20220502">Closure 2022.05</abbr></a></th>
+<th class="platform closure20220502 compiler obsolete" data-browser="closure20220502"><a href="#closure20220502" class="browser-name"><abbr title="Closure Compiler &gt;=v20220502">Closure 2022.05</abbr></a></th>
+<th class="platform closure20220719 compiler" data-browser="closure20220719"><a href="#closure20220719" class="browser-name"><abbr title="Closure Compiler &gt;=v20220719">Closure 2022.07</abbr></a></th>
 <th class="platform typescript1corejs2 compiler obsolete" data-browser="typescript1corejs2"><a href="#typescript1corejs2" class="browser-name"><abbr title="TypeScript 1.8 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform typescript2_9corejs2 compiler obsolete" data-browser="typescript2_9corejs2"><a href="#typescript2_9corejs2" class="browser-name"><abbr title="TypeScript 2.9 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform typescript3_2corejs2 compiler obsolete" data-browser="typescript3_2corejs2"><a href="#typescript3_2corejs2" class="browser-name"><abbr title="TypeScript 3.2 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
@@ -297,14 +297,14 @@
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">3/3</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="closure20200517" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20211107" data-tally="1">3/3</td>
-<td class="tally" data-browser="closure20220502" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="closure20220502" data-tally="1">3/3</td>
+<td class="tally" data-browser="closure20220719" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -463,14 +463,14 @@ return 2 ** 3 === 8 &amp;&amp; -(5 ** 2) === -25 &amp;&amp; (-5) ** 2 === 25;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -629,14 +629,14 @@ var a = 2; a **= 3; return a === 8;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -800,14 +800,14 @@ return true;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -963,14 +963,14 @@ return true;
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">4/4</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="closure20200517" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20211107" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td class="tally" data-browser="closure20220502" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td class="tally obsolete" data-browser="closure20220502" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td class="tally" data-browser="closure20220719" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">4/4</td>
@@ -1132,14 +1132,14 @@ return [1, 2, 3].includes(1)
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -1299,14 +1299,14 @@ return [,].includes()
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -1487,14 +1487,14 @@ return 24;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -1658,14 +1658,14 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -1833,14 +1833,14 @@ return true;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -2012,14 +2012,14 @@ return iter[&apos;throw&apos;]().value === &apos;bar&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -2183,14 +2183,14 @@ return true;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -2350,14 +2350,14 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -2518,14 +2518,14 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -2691,14 +2691,14 @@ return passed;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -2866,14 +2866,14 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -3031,14 +3031,14 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">4/4</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="closure20200517" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20211107" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td class="tally" data-browser="closure20220502" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td class="tally obsolete" data-browser="closure20220502" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td class="tally" data-browser="closure20220719" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">4/4</td>
@@ -3200,14 +3200,14 @@ return Array.isArray(v) &amp;&amp; String(v) === &quot;foo,bar,baz&quot;;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -3373,14 +3373,14 @@ return Array.isArray(e)
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -3547,14 +3547,14 @@ return D.a.value === 1 &amp;&amp; D.a.enumerable === true &amp;&amp; D.a.configu
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -3716,14 +3716,14 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -3879,14 +3879,14 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">2/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20200517" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20211107" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20220502" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20220502" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20220719" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">2/2</td>
@@ -4050,14 +4050,14 @@ return &apos;hello&apos;.padStart(10) === &apos;     hello&apos;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -4221,14 +4221,14 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -4384,14 +4384,14 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">2/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20200517" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20211107" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20220502" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20220502" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20220719" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">2/2</td>
@@ -4550,14 +4550,14 @@ return typeof function f( a, b, ){} === &apos;function&apos;;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -4716,14 +4716,14 @@ return Math.min(1,2,3,) === 1;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -4879,14 +4879,14 @@ return Math.min(1,2,3,) === 1;
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0.25" style="background-color:hsl(30,75%,50%)">4/16</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0.5625" style="background-color:hsl(67,61%,50%)">9/16</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
-<td class="tally obsolete" data-browser="closure20200517" data-tally="0.6875" style="background-color:hsl(82,55%,50%)">11/16</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
 <td class="tally obsolete" data-browser="closure20211107" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
-<td class="tally" data-browser="closure20220502" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
+<td class="tally obsolete" data-browser="closure20220502" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
+<td class="tally" data-browser="closure20220719" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.5625" style="background-color:hsl(67,61%,50%)">9/16</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0.5625" style="background-color:hsl(67,61%,50%)">9/16</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0.5625" style="background-color:hsl(67,61%,50%)">9/16</td>
@@ -5056,14 +5056,14 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -5233,14 +5233,14 @@ p.catch(function(result) {
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -5400,14 +5400,14 @@ try { Function(&quot;async\n function a(){await 0}&quot;)(); } catch(e) { return
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -5567,14 +5567,14 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="no obsolete" data-browser="closure20200517">No</td>
 <td class="no obsolete" data-browser="closure20200614">No</td>
 <td class="no obsolete" data-browser="closure20200927">No</td>
 <td class="no obsolete" data-browser="closure20210808">No</td>
 <td class="no obsolete" data-browser="closure20210906">No</td>
 <td class="no obsolete" data-browser="closure20211006">No</td>
 <td class="no obsolete" data-browser="closure20211107">No</td>
-<td class="no" data-browser="closure20220502">No</td>
+<td class="no obsolete" data-browser="closure20220502">No</td>
+<td class="no" data-browser="closure20220719">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -5740,14 +5740,14 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -5915,14 +5915,14 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -6082,14 +6082,14 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -6254,14 +6254,14 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -6421,14 +6421,14 @@ try { Function(&quot;(async function a(b = await Promise.resolve()){}())&quot;)(
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="no obsolete" data-browser="closure20200517">No</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -6598,14 +6598,14 @@ p.then(function(result) {
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -6775,14 +6775,14 @@ p.then(function(result) {
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -6952,14 +6952,14 @@ var p = new C().a();
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -7127,14 +7127,14 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -7295,14 +7295,14 @@ return asyncFunctionProto !== function(){}.prototype
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="no obsolete" data-browser="closure20200517">No</td>
 <td class="no obsolete" data-browser="closure20200614">No</td>
 <td class="no obsolete" data-browser="closure20200927">No</td>
 <td class="no obsolete" data-browser="closure20210808">No</td>
 <td class="no obsolete" data-browser="closure20210906">No</td>
 <td class="no obsolete" data-browser="closure20211006">No</td>
 <td class="no obsolete" data-browser="closure20211107">No</td>
-<td class="no" data-browser="closure20220502">No</td>
+<td class="no obsolete" data-browser="closure20220502">No</td>
+<td class="no" data-browser="closure20220719">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -7461,14 +7461,14 @@ return Object.getPrototypeOf(async function (){})[Symbol.toStringTag] === &quot;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="no obsolete" data-browser="closure20200517">No</td>
 <td class="no obsolete" data-browser="closure20200614">No</td>
 <td class="no obsolete" data-browser="closure20200927">No</td>
 <td class="no obsolete" data-browser="closure20210808">No</td>
 <td class="no obsolete" data-browser="closure20210906">No</td>
 <td class="no obsolete" data-browser="closure20211006">No</td>
 <td class="no obsolete" data-browser="closure20211107">No</td>
-<td class="no" data-browser="closure20220502">No</td>
+<td class="no obsolete" data-browser="closure20220502">No</td>
+<td class="no" data-browser="closure20220719">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -7636,14 +7636,14 @@ p.then(function(result) {
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="no obsolete" data-browser="closure20200517">No</td>
 <td class="no obsolete" data-browser="closure20200614">No</td>
 <td class="no obsolete" data-browser="closure20200927">No</td>
 <td class="no obsolete" data-browser="closure20210808">No</td>
 <td class="no obsolete" data-browser="closure20210906">No</td>
 <td class="no obsolete" data-browser="closure20211006">No</td>
 <td class="no obsolete" data-browser="closure20211107">No</td>
-<td class="no" data-browser="closure20220502">No</td>
+<td class="no obsolete" data-browser="closure20220502">No</td>
+<td class="no" data-browser="closure20220719">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -7799,14 +7799,14 @@ p.then(function(result) {
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/17</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/17</td>
-<td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20211107" data-tally="0">0/17</td>
-<td class="tally" data-browser="closure20220502" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="closure20220502" data-tally="0">0/17</td>
+<td class="tally" data-browser="closure20220719" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/17</td>
@@ -7965,14 +7965,14 @@ return typeof SharedArrayBuffer === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -8131,14 +8131,14 @@ return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -8297,14 +8297,14 @@ return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -8463,14 +8463,14 @@ return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -8629,14 +8629,14 @@ return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuff
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -8795,14 +8795,14 @@ return typeof Atomics.add === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -8961,14 +8961,14 @@ return typeof Atomics.and === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -9127,14 +9127,14 @@ return typeof Atomics.compareExchange === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -9293,14 +9293,14 @@ return typeof Atomics.exchange === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -9459,14 +9459,14 @@ return typeof Atomics.wait === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -9625,14 +9625,14 @@ return typeof Atomics.notify === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -9791,14 +9791,14 @@ return typeof Atomics.isLockFree === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -9957,14 +9957,14 @@ return typeof Atomics.load === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -10123,14 +10123,14 @@ return typeof Atomics.or === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -10289,14 +10289,14 @@ return typeof Atomics.store === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -10455,14 +10455,14 @@ return typeof Atomics.sub === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -10621,14 +10621,14 @@ return typeof Atomics.xor === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -10792,14 +10792,14 @@ return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -10961,14 +10961,14 @@ return (function(){
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -11126,14 +11126,14 @@ return (function(){
 <td class="tally obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
-<td class="tally obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20210906" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20211006" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
-<td class="tally not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
+<td class="tally obsolete not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
+<td class="tally not-applicable" data-browser="closure20220719" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
@@ -11297,14 +11297,14 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210906" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211006" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20220719" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -11469,14 +11469,14 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210906" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211006" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20220719" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -11641,14 +11641,14 @@ return true;
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210906" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211006" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20220719" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -11812,14 +11812,14 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210906" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211006" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20220719" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -11984,14 +11984,14 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210906" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211006" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20220719" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -12156,14 +12156,14 @@ return true;
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210906" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211006" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20220719" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -12329,14 +12329,14 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210906" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211006" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20220719" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -12502,14 +12502,14 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210906" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211006" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20220719" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -12676,14 +12676,14 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210906" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211006" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20220719" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -12847,14 +12847,14 @@ return true;
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210906" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211006" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20220719" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -13017,14 +13017,14 @@ return b.__lookupGetter__(&quot;foo&quot;) === void undefined
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210906" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211006" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20220719" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -13190,14 +13190,14 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210906" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211006" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20220719" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -13363,14 +13363,14 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210906" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211006" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20220719" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -13537,14 +13537,14 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210906" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211006" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20220719" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -13708,14 +13708,14 @@ return true;
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210906" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211006" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20220719" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -13878,14 +13878,14 @@ return b.__lookupSetter__(&quot;foo&quot;) === void undefined
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210906" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211006" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20220719" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -14041,14 +14041,14 @@ return b.__lookupSetter__(&quot;foo&quot;) === void undefined
 <td class="tally obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
-<td class="tally obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20210906" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20211006" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
-<td class="tally not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
+<td class="tally obsolete not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
+<td class="tally not-applicable" data-browser="closure20220719" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
@@ -14211,14 +14211,14 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="unknown obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210906" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211006" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20220719" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -14381,14 +14381,14 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="unknown obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210906" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211006" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20220719" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -14556,14 +14556,14 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="unknown obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210906" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211006" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20220719" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -14731,14 +14731,14 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="unknown obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210906" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211006" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20220719" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -14898,14 +14898,14 @@ return i === 0;
 <td class="unknown obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210906" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211006" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20220719" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -15063,14 +15063,14 @@ return i === 0;
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">2/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20211107" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20220502" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20220502" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20220719" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">2/2</td>
@@ -15230,14 +15230,14 @@ return a === 1 &amp;&amp; rest.a === void undefined &amp;&amp; rest.b === 2 &amp
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="no obsolete" data-browser="closure20200517">No<a href="#closure-object-assign-note"><sup>[22]</sup></a></td>
 <td class="no obsolete" data-browser="closure20200614">No<a href="#closure-object-assign-note"><sup>[22]</sup></a></td>
 <td class="no obsolete" data-browser="closure20200927">No<a href="#closure-object-assign-note"><sup>[22]</sup></a></td>
 <td class="no obsolete" data-browser="closure20210808">No<a href="#closure-object-assign-note"><sup>[22]</sup></a></td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -15398,14 +15398,14 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="no obsolete" data-browser="closure20200517">No<a href="#closure-object-assign-note"><sup>[22]</sup></a></td>
 <td class="no obsolete" data-browser="closure20200614">No<a href="#closure-object-assign-note"><sup>[22]</sup></a></td>
 <td class="no obsolete" data-browser="closure20200927">No<a href="#closure-object-assign-note"><sup>[22]</sup></a></td>
 <td class="no obsolete" data-browser="closure20210808">No<a href="#closure-object-assign-note"><sup>[22]</sup></a></td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -15561,14 +15561,14 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">3/3</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="closure20200517" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20211107" data-tally="1">3/3</td>
-<td class="tally" data-browser="closure20220502" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="closure20220502" data-tally="1">3/3</td>
+<td class="tally" data-browser="closure20220719" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">3/3</td>
@@ -15753,14 +15753,14 @@ function check() {
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -15937,14 +15937,14 @@ function check() {
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -16123,14 +16123,14 @@ function check() {
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -16290,14 +16290,14 @@ return regex.test(&apos;foo\nbar&apos;);
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="no obsolete" data-browser="closure20200517">No</td>
 <td class="no obsolete" data-browser="closure20200614">No</td>
 <td class="no obsolete" data-browser="closure20200927">No</td>
 <td class="no obsolete" data-browser="closure20210808">No</td>
 <td class="no obsolete" data-browser="closure20210906">No</td>
 <td class="no obsolete" data-browser="closure20211006">No</td>
 <td class="no obsolete" data-browser="closure20211107">No</td>
-<td class="no" data-browser="closure20220502">No</td>
+<td class="no obsolete" data-browser="closure20220502">No</td>
+<td class="no" data-browser="closure20220719">No</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -16463,14 +16463,14 @@ return result.groups.year === &apos;2016&apos;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -16630,14 +16630,14 @@ return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&a
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="no" data-browser="babel7corejs3">No</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -16797,14 +16797,14 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -16960,14 +16960,14 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">2/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20200517" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20211107" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20220502" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20220502" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20220719" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">2/2</td>
@@ -17133,14 +17133,14 @@ iterator.next().then(function(step){
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -17316,14 +17316,14 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -17494,14 +17494,14 @@ return false;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -17667,14 +17667,14 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -17832,14 +17832,14 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/3</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="closure20200517" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20211107" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
-<td class="tally" data-browser="closure20220502" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally obsolete" data-browser="closure20220502" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally" data-browser="closure20220719" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/3</td>
@@ -17998,14 +17998,14 @@ return Symbol(&apos;foo&apos;).description === &apos;foo&apos;;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
@@ -18164,14 +18164,14 @@ return Symbol(&apos;&apos;).description === &apos;&apos;;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
@@ -18331,14 +18331,14 @@ return Symbol.prototype.hasOwnProperty(&apos;description&apos;)
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
@@ -18498,14 +18498,14 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
@@ -18661,14 +18661,14 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">4/4</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="closure20200517" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="closure20211107" data-tally="1">4/4</td>
-<td class="tally" data-browser="closure20220502" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="closure20220502" data-tally="1">4/4</td>
+<td class="tally" data-browser="closure20220719" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">4/4</td>
@@ -18827,14 +18827,14 @@ return &apos; \t \n abc   \t\n&apos;.trimLeft() === &apos;abc   \t\n&apos;;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -18993,14 +18993,14 @@ return &apos; \t \n abc   \t\n&apos;.trimRight() === &apos; \t \n abc&apos;;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -19159,14 +19159,14 @@ return &apos; \t \n abc   \t\n&apos;.trimStart() === &apos;abc   \t\n&apos;;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -19325,14 +19325,14 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -19488,14 +19488,14 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="closure20200517" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20211107" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
-<td class="tally" data-browser="closure20220502" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally obsolete" data-browser="closure20220502" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally" data-browser="closure20220719" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
@@ -19654,14 +19654,14 @@ return [1, [2, 3], [4, [5, 6]]].flat().join(&apos;&apos;) === &apos;12345,6&apos
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
@@ -19822,14 +19822,14 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -19989,14 +19989,14 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
@@ -20154,14 +20154,14 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">3/3</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="closure20200517" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20211107" data-tally="1">3/3</td>
-<td class="tally" data-browser="closure20220502" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="closure20220502" data-tally="1">3/3</td>
+<td class="tally" data-browser="closure20220719" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">3/3</td>
@@ -20326,14 +20326,14 @@ return false;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -20499,14 +20499,14 @@ return false;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -20676,14 +20676,14 @@ return it.throw().value;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -20839,14 +20839,14 @@ return it.throw().value;
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/7</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20211107" data-tally="0">0/7</td>
-<td class="tally" data-browser="closure20220502" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20220502" data-tally="0">0/7</td>
+<td class="tally" data-browser="closure20220719" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/7</td>
@@ -21007,14 +21007,14 @@ return fn + &apos;&apos; === str;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -21174,14 +21174,14 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -21341,14 +21341,14 @@ return NATIVE_EVAL_RE.test(eval + &apos;&apos;);
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -21508,14 +21508,14 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -21675,14 +21675,14 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -21842,14 +21842,14 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -22009,14 +22009,14 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -22172,14 +22172,14 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">2/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20200517" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20211107" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20220502" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20220502" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20220719" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
@@ -22338,14 +22338,14 @@ return eval(&quot;&apos;\u2028&apos;&quot;) === &quot;\u2028&quot;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -22504,14 +22504,14 @@ return eval(&quot;&apos;\u2029&apos;&quot;) === &quot;\u2029&quot;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -22671,14 +22671,14 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
@@ -22836,14 +22836,14 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20200517" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20211107" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20220502" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20220502" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20220719" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
@@ -23012,14 +23012,14 @@ return a === &apos;1a2b&apos;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -23183,14 +23183,14 @@ try {
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
@@ -23346,14 +23346,14 @@ try {
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/8</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20211107" data-tally="0">0/8</td>
-<td class="tally" data-browser="closure20220502" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="closure20220502" data-tally="0">0/8</td>
+<td class="tally" data-browser="closure20220719" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/8</td>
@@ -23512,14 +23512,14 @@ return (1n + 2n) === 3n;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -23678,14 +23678,14 @@ return BigInt(&quot;3&quot;) === 3n;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -23844,14 +23844,14 @@ return typeof BigInt.asUintN === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -24010,14 +24010,14 @@ return typeof BigInt.asIntN === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -24179,14 +24179,14 @@ return view[0] === -0x8000000000000000n;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -24348,14 +24348,14 @@ return view[0] === 0n;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -24517,14 +24517,14 @@ return view.getBigInt64(0) === 1n;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -24686,14 +24686,14 @@ return view.getBigUint64(0) === 1n;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -24863,14 +24863,14 @@ Promise.allSettled([
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
@@ -25026,14 +25026,14 @@ Promise.allSettled([
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20200517" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20211107" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20220502" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20220502" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20220719" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
@@ -25194,14 +25194,14 @@ return typeof globalThis === &apos;object&apos; &amp;&amp; globalThis &amp;&amp;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
@@ -25366,14 +25366,14 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
@@ -25529,14 +25529,14 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="closure20211107" data-tally="1">5/5</td>
-<td class="tally" data-browser="closure20220502" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="closure20220502" data-tally="1">5/5</td>
+<td class="tally" data-browser="closure20220719" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/5</td>
@@ -25697,14 +25697,14 @@ return foo?.baz === 42 &amp;&amp; bar?.baz === void undefined;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="no obsolete" data-browser="closure20200517">No</td>
 <td class="no obsolete" data-browser="closure20200614">No</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -25865,14 +25865,14 @@ return foo?.[&apos;baz&apos;] === 42 &amp;&amp; bar?.[&apos;baz&apos;] === void 
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="no obsolete" data-browser="closure20200517">No</td>
 <td class="no obsolete" data-browser="closure20200614">No</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -26033,14 +26033,14 @@ return foo?.baz() === 42 &amp;&amp; bar?.baz() === void undefined;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="no obsolete" data-browser="closure20200517">No</td>
 <td class="no obsolete" data-browser="closure20200614">No</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -26203,14 +26203,14 @@ return foo.baz?.() === 42 &amp;&amp; bar.baz?.() === void undefined &amp;&amp; b
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="no obsolete" data-browser="closure20200517">No</td>
 <td class="no obsolete" data-browser="closure20200614">No</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -26373,14 +26373,14 @@ return fn?.(...[], 1) === void undefined &amp;&amp; fn?.(...[], ...[]) === void 
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="no obsolete" data-browser="closure20200517">No</td>
 <td class="no obsolete" data-browser="closure20200614">No</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -26544,14 +26544,14 @@ return (null ?? 42) === 42 &amp;&amp;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -26712,14 +26712,14 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="no obsolete" data-browser="closure20200517">No</td>
 <td class="no obsolete" data-browser="closure20200614">No</td>
 <td class="no obsolete" data-browser="closure20200927">No</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
@@ -26875,14 +26875,14 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20211107" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20220502" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20220502" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20220719" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
@@ -27047,14 +27047,14 @@ Promise.any([
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="no obsolete" data-browser="closure20200517">No</td>
 <td class="no obsolete" data-browser="closure20200614">No</td>
 <td class="no obsolete" data-browser="closure20200927">No</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
@@ -27219,14 +27219,14 @@ Promise.any([
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="no obsolete" data-browser="closure20200517">No</td>
 <td class="no obsolete" data-browser="closure20200614">No</td>
 <td class="no obsolete" data-browser="closure20200927">No</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
@@ -27382,14 +27382,14 @@ Promise.any([
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20211107" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20220502" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20220502" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20220719" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
@@ -27550,14 +27550,14 @@ return weakref.deref() === O;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -27717,14 +27717,14 @@ return Object.getPrototypeOf(fr) === FinalizationRegistry.prototype;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -27880,14 +27880,14 @@ return Object.getPrototypeOf(fr) === FinalizationRegistry.prototype;
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">9/9</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">9/9</td>
-<td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="1">9/9</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="1">9/9</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="1">9/9</td>
 <td class="tally obsolete" data-browser="closure20211107" data-tally="1">9/9</td>
-<td class="tally" data-browser="closure20220502" data-tally="1">9/9</td>
+<td class="tally obsolete" data-browser="closure20220502" data-tally="1">9/9</td>
+<td class="tally" data-browser="closure20220719" data-tally="1">9/9</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/9</td>
@@ -28052,14 +28052,14 @@ return a === 2 &amp;&amp; b === 2 &amp;&amp; c === 1;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="no obsolete" data-browser="closure20200517">No</td>
 <td class="no obsolete" data-browser="closure20200614">No</td>
 <td class="no obsolete" data-browser="closure20200927">No</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -28221,14 +28221,14 @@ return a === 1 &amp;&amp; i === 1;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="no obsolete" data-browser="closure20200517">No</td>
 <td class="no obsolete" data-browser="closure20200614">No</td>
 <td class="no obsolete" data-browser="closure20200927">No</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -28390,14 +28390,14 @@ return i === 1;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="no obsolete" data-browser="closure20200517">No</td>
 <td class="no obsolete" data-browser="closure20200614">No</td>
 <td class="no obsolete" data-browser="closure20200927">No</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -28562,14 +28562,14 @@ return typeof a === &apos;undefined&apos; &amp;&amp; b === 0 &amp;&amp; c === 2;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="no obsolete" data-browser="closure20200517">No</td>
 <td class="no obsolete" data-browser="closure20200614">No</td>
 <td class="no obsolete" data-browser="closure20200927">No</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -28731,14 +28731,14 @@ return typeof a === &apos;undefined&apos; &amp;&amp; i === 1;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="no obsolete" data-browser="closure20200517">No</td>
 <td class="no obsolete" data-browser="closure20200614">No</td>
 <td class="no obsolete" data-browser="closure20200927">No</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -28900,14 +28900,14 @@ return i === 1;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="no obsolete" data-browser="closure20200517">No</td>
 <td class="no obsolete" data-browser="closure20200614">No</td>
 <td class="no obsolete" data-browser="closure20200927">No</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -29072,14 +29072,14 @@ return a === 2 &amp;&amp; b === 0 &amp;&amp; c === 1;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="no obsolete" data-browser="closure20200517">No</td>
 <td class="no obsolete" data-browser="closure20200614">No</td>
 <td class="no obsolete" data-browser="closure20200927">No</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -29241,14 +29241,14 @@ return a === 1 &amp;&amp; i === 1;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="no obsolete" data-browser="closure20200517">No</td>
 <td class="no obsolete" data-browser="closure20200614">No</td>
 <td class="no obsolete" data-browser="closure20200927">No</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -29410,14 +29410,14 @@ return i === 1;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="no obsolete" data-browser="closure20200517">No</td>
 <td class="no obsolete" data-browser="closure20200614">No</td>
 <td class="no obsolete" data-browser="closure20200927">No</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -29577,14 +29577,14 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="no obsolete" data-browser="closure20200517">No</td>
 <td class="no obsolete" data-browser="closure20200614">No</td>
 <td class="no obsolete" data-browser="closure20200927">No</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
 <td class="yes obsolete" data-browser="closure20211107">Yes</td>
-<td class="yes" data-browser="closure20220502">Yes</td>
+<td class="yes obsolete" data-browser="closure20220502">Yes</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -29742,14 +29742,14 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">6/6</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="closure20211107" data-tally="0">0/6</td>
-<td class="tally" data-browser="closure20220502" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="closure20220502" data-tally="0">0/6</td>
+<td class="tally" data-browser="closure20220719" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
@@ -29911,14 +29911,14 @@ return new C().x === &apos;x&apos;;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -30086,14 +30086,14 @@ return new C(42).x() === 42;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -30258,14 +30258,14 @@ return new C().x() === 42;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -30430,14 +30430,14 @@ return new C().x() === 42 &amp;&amp; new C().x(null) === void 0;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -30602,14 +30602,14 @@ return new C().x() === 42 &amp;&amp; new C().x(null) === void 0;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -30771,14 +30771,14 @@ return new C().x === 42;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -30934,14 +30934,14 @@ return new C().x === 42;
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20211107" data-tally="0">0/4</td>
-<td class="tally" data-browser="closure20220502" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="closure20220502" data-tally="0">0/4</td>
+<td class="tally" data-browser="closure20220719" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
@@ -31103,14 +31103,14 @@ return C.x === &apos;x&apos;;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -31269,14 +31269,14 @@ return (class X { static name = &quot;name&quot;; }).name === &apos;name&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -31441,14 +31441,14 @@ return new C().x() === 42;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -31610,14 +31610,14 @@ return C.x === 42;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -31773,14 +31773,14 @@ return C.x === 42;
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">4/4</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20211107" data-tally="0">0/4</td>
-<td class="tally" data-browser="closure20220502" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="closure20220502" data-tally="0">0/4</td>
+<td class="tally" data-browser="closure20220719" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/4</td>
@@ -31945,14 +31945,14 @@ return new C().x() === 42;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -32117,14 +32117,14 @@ return new C().x() === 42;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -32292,14 +32292,14 @@ return new C().x() === 42 &amp;&amp; y;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -32467,14 +32467,14 @@ return new C().x() === 42 &amp;&amp; y;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -32639,14 +32639,14 @@ return A.check(new A) &amp;&amp; !A.check({});
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -32802,14 +32802,14 @@ return A.check(new A) &amp;&amp; !A.check({});
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/3</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20211107" data-tally="0">0/3</td>
-<td class="tally" data-browser="closure20220502" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="closure20220502" data-tally="0">0/3</td>
+<td class="tally" data-browser="closure20220719" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/3</td>
@@ -32976,14 +32976,14 @@ return arr.at(0) === 1
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="no obsolete" data-browser="closure20200517">No</td>
 <td class="no obsolete" data-browser="closure20200614">No</td>
 <td class="no obsolete" data-browser="closure20200927">No</td>
 <td class="no obsolete" data-browser="closure20210808">No</td>
 <td class="no obsolete" data-browser="closure20210906">No</td>
 <td class="no obsolete" data-browser="closure20211006">No</td>
 <td class="no obsolete" data-browser="closure20211107">No</td>
-<td class="no" data-browser="closure20220502">No<a href="#closure-at-method-note"><sup>[37]</sup></a></td>
+<td class="no obsolete" data-browser="closure20220502">No<a href="#closure-at-method-note"><sup>[37]</sup></a></td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -33150,14 +33150,14 @@ return str.at(0) === &apos;a&apos;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="no obsolete" data-browser="closure20200517">No</td>
 <td class="no obsolete" data-browser="closure20200614">No</td>
 <td class="no obsolete" data-browser="closure20200927">No</td>
 <td class="no obsolete" data-browser="closure20210808">No</td>
 <td class="no obsolete" data-browser="closure20210906">No</td>
 <td class="no obsolete" data-browser="closure20211006">No</td>
 <td class="no obsolete" data-browser="closure20211107">No</td>
-<td class="no" data-browser="closure20220502">No<a href="#closure-at-method-note"><sup>[37]</sup></a></td>
+<td class="no obsolete" data-browser="closure20220502">No<a href="#closure-at-method-note"><sup>[37]</sup></a></td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -33340,14 +33340,14 @@ return [
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="no obsolete" data-browser="closure20200517">No</td>
 <td class="no obsolete" data-browser="closure20200614">No</td>
 <td class="no obsolete" data-browser="closure20200927">No</td>
 <td class="no obsolete" data-browser="closure20210808">No</td>
 <td class="no obsolete" data-browser="closure20210906">No</td>
 <td class="no obsolete" data-browser="closure20211006">No</td>
 <td class="no obsolete" data-browser="closure20211107">No</td>
-<td class="no" data-browser="closure20220502">No<a href="#closure-typed-array-note"><sup>[40]</sup></a></td>
+<td class="no obsolete" data-browser="closure20220502">No<a href="#closure-typed-array-note"><sup>[40]</sup></a></td>
+<td class="no" data-browser="closure20220719">No<a href="#closure-typed-array-note"><sup>[40]</sup></a></td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -33503,14 +33503,14 @@ return [
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20211107" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20220502" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20220502" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20220719" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
@@ -33669,14 +33669,14 @@ return Object.hasOwn({ x: 2 }, &quot;x&quot;) === true;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -33841,14 +33841,14 @@ try {
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="yes" data-browser="closure20220719">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -34011,14 +34011,14 @@ return ok;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -34174,14 +34174,14 @@ return ok;
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/16</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/16</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/16</td>
-<td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/16</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/16</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/16</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="0">0/16</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="0">0/16</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="0">0/16</td>
 <td class="tally obsolete" data-browser="closure20211107" data-tally="0">0/16</td>
-<td class="tally" data-browser="closure20220502" data-tally="0">0/16</td>
+<td class="tally obsolete" data-browser="closure20220502" data-tally="0">0/16</td>
+<td class="tally" data-browser="closure20220719" data-tally="0">0/16</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/16</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/16</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/16</td>
@@ -34341,14 +34341,14 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -34507,14 +34507,14 @@ return !(&apos;cause&apos; in Error.prototype);
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -34674,14 +34674,14 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -34840,14 +34840,14 @@ return !(&apos;cause&apos; in EvalError.prototype);
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -35007,14 +35007,14 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -35173,14 +35173,14 @@ return !(&apos;cause&apos; in RangeError.prototype);
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -35340,14 +35340,14 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -35506,14 +35506,14 @@ return !(&apos;cause&apos; in ReferenceError.prototype);
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -35673,14 +35673,14 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -35839,14 +35839,14 @@ return !(&apos;cause&apos; in SyntaxError.prototype);
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -36006,14 +36006,14 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -36172,14 +36172,14 @@ return !(&apos;cause&apos; in TypeError.prototype);
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -36339,14 +36339,14 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -36505,14 +36505,14 @@ return !(&apos;cause&apos; in URIError.prototype);
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -36672,14 +36672,14 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -36838,14 +36838,14 @@ return !(&apos;cause&apos; in AggregateError.prototype);
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -37001,14 +37001,14 @@ return !(&apos;cause&apos; in AggregateError.prototype);
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20211107" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20220502" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20220502" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20220719" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
@@ -37167,14 +37167,14 @@ return new RegExp(&apos;a&apos;, &apos;d&apos;) instanceof RegExp;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -37348,14 +37348,14 @@ return true;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -134,14 +134,14 @@
 <th class="platform babel6corejs2 compiler obsolete" data-browser="babel6corejs2"><a href="#babel6corejs2" class="browser-name"><abbr title="Babel 6.5 + core-js 2.5">Babel 6 +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform babel7corejs2 compiler obsolete" data-browser="babel7corejs2"><a href="#babel7corejs2" class="browser-name"><abbr title="Babel 7 + core-js 2.5">Babel 7 +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform babel7corejs3 compiler" data-browser="babel7corejs3"><a href="#babel7corejs3" class="browser-name"><abbr title="Babel 7 + core-js 3">Babel 7 +<br><nobr>core-js 3</nobr></abbr></a></th>
-<th class="platform closure20200517 compiler obsolete" data-browser="closure20200517"><a href="#closure20200517" class="browser-name"><abbr title="Closure Compiler &gt;=v20200517 &lt;v20200614">Closure 2020.05</abbr></a></th>
 <th class="platform closure20200614 compiler obsolete" data-browser="closure20200614"><a href="#closure20200614" class="browser-name"><abbr title="Closure Compiler &gt;=v20200614 &lt;v20200927">Closure 2020.06</abbr></a></th>
 <th class="platform closure20200927 compiler obsolete" data-browser="closure20200927"><a href="#closure20200927" class="browser-name"><abbr title="Closure Compiler &gt;=v20200927 &lt;v20210808">Closure 2020.09</abbr></a></th>
 <th class="platform closure20210808 compiler obsolete" data-browser="closure20210808"><a href="#closure20210808" class="browser-name"><abbr title="Closure Compiler v20210808">Closure 2021.08</abbr></a></th>
 <th class="platform closure20210906 compiler obsolete" data-browser="closure20210906"><a href="#closure20210906" class="browser-name"><abbr title="Closure Compiler v20210906">Closure 2021.09</abbr></a></th>
 <th class="platform closure20211006 compiler obsolete" data-browser="closure20211006"><a href="#closure20211006" class="browser-name"><abbr title="Closure Compiler v20211006">Closure 2021.10</abbr></a></th>
 <th class="platform closure20211107 compiler obsolete" data-browser="closure20211107"><a href="#closure20211107" class="browser-name"><abbr title="Closure Compiler &gt;=v20211107">Closure 2021.11</abbr></a></th>
-<th class="platform closure20220502 compiler" data-browser="closure20220502"><a href="#closure20220502" class="browser-name"><abbr title="Closure Compiler &gt;=v20220502">Closure 2022.05</abbr></a></th>
+<th class="platform closure20220502 compiler obsolete" data-browser="closure20220502"><a href="#closure20220502" class="browser-name"><abbr title="Closure Compiler &gt;=v20220502">Closure 2022.05</abbr></a></th>
+<th class="platform closure20220719 compiler" data-browser="closure20220719"><a href="#closure20220719" class="browser-name"><abbr title="Closure Compiler &gt;=v20220719">Closure 2022.07</abbr></a></th>
 <th class="platform typescript1corejs2 compiler obsolete" data-browser="typescript1corejs2"><a href="#typescript1corejs2" class="browser-name"><abbr title="TypeScript 1.8 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform typescript2_9corejs2 compiler obsolete" data-browser="typescript2_9corejs2"><a href="#typescript2_9corejs2" class="browser-name"><abbr title="TypeScript 2.9 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform typescript3_2corejs2 compiler obsolete" data-browser="typescript3_2corejs2"><a href="#typescript3_2corejs2" class="browser-name"><abbr title="TypeScript 3.2 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
@@ -304,14 +304,14 @@ return typeof Realm === &quot;function&quot;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -462,14 +462,14 @@ return typeof Realm === &quot;function&quot;
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20211107" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20220502" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20220502" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20220719" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
@@ -629,14 +629,14 @@ return RegExp.lastMatch === 'x';
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -798,14 +798,14 @@ return true;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -963,14 +963,14 @@ try {
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="no" data-browser="babel7corejs3">No</td>
-<td class="no obsolete" data-browser="closure20200517">No</td>
 <td class="no obsolete" data-browser="closure20200614">No</td>
 <td class="no obsolete" data-browser="closure20200927">No</td>
 <td class="no obsolete" data-browser="closure20210808">No</td>
 <td class="no obsolete" data-browser="closure20210906">No</td>
 <td class="no obsolete" data-browser="closure20211006">No</td>
 <td class="no obsolete" data-browser="closure20211107">No</td>
-<td class="no" data-browser="closure20220502">No</td>
+<td class="no obsolete" data-browser="closure20220502">No</td>
+<td class="no" data-browser="closure20220719">No</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -1121,14 +1121,14 @@ try {
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20211107" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20220502" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20220502" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20220719" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
@@ -1283,14 +1283,14 @@ return arr.findLast(function (o) { return o.x === 1; }) === arr[2];
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -1445,14 +1445,14 @@ return arr.findLastIndex(function (o) { return o.x === 1; }) === 2;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -1614,14 +1614,14 @@ return result === &apos;tromple&apos;;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -1772,14 +1772,14 @@ return result === &apos;tromple&apos;;
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/1</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/1</td>
-<td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20211107" data-tally="0">0/1</td>
-<td class="tally" data-browser="closure20220502" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="closure20220502" data-tally="0">0/1</td>
+<td class="tally" data-browser="closure20220719" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">1/1</td>
@@ -1941,14 +1941,14 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="no obsolete" data-browser="babel6corejs2">No<a href="#babel-decorators-legacy-note"><sup>[7]</sup></a></td>
 <td class="no obsolete" data-browser="babel7corejs2">No<a href="#babel-decorators-legacy-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="babel7corejs3">No<a href="#babel-decorators-legacy-note"><sup>[7]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -2099,14 +2099,14 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">4/4</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20211107" data-tally="0">0/4</td>
-<td class="tally" data-browser="closure20220502" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="closure20220502" data-tally="0">0/4</td>
+<td class="tally" data-browser="closure20220719" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/4</td>
@@ -2266,14 +2266,14 @@ try {
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -2437,14 +2437,14 @@ try {
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -2603,14 +2603,14 @@ try {
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -2769,14 +2769,14 @@ try {
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -2927,14 +2927,14 @@ try {
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/7</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20211107" data-tally="0">0/7</td>
-<td class="tally" data-browser="closure20220502" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20220502" data-tally="0">0/7</td>
+<td class="tally" data-browser="closure20220719" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/7</td>
@@ -3091,14 +3091,14 @@ return set.size === 2
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -3256,14 +3256,14 @@ return set.size === 3
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -3420,14 +3420,14 @@ return set.size === 2
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -3584,14 +3584,14 @@ return set.size === 2
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -3745,14 +3745,14 @@ return new Set([1, 2, 3]).isDisjointFrom([4, 5, 6]);
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -3906,14 +3906,14 @@ return new Set([1, 2, 3]).isSubsetOf([5, 4, 3, 2, 1]);
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -4067,14 +4067,14 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -4225,14 +4225,14 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20211107" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20220502" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20220502" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20220719" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
@@ -4389,14 +4389,14 @@ return buffer1.byteLength === 0
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -4553,14 +4553,14 @@ return buffer1.byteLength === 0
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -4711,14 +4711,14 @@ return buffer1.byteLength === 0
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20211107" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20220502" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20220502" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20220719" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
@@ -4875,14 +4875,14 @@ return Array.from(map).join() === &apos;a,2,b,3&apos;;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -5040,14 +5040,14 @@ return map.get(a) === 2 &amp;&amp; map.get(b) === 3;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -5202,14 +5202,14 @@ return !Array.isTemplateObject([])
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -5360,14 +5360,14 @@ return !Array.isTemplateObject([])
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/35</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">35/35</td>
-<td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="closure20211107" data-tally="0">0/35</td>
-<td class="tally" data-browser="closure20220502" data-tally="0">0/35</td>
+<td class="tally obsolete" data-browser="closure20220502" data-tally="0">0/35</td>
+<td class="tally" data-browser="closure20220719" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/35</td>
@@ -5521,14 +5521,14 @@ return [1, 2, 3].values() instanceof Iterator;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -5684,14 +5684,14 @@ return instance[Symbol.iterator]() === instance;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -5848,14 +5848,14 @@ return &apos;next&apos; in iterator
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -6017,14 +6017,14 @@ return &apos;next&apos; in iterator
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -6178,14 +6178,14 @@ return Array.from([1, 2, 3].values().asIndexedPairs()).join() === &apos;0,1,1,2,
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -6339,14 +6339,14 @@ return Array.from([1, 2, 3].values().drop(1)).join() === &apos;2,3&apos;;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -6500,14 +6500,14 @@ return [1, 2, 3].values().every(it =&gt; typeof it === &apos;number&apos;);
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -6661,14 +6661,14 @@ return Array.from([1, 2, 3].values().filter(it =&gt; it % 2)).join() === &apos;1
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -6822,14 +6822,14 @@ return [1, 2, 3].values().find(it =&gt; it % 2) === 1;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -6983,14 +6983,14 @@ return Array.from([1, 2, 3].values().flatMap(it =&gt; [it, 0])).join() === &apos
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -7146,14 +7146,14 @@ return result === &apos;123&apos;;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -7307,14 +7307,14 @@ return Array.from([1, 2, 3].values().map(it =&gt; it * it)).join() === &apos;1,4
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -7468,14 +7468,14 @@ return [1, 2, 3].values().reduce((a, b) =&gt; a + b) === 6;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -7629,14 +7629,14 @@ return [1, 2, 3].values().some(it =&gt; typeof it === &apos;number&apos;);
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -7790,14 +7790,14 @@ return Array.from([1, 2, 3].values().take(2)).join() === &apos;1,2&apos;;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -7952,14 +7952,14 @@ return Array.isArray(array) &amp;&amp; array.join() === &apos;1,2,3&apos;;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -8113,14 +8113,14 @@ return Iterator.prototype[Symbol.toStringTag] === &apos;Iterator&apos;;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -8274,14 +8274,14 @@ return (async function*() {})() instanceof AsyncIterator;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -8437,14 +8437,14 @@ return instance[Symbol.asyncIterator]() === instance;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -8610,14 +8610,14 @@ toArray(iterator).then(it =&gt; {
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -8783,14 +8783,14 @@ toArray(iterator).then(it =&gt; {
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -8956,14 +8956,14 @@ toArray(iterator).then(it =&gt; {
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -9125,14 +9125,14 @@ toArray((async function*() { yield * [1, 2, 3] })().asIndexedPairs()).then(it =&
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -9294,14 +9294,14 @@ toArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it =&gt; {
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -9457,14 +9457,14 @@ toArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it =&gt; {
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -9626,14 +9626,14 @@ toArray(async function*() { yield * [1, 2, 3] }().filter(it =&gt; it % 2)).then(
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -9789,14 +9789,14 @@ toArray(async function*() { yield * [1, 2, 3] }().filter(it =&gt; it % 2)).then(
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -9958,14 +9958,14 @@ toArray(async function*() { yield * [1, 2, 3] }().flatMap(it =&gt; [it, 0])).the
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -10122,14 +10122,14 @@ let result = &apos;&apos;;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -10291,14 +10291,14 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -10454,14 +10454,14 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -10617,14 +10617,14 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -10786,14 +10786,14 @@ toArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it =&gt; {
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -10949,14 +10949,14 @@ toArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it =&gt; {
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -11110,14 +11110,14 @@ return AsyncIterator.prototype[Symbol.toStringTag] === &apos;AsyncIterator&apos;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
 <td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown" data-browser="closure20220719">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>


### PR DESCRIPTION
- support `(String|Array).prototype.at()`
- support `Object.hasOwn()`

https://github.com/google/closure-compiler/wiki/Releases#july-19th-2022-v20220719