### PR TITLE
Change Hermes to React native

### DIFF
--- a/data-es2016plus.js
+++ b/data-es2016plus.js
@@ -675,6 +675,7 @@ exports.tests = [
           graalvm19: true,
           hermes0_7_0: false,
           hermes0_12_0: true,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -916,6 +917,7 @@ exports.tests = [
           jerryscript2_3_0: true,
           graalvm19: true,
           hermes0_7_0: false,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -955,6 +957,7 @@ exports.tests = [
           jerryscript2_3_0: true,
           graalvm19: true,
           hermes0_7_0: false,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -990,6 +993,7 @@ exports.tests = [
           jerryscript2_3_0: true,
           graalvm19: true,
           hermes0_7_0: false,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -1021,6 +1025,7 @@ exports.tests = [
           graalvm19: true,
           hermes0_7_0: false,
           hermes0_12_0: true,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -1049,6 +1054,7 @@ exports.tests = [
           graalvm19: true,
           hermes0_7_0: false,
           hermes0_12_0: true,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -1087,6 +1093,7 @@ exports.tests = [
           graalvm19: true,
           hermes0_7_0: false,
           hermes0_12_0: true,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       }
@@ -2768,6 +2775,7 @@ exports.tests = [
       jerryscript2_3_0: false,
       graalvm19: true,
       hermes0_7_0: true,
+      reactnative0_70_3: false,
       rhino1_7_13: true
     }
   },
@@ -3210,6 +3218,7 @@ exports.tests = [
       jerryscript2_3_0: false,
       graalvm19: true,
       hermes0_7_0: false,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }
   },

--- a/data-es6.js
+++ b/data-es6.js
@@ -464,6 +464,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -505,6 +506,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -614,6 +616,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -765,6 +768,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -800,6 +804,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -835,6 +840,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -945,6 +951,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -1100,6 +1107,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -1136,6 +1144,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -1172,6 +1181,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -1291,6 +1301,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -1404,6 +1415,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -1480,6 +1492,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -1590,6 +1603,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -1706,6 +1720,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -1784,6 +1799,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2038,6 +2054,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2144,6 +2161,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2770,6 +2788,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2807,6 +2826,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2839,6 +2859,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2871,6 +2892,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2907,6 +2929,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2943,6 +2966,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2979,6 +3003,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3015,6 +3040,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3055,6 +3081,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3091,6 +3118,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3127,6 +3155,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3165,6 +3194,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3201,6 +3231,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3239,6 +3270,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3275,6 +3307,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3311,6 +3344,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3375,6 +3409,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3441,6 +3476,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3487,6 +3523,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3528,6 +3565,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3563,6 +3601,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3600,6 +3639,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -3648,6 +3688,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3686,6 +3727,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3725,6 +3767,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3763,6 +3806,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3803,6 +3847,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3836,6 +3881,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3878,6 +3924,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3920,6 +3967,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -5600,6 +5648,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -5684,6 +5733,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -5725,6 +5775,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -5767,6 +5818,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -5803,6 +5855,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -6201,6 +6254,7 @@ exports.tests = [
         jerryscript2_2_0: true,
         hermes0_7_0: false,
         hermes0_12_0: true,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -6282,6 +6336,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: false,
         rhino1_7_13: false,
         rhino1_7_14: true,
       }
@@ -6368,6 +6423,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false,
         rhino1_7_14: true,
       }
@@ -11618,6 +11674,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -13917,6 +13974,7 @@ exports.tests = [
     jerryscript2_0: false,
     jerryscript2_3_0: true,
     hermes0_7_0: false,
+    reactnative0_70_3: true,
     rhino1_7_13: false
   }
 },
@@ -14569,6 +14627,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.catchDestructuring,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -16288,6 +16347,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -17740,6 +17800,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -17767,6 +17828,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -17798,6 +17860,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -17858,6 +17921,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -17887,6 +17951,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -22130,6 +22195,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -22161,6 +22227,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -22218,6 +22285,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -22390,6 +22458,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -22420,6 +22489,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -22458,6 +22528,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -22519,6 +22590,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -22549,6 +22621,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -22585,6 +22658,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -22643,6 +22717,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -22671,6 +22746,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -22699,6 +22775,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -22784,6 +22861,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -22814,6 +22892,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -22934,6 +23013,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -22964,6 +23044,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -22996,6 +23077,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -23026,6 +23108,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -23059,6 +23142,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -23093,6 +23177,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }

--- a/environments.json
+++ b/environments.json
@@ -5307,6 +5307,14 @@
     "short": "Hermes 0.12.0",
     "platformtype": "engine",
     "release": "2022-08-24",
+    "obsolete": true 
+  },
+  "reactnative0_70_3": {
+    "full": "Reactnative 0.70.3",
+    "family": "Hermes",
+    "short": "Reactnative 0.70.3",
+    "platformtype": "mobile",
+    "release": "2022-10-25",
     "obsolete": false
   },
   "deno1_0": {

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -251,7 +251,8 @@
 <th class="platform graalvm21_3_3 engine" data-browser="graalvm21_3_3"><a href="#graalvm21_3_3" class="browser-name"><abbr title="GraalVM JavaScript 21.3.3">GraalVM 21.3.3</abbr></a><a href="#graalvm-js-intl-mode-note"><sup>[4]</sup></a></th>
 <th class="platform graalvm22_2 engine" data-browser="graalvm22_2"><a href="#graalvm22_2" class="browser-name"><abbr title="GraalVM JavaScript 22.2.0">GraalVM 22.2.0</abbr></a><a href="#graalvm-js-intl-mode-note"><sup>[4]</sup></a></th>
 <th class="platform hermes0_7_0 engine obsolete" data-browser="hermes0_7_0"><a href="#hermes0_7_0" class="browser-name"><abbr title="Hermes 0.7.0">Hermes 0.7.0</abbr></a></th>
-<th class="platform hermes0_12_0 engine" data-browser="hermes0_12_0"><a href="#hermes0_12_0" class="browser-name"><abbr title="Hermes 0.12.0">Hermes 0.12.0</abbr></a></th>
+<th class="platform hermes0_12_0 engine obsolete" data-browser="hermes0_12_0"><a href="#hermes0_12_0" class="browser-name"><abbr title="Hermes 0.12.0">Hermes 0.12.0</abbr></a></th>
+<th class="platform reactnative0_70_3 mobile" data-browser="reactnative0_70_3"><a href="#reactnative0_70_3" class="browser-name"><abbr title="Reactnative 0.70.3">Reactnative 0.70.3</abbr></a></th>
 <th class="platform deno1_19 engine obsolete" data-browser="deno1_19"><a href="#deno1_19" class="browser-name"><abbr title="Deno">Deno 1.19</abbr></a></th>
 <th class="platform deno1_20 engine obsolete" data-browser="deno1_20"><a href="#deno1_20" class="browser-name"><abbr title="Deno">Deno 1.20</abbr></a></th>
 <th class="platform deno1_21 engine obsolete" data-browser="deno1_21"><a href="#deno1_21" class="browser-name"><abbr title="Deno">Deno 1.21</abbr></a></th>
@@ -285,7 +286,7 @@
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr class="category"><td colspan="159"><span>2016 features</span></td>
+      <tr class="category"><td colspan="160"><span>2016 features</span></td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-exponentiation_(**)_operator"><span><a class="anchor" href="#test-exponentiation_(**)_operator">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-exp-operator">exponentiation (**) operator</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Exponentiation_(**)" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -415,7 +416,8 @@
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">3/3</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="hermes0_7_0" data-tally="1">3/3</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="1">3/3</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">3/3</td>
@@ -576,7 +578,8 @@ return 2 ** 3 === 8 &amp;&amp; -(5 ** 2) === -25 &amp;&amp; (-5) ** 2 === 25;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -737,7 +740,8 @@ var a = 2; a **= 3; return a === 8;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -903,7 +907,8 @@ return true;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -1061,7 +1066,8 @@ return true;
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">4/4</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="hermes0_7_0" data-tally="1">4/4</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="1">4/4</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">4/4</td>
@@ -1225,7 +1231,8 @@ return [1, 2, 3].includes(1)
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -1387,7 +1394,8 @@ return [,].includes()
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -1570,7 +1578,8 @@ return 24;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -1736,7 +1745,8 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -1766,7 +1776,7 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
 </tr>
-<tr class="category"><td colspan="159"><span>2016 misc</span></td>
+<tr class="category"><td colspan="160"><span>2016 misc</span></td>
 </tr>
 <tr significance="0.125"><td id="test-generator_functions_can&apos;t_be_used_with_new"><span><a class="anchor" href="#test-generator_functions_can&apos;t_be_used_with_new">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-createdynamicfunction">generator functions can&apos;t be used with &quot;new&quot;</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*#Generators_are_not_constructable" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;<a href="#new-gen-fn-note"><sup>[7]</sup></a></span><script data-source="
 function * generator() {
@@ -1906,7 +1916,8 @@ return true;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -2080,7 +2091,8 @@ return iter[&apos;throw&apos;]().value === &apos;bar&apos;;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -2246,7 +2258,8 @@ return true;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -2408,7 +2421,8 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -2571,7 +2585,8 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -2739,7 +2754,8 @@ return passed;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -2909,7 +2925,8 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -2939,7 +2956,7 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
 </tr>
-<tr class="category"><td colspan="159"><span>2017 features</span></td>
+<tr class="category"><td colspan="160"><span>2017 features</span></td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-Object_static_methods"><span><a class="anchor" href="#test-Object_static_methods">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-properties-of-the-object-constructor">Object static methods</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/4</td>
@@ -3069,7 +3086,8 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">4/4</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="hermes0_7_0" data-tally="1">4/4</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="1">4/4</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">4/4</td>
@@ -3233,7 +3251,8 @@ return Array.isArray(v) &amp;&amp; String(v) === &quot;foo,bar,baz&quot;;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -3401,7 +3420,8 @@ return Array.isArray(e)
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -3570,7 +3590,8 @@ return D.a.value === 1 &amp;&amp; D.a.enumerable === true &amp;&amp; D.a.configu
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -3734,7 +3755,8 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -3892,7 +3914,8 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">2/2</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="hermes0_7_0" data-tally="1">2/2</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="1">2/2</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">2/2</td>
@@ -4058,7 +4081,8 @@ return &apos;hello&apos;.padStart(10) === &apos;     hello&apos;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -4224,7 +4248,8 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -4382,7 +4407,8 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">2/2</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="hermes0_7_0" data-tally="1">2/2</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="1">2/2</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">2/2</td>
@@ -4543,7 +4569,8 @@ return typeof function f( a, b, ){} === &apos;function&apos;;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -4704,7 +4731,8 @@ return Math.min(1,2,3,) === 1;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -4862,7 +4890,8 @@ return Math.min(1,2,3,) === 1;
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">16/16</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="hermes0_7_0" data-tally="0">0/16</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0.1875" style="background-color:hsl(22,77%,50%)">3/16</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">16/16</td>
@@ -5034,7 +5063,8 @@ p.then(function(result) {
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -5206,7 +5236,8 @@ p.catch(function(result) {
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -5368,7 +5399,8 @@ try { Function(&quot;async\n function a(){await 0}&quot;)(); } catch(e) { return
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -5530,7 +5562,8 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -5698,7 +5731,8 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -5868,7 +5902,8 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -6030,7 +6065,8 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -6197,7 +6233,8 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -6359,7 +6396,8 @@ try { Function(&quot;(async function a(b = await Promise.resolve()){}())&quot;)(
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="hermes0_12_0">No</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -6531,7 +6569,8 @@ p.then(function(result) {
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -6703,7 +6742,8 @@ p.then(function(result) {
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="hermes0_12_0">No</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -6875,7 +6915,8 @@ var p = new C().a();
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="hermes0_12_0">No</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -7045,7 +7086,8 @@ p.then(function(result) {
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="hermes0_12_0">No</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -7208,7 +7250,8 @@ return asyncFunctionProto !== function(){}.prototype
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -7369,7 +7412,8 @@ return Object.getPrototypeOf(async function (){})[Symbol.toStringTag] === &quot;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -7539,7 +7583,8 @@ p.then(function(result) {
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -7697,7 +7742,8 @@ p.then(function(result) {
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">17/17</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">17/17</td>
 <td class="tally obsolete" data-browser="hermes0_7_0" data-tally="0">0/17</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="0">0/17</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">17/17</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">17/17</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">17/17</td>
@@ -7858,7 +7904,8 @@ return typeof SharedArrayBuffer === &apos;function&apos;;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="hermes0_12_0">No</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -8019,7 +8066,8 @@ return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="hermes0_12_0">No</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -8180,7 +8228,8 @@ return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="hermes0_12_0">No</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -8341,7 +8390,8 @@ return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="hermes0_12_0">No</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -8502,7 +8552,8 @@ return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuff
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="hermes0_12_0">No</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -8663,7 +8714,8 @@ return typeof Atomics.add === &apos;function&apos;;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="hermes0_12_0">No</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -8824,7 +8876,8 @@ return typeof Atomics.and === &apos;function&apos;;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="hermes0_12_0">No</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -8985,7 +9038,8 @@ return typeof Atomics.compareExchange === &apos;function&apos;;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="hermes0_12_0">No</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -9146,7 +9200,8 @@ return typeof Atomics.exchange === &apos;function&apos;;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="hermes0_12_0">No</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -9307,7 +9362,8 @@ return typeof Atomics.wait === &apos;function&apos;;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="hermes0_12_0">No</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -9468,7 +9524,8 @@ return typeof Atomics.notify === &apos;function&apos;;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="hermes0_12_0">No</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -9629,7 +9686,8 @@ return typeof Atomics.isLockFree === &apos;function&apos;;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="hermes0_12_0">No</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -9790,7 +9848,8 @@ return typeof Atomics.load === &apos;function&apos;;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="hermes0_12_0">No</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -9951,7 +10010,8 @@ return typeof Atomics.or === &apos;function&apos;;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="hermes0_12_0">No</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -10112,7 +10172,8 @@ return typeof Atomics.store === &apos;function&apos;;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="hermes0_12_0">No</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -10273,7 +10334,8 @@ return typeof Atomics.sub === &apos;function&apos;;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="hermes0_12_0">No</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -10434,7 +10496,8 @@ return typeof Atomics.xor === &apos;function&apos;;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="hermes0_12_0">No</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -10464,7 +10527,7 @@ return typeof Atomics.xor === &apos;function&apos;;
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
 </tr>
-<tr class="category"><td colspan="159"><span>2017 misc</span></td>
+<tr class="category"><td colspan="160"><span>2017 misc</span></td>
 </tr>
 <tr significance="0.125"><td id="test-RegExp_u_flag,_case_folding"><span><a class="anchor" href="#test-RegExp_u_flag,_case_folding">&#xA7;</a><a href="https://github.com/tc39/ecma262/pull/525">RegExp &quot;u&quot; flag, case folding</a></span><script data-source="
 return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/\W/iu)
@@ -10600,7 +10663,8 @@ return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="hermes0_12_0">No</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -10764,7 +10828,8 @@ return (function(){
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="hermes0_12_0">No</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -10794,7 +10859,7 @@ return (function(){
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
 </tr>
-<tr class="category"><td colspan="159"><span>2017 annex b</span></td>
+<tr class="category"><td colspan="160"><span>2017 annex b</span></td>
 </tr>
 <tr class="supertest optional-feature" significance="0.125"><td id="test-Object.prototype_getter/setter_methods"><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-object.prototype.__defineGetter__">Object.prototype getter/setter methods</a></span></td>
 <td class="tally obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
@@ -10924,7 +10989,8 @@ return (function(){
 <td class="tally not-applicable" data-browser="graalvm21_3_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally not-applicable" data-browser="graalvm22_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally obsolete not-applicable" data-browser="hermes0_7_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
-<td class="tally not-applicable" data-browser="hermes0_12_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
+<td class="tally obsolete not-applicable" data-browser="hermes0_12_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="deno1_19" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally obsolete not-applicable" data-browser="deno1_20" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally obsolete not-applicable" data-browser="deno1_21" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
@@ -11090,7 +11156,8 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes not-applicable" data-browser="graalvm21_3_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="graalvm22_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="hermes0_7_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="hermes0_12_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="hermes0_12_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_19" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_20" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_21" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -11257,7 +11324,8 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes not-applicable" data-browser="graalvm21_3_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="graalvm22_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="hermes0_7_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="hermes0_12_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="hermes0_12_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_19" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_20" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_21" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -11424,7 +11492,8 @@ return true;
 <td class="yes not-applicable" data-browser="graalvm21_3_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="graalvm22_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="hermes0_7_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="hermes0_12_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="hermes0_12_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_19" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_20" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_21" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -11590,7 +11659,8 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes not-applicable" data-browser="graalvm21_3_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="graalvm22_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="hermes0_7_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="hermes0_12_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="hermes0_12_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_19" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_20" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_21" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -11757,7 +11827,8 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes not-applicable" data-browser="graalvm21_3_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="graalvm22_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="hermes0_7_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="hermes0_12_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="hermes0_12_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_19" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_20" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_21" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -11924,7 +11995,8 @@ return true;
 <td class="yes not-applicable" data-browser="graalvm21_3_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="graalvm22_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="hermes0_7_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="hermes0_12_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="hermes0_12_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_19" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_20" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_21" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -12092,7 +12164,8 @@ return foo() === &quot;bar&quot;
 <td class="yes not-applicable" data-browser="graalvm21_3_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="graalvm22_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="hermes0_7_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="hermes0_12_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="hermes0_12_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_19" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_20" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_21" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -12260,7 +12333,8 @@ return foo() === &quot;bar&quot;
 <td class="yes not-applicable" data-browser="graalvm21_3_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="graalvm22_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="hermes0_7_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="hermes0_12_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="hermes0_12_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_19" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_20" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_21" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -12429,7 +12503,8 @@ return foo() === &quot;bar&quot;
 <td class="yes not-applicable" data-browser="graalvm21_3_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="graalvm22_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="hermes0_7_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="hermes0_12_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="hermes0_12_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_19" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_20" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_21" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -12595,7 +12670,8 @@ return true;
 <td class="yes not-applicable" data-browser="graalvm21_3_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="graalvm22_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="hermes0_7_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="hermes0_12_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="hermes0_12_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_19" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_20" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_21" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -12760,7 +12836,8 @@ return b.__lookupGetter__(&quot;foo&quot;) === void undefined
 <td class="yes not-applicable" data-browser="graalvm21_3_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="graalvm22_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="hermes0_7_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="hermes0_12_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="hermes0_12_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_19" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_20" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_21" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -12928,7 +13005,8 @@ return foo() === &quot;bar&quot;
 <td class="yes not-applicable" data-browser="graalvm21_3_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="graalvm22_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="hermes0_7_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="hermes0_12_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="hermes0_12_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_19" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_20" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_21" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -13096,7 +13174,8 @@ return foo() === &quot;bar&quot;
 <td class="yes not-applicable" data-browser="graalvm21_3_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="graalvm22_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="hermes0_7_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="hermes0_12_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="hermes0_12_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_19" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_20" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_21" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -13265,7 +13344,8 @@ return foo() === &quot;bar&quot;
 <td class="yes not-applicable" data-browser="graalvm21_3_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="graalvm22_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="hermes0_7_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="hermes0_12_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="hermes0_12_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_19" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_20" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_21" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -13431,7 +13511,8 @@ return true;
 <td class="yes not-applicable" data-browser="graalvm21_3_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="graalvm22_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="hermes0_7_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="hermes0_12_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="hermes0_12_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_19" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_20" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_21" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -13596,7 +13677,8 @@ return b.__lookupSetter__(&quot;foo&quot;) === void undefined
 <td class="yes not-applicable" data-browser="graalvm21_3_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="graalvm22_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="hermes0_7_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="hermes0_12_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="hermes0_12_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_19" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_20" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_21" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -13754,7 +13836,8 @@ return b.__lookupSetter__(&quot;foo&quot;) === void undefined
 <td class="tally not-applicable" data-browser="graalvm21_3_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">4/4</td>
 <td class="tally not-applicable" data-browser="graalvm22_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">4/4</td>
 <td class="tally obsolete not-applicable" data-browser="hermes0_7_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">4/4</td>
-<td class="tally not-applicable" data-browser="hermes0_12_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">4/4</td>
+<td class="tally obsolete not-applicable" data-browser="hermes0_12_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">4/4</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="deno1_19" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">4/4</td>
 <td class="tally obsolete not-applicable" data-browser="deno1_20" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">4/4</td>
 <td class="tally obsolete not-applicable" data-browser="deno1_21" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">4/4</td>
@@ -13919,7 +14002,8 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="yes not-applicable" data-browser="graalvm21_3_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="graalvm22_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="hermes0_7_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="hermes0_12_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="hermes0_12_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_19" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_20" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_21" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -14084,7 +14168,8 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="yes not-applicable" data-browser="graalvm21_3_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="graalvm22_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="hermes0_7_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="hermes0_12_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="hermes0_12_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_19" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_20" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_21" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -14254,7 +14339,8 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="yes not-applicable" data-browser="graalvm21_3_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="graalvm22_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="hermes0_7_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="hermes0_12_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="hermes0_12_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_19" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_20" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_21" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -14424,7 +14510,8 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="yes not-applicable" data-browser="graalvm21_3_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="graalvm22_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="hermes0_7_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="hermes0_12_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="hermes0_12_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_19" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_20" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_21" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -14586,7 +14673,8 @@ return i === 0;
 <td class="yes not-applicable" data-browser="graalvm21_3_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="graalvm22_2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="hermes0_7_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="hermes0_12_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="hermes0_12_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_19" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_20" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="deno1_21" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -14616,7 +14704,7 @@ return i === 0;
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
 </tr>
-<tr class="category"><td colspan="159"><span>2018 features</span></td>
+<tr class="category"><td colspan="160"><span>2018 features</span></td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-object_rest/spread_properties"><span><a class="anchor" href="#test-object_rest/spread_properties">&#xA7;</a><a href="https://github.com/tc39/proposal-object-rest-spread">object rest/spread properties</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/2</td>
@@ -14746,7 +14834,8 @@ return i === 0;
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">2/2</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="hermes0_7_0" data-tally="1">2/2</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="1">2/2</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">2/2</td>
@@ -14908,7 +14997,8 @@ return a === 1 &amp;&amp; rest.a === void undefined &amp;&amp; rest.b === 2 &amp
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -15071,7 +15161,8 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -15229,7 +15320,8 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">3/3</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="hermes0_7_0" data-tally="0">0/3</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="1">3/3</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">3/3</td>
@@ -15416,7 +15508,8 @@ function check() {
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -15595,7 +15688,8 @@ function check() {
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -15776,7 +15870,8 @@ function check() {
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -15938,7 +16033,8 @@ return regex.test(&apos;foo\nbar&apos;);
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -16106,7 +16202,8 @@ return result.groups.year === &apos;2016&apos;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="hermes0_12_0">No</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -16268,7 +16365,8 @@ return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&a
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -16430,7 +16528,8 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="hermes0_12_0">No</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -16588,7 +16687,8 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">2/2</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="hermes0_7_0" data-tally="0">0/2</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="0">0/2</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">2/2</td>
@@ -16756,7 +16856,8 @@ iterator.next().then(function(step){
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="hermes0_12_0">No</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -16934,7 +17035,8 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="hermes0_12_0">No</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -16964,7 +17066,7 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
 </tr>
-<tr class="category"><td colspan="159"><span>2018 misc</span></td>
+<tr class="category"><td colspan="160"><span>2018 misc</span></td>
 </tr>
 <tr significance="0.125"><td id="test-Proxy_ownKeys_handler,_duplicate_keys_for_non-extensible_targets"><span><a class="anchor" href="#test-Proxy_ownKeys_handler,_duplicate_keys_for_non-extensible_targets">&#xA7;</a><a href="https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-ownpropertykeys">Proxy &quot;ownKeys&quot; handler, duplicate keys for non-extensible targets</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/ownKeys" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var p = new Proxy({}, {
@@ -17107,7 +17209,8 @@ return false;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -17275,7 +17378,8 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -17305,7 +17409,7 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
 </tr>
-<tr class="category"><td colspan="159"><span>2019 features</span></td>
+<tr class="category"><td colspan="160"><span>2019 features</span></td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Symbol.prototype.description"><span><a class="anchor" href="#test-Symbol.prototype.description">&#xA7;</a><a href="https://github.com/tc39/proposal-Symbol-description">Symbol.prototype.description</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/description" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/3</td>
@@ -17435,7 +17539,8 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">3/3</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="hermes0_7_0" data-tally="0">0/3</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">3/3</td>
@@ -17596,7 +17701,8 @@ return Symbol(&apos;foo&apos;).description === &apos;foo&apos;;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -17757,7 +17863,8 @@ return Symbol(&apos;&apos;).description === &apos;&apos;;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -17919,7 +18026,8 @@ return Symbol.prototype.hasOwnProperty(&apos;description&apos;)
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="hermes0_12_0">No</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -18081,7 +18189,8 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -18239,7 +18348,8 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">4/4</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="hermes0_7_0" data-tally="1">4/4</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="1">4/4</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">4/4</td>
@@ -18400,7 +18510,8 @@ return &apos; \t \n abc   \t\n&apos;.trimLeft() === &apos;abc   \t\n&apos;;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -18561,7 +18672,8 @@ return &apos; \t \n abc   \t\n&apos;.trimRight() === &apos; \t \n abc&apos;;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -18722,7 +18834,8 @@ return &apos; \t \n abc   \t\n&apos;.trimStart() === &apos;abc   \t\n&apos;;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -18883,7 +18996,8 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -19041,7 +19155,8 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">3/3</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="hermes0_7_0" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">3/3</td>
@@ -19202,7 +19317,8 @@ return [1, [2, 3], [4, [5, 6]]].flat().join(&apos;&apos;) === &apos;12345,6&apos
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -19365,7 +19481,8 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -19527,7 +19644,8 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="hermes0_12_0">No</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -19557,7 +19675,7 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
 </tr>
-<tr class="category"><td colspan="159"><span>2019 misc</span></td>
+<tr class="category"><td colspan="160"><span>2019 misc</span></td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-optional_catch_binding"><span><a class="anchor" href="#test-optional_catch_binding">&#xA7;</a><a href="https://github.com/tc39/proposal-optional-catch-binding">optional catch binding</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/3</td>
@@ -19687,7 +19805,8 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">3/3</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="hermes0_7_0" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="1">3/3</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">3/3</td>
@@ -19854,7 +19973,8 @@ return false;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -20022,7 +20142,8 @@ return false;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -20194,7 +20315,8 @@ return it.throw().value;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -20352,7 +20474,8 @@ return it.throw().value;
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">7/7</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="hermes0_7_0" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">7/7</td>
@@ -20515,7 +20638,8 @@ return fn + &apos;&apos; === str;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="hermes0_12_0">No</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -20677,7 +20801,8 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="hermes0_12_0">No</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -20839,7 +20964,8 @@ return NATIVE_EVAL_RE.test(eval + &apos;&apos;);
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -21001,7 +21127,8 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="hermes0_12_0">No</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -21163,7 +21290,8 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="hermes0_12_0">No</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -21325,7 +21453,8 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="hermes0_12_0">No</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -21487,7 +21616,8 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="hermes0_12_0">No</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -21645,7 +21775,8 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">2/2</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="hermes0_7_0" data-tally="1">2/2</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="1">2/2</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">2/2</td>
@@ -21806,7 +21937,8 @@ return eval(&quot;&apos;\u2028&apos;&quot;) === &quot;\u2028&quot;;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -21967,7 +22099,8 @@ return eval(&quot;&apos;\u2029&apos;&quot;) === &quot;\u2029&quot;;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -22129,7 +22262,8 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="hermes0_12_0">No</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -22159,7 +22293,7 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
 </tr>
-<tr class="category"><td colspan="159"><span>2020 features</span></td>
+<tr class="category"><td colspan="160"><span>2020 features</span></td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-String.prototype.matchAll"><span><a class="anchor" href="#test-String.prototype.matchAll">&#xA7;</a><a href="https://github.com/tc39/String.prototype.matchAll">String.prototype.matchAll</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/matchAll" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/2</td>
@@ -22289,7 +22423,8 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">2/2</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="hermes0_7_0" data-tally="1">2/2</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="1">2/2</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">2/2</td>
@@ -22460,7 +22595,8 @@ return a === &apos;1a2b&apos;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -22626,7 +22762,8 @@ try {
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -22784,7 +22921,8 @@ try {
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">8/8</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="hermes0_7_0" data-tally="0">0/8</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="1">8/8</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="1">8/8</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">8/8</td>
@@ -22945,7 +23083,8 @@ return (1n + 2n) === 3n;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -23106,7 +23245,8 @@ return BigInt(&quot;3&quot;) === 3n;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -23267,7 +23407,8 @@ return typeof BigInt.asUintN === &apos;function&apos;;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -23428,7 +23569,8 @@ return typeof BigInt.asIntN === &apos;function&apos;;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -23592,7 +23734,8 @@ return view[0] === -0x8000000000000000n;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -23756,7 +23899,8 @@ return view[0] === 0n;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -23920,7 +24064,8 @@ return view.getBigInt64(0) === 1n;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -24084,7 +24229,8 @@ return view.getBigUint64(0) === 1n;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -24256,7 +24402,8 @@ Promise.allSettled([
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="hermes0_12_0">No</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -24414,7 +24561,8 @@ Promise.allSettled([
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">2/2</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="hermes0_7_0" data-tally="1">2/2</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="1">2/2</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">2/2</td>
@@ -24577,7 +24725,8 @@ return typeof globalThis === &apos;object&apos; &amp;&amp; globalThis &amp;&amp;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -24744,7 +24893,8 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -24902,7 +25052,8 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">5/5</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="hermes0_7_0" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">5/5</td>
@@ -25065,7 +25216,8 @@ return foo?.baz === 42 &amp;&amp; bar?.baz === void undefined;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -25228,7 +25380,8 @@ return foo?.[&apos;baz&apos;] === 42 &amp;&amp; bar?.[&apos;baz&apos;] === void 
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -25391,7 +25544,8 @@ return foo?.baz() === 42 &amp;&amp; bar?.baz() === void undefined;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -25556,7 +25710,8 @@ return foo.baz?.() === 42 &amp;&amp; bar.baz?.() === void undefined &amp;&amp; b
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -25721,7 +25876,8 @@ return fn?.(...[], 1) === void undefined &amp;&amp; fn?.(...[], ...[]) === void 
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -25887,7 +26043,8 @@ return (null ?? 42) === 42 &amp;&amp;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -25917,7 +26074,7 @@ return (null ?? 42) === 42 &amp;&amp;
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
 </tr>
-<tr class="category"><td colspan="159"><span>2021 features</span></td>
+<tr class="category"><td colspan="160"><span>2021 features</span></td>
 </tr>
 <tr significance="0.25"><td id="test-String.prototype.replaceAll"><span><a class="anchor" href="#test-String.prototype.replaceAll">&#xA7;</a><a href="https://github.com/tc39/proposal-string-replace-all">String.prototype.replaceAll</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &apos;) === &apos;q=query string parameters&apos;;
@@ -26050,7 +26207,8 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -26208,7 +26366,8 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">2/2</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="hermes0_7_0" data-tally="0">0/2</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="0">0/2</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">2/2</td>
@@ -26375,7 +26534,8 @@ Promise.any([
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="hermes0_12_0">No</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -26542,7 +26702,8 @@ Promise.any([
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="hermes0_12_0">No</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -26700,7 +26861,8 @@ Promise.any([
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">2/2</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="hermes0_7_0" data-tally="0">0/2</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="0">0/2</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">2/2</td>
@@ -26863,7 +27025,8 @@ return weakref.deref() === O;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="hermes0_12_0">No</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -27025,7 +27188,8 @@ return Object.getPrototypeOf(fr) === FinalizationRegistry.prototype;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="hermes0_12_0">No</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -27183,7 +27347,8 @@ return Object.getPrototypeOf(fr) === FinalizationRegistry.prototype;
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">9/9</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">9/9</td>
 <td class="tally obsolete" data-browser="hermes0_7_0" data-tally="1">9/9</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="1">9/9</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="1">9/9</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">9/9</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">9/9</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">9/9</td>
@@ -27350,7 +27515,8 @@ return a === 2 &amp;&amp; b === 2 &amp;&amp; c === 1;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -27514,7 +27680,8 @@ return a === 1 &amp;&amp; i === 1;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -27678,7 +27845,8 @@ return i === 1;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -27845,7 +28013,8 @@ return typeof a === &apos;undefined&apos; &amp;&amp; b === 0 &amp;&amp; c === 2;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -28009,7 +28178,8 @@ return typeof a === &apos;undefined&apos; &amp;&amp; i === 1;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -28173,7 +28343,8 @@ return i === 1;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -28340,7 +28511,8 @@ return a === 2 &amp;&amp; b === 0 &amp;&amp; c === 1;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -28504,7 +28676,8 @@ return a === 1 &amp;&amp; i === 1;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -28668,7 +28841,8 @@ return i === 1;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -28830,7 +29004,8 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -28860,7 +29035,7 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
 </tr>
-<tr class="category"><td colspan="159"><span>2022 features</span></td>
+<tr class="category"><td colspan="160"><span>2022 features</span></td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-instance_class_fields"><span><a class="anchor" href="#test-instance_class_fields">&#xA7;</a><a href="https://github.com/tc39/proposal-class-fields">instance class fields</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
@@ -28990,7 +29165,8 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">6/6</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="hermes0_7_0" data-tally="0">0/6</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="0">0/6</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">6/6</td>
@@ -29154,7 +29330,8 @@ return new C().x === &apos;x&apos;;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -29324,7 +29501,8 @@ return new C(42).x() === 42;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -29491,7 +29669,8 @@ return new C().x() === 42;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -29658,7 +29837,8 @@ return new C().x() === 42 &amp;&amp; new C().x(null) === void 0;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -29825,7 +30005,8 @@ return new C().x() === 42 &amp;&amp; new C().x(null) === void 0;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -29989,7 +30170,8 @@ return new C().x === 42;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -30147,7 +30329,8 @@ return new C().x === 42;
 <td class="tally" data-browser="graalvm21_3_3" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="hermes0_7_0" data-tally="0">0/4</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="0">0/4</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">4/4</td>
@@ -30311,7 +30494,8 @@ return C.x === &apos;x&apos;;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -30472,7 +30656,8 @@ return (class X { static name = &quot;name&quot;; }).name === &apos;name&apos;;
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -30639,7 +30824,8 @@ return new C().x() === 42;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -30803,7 +30989,8 @@ return C.x === 42;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -30961,7 +31148,8 @@ return C.x === 42;
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">4/4</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="hermes0_7_0" data-tally="0">0/4</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="0">0/4</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">4/4</td>
@@ -31128,7 +31316,8 @@ return new C().x() === 42;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -31295,7 +31484,8 @@ return new C().x() === 42;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -31465,7 +31655,8 @@ return new C().x() === 42 &amp;&amp; y;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -31635,7 +31826,8 @@ return new C().x() === 42 &amp;&amp; y;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -31802,7 +31994,8 @@ return A.check(new A) &amp;&amp; !A.check({});
 <td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-js-ecmascript-version-staging-note"><sup>[35]</sup></a></td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -31960,7 +32153,8 @@ return A.check(new A) &amp;&amp; !A.check({});
 <td class="tally" data-browser="graalvm21_3_3" data-tally="0" data-flagged-tally="1">0/3</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="hermes0_7_0" data-tally="0">0/3</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="0">0/3</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">3/3</td>
@@ -32129,7 +32323,8 @@ return arr.at(0) === 1
 <td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-js-ecmascript-version-staging-note"><sup>[35]</sup></a></td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -32298,7 +32493,8 @@ return str.at(0) === &apos;a&apos;
 <td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-js-ecmascript-version-staging-note"><sup>[35]</sup></a></td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -32483,7 +32679,8 @@ return [
 <td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-js-ecmascript-version-staging-note"><sup>[35]</sup></a></td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -32641,7 +32838,8 @@ return [
 <td class="tally" data-browser="graalvm21_3_3" data-tally="0" data-flagged-tally="1">0/2</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="hermes0_7_0" data-tally="0">0/2</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="0">0/2</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">2/2</td>
@@ -32802,7 +33000,8 @@ return Object.hasOwn({ x: 2 }, &quot;x&quot;) === true;
 <td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-js-ecmascript-version-staging-note"><sup>[35]</sup></a></td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -32969,7 +33168,8 @@ try {
 <td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-js-ecmascript-version-staging-note"><sup>[35]</sup></a></td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -33134,7 +33334,8 @@ return ok;
 <td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-js-ecmascript-version-staging-note"><sup>[35]</sup></a></td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -33292,7 +33493,8 @@ return ok;
 <td class="tally" data-browser="graalvm21_3_3" data-tally="0.5" style="background-color:hsl(60,64%,50%)">8/16</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="hermes0_7_0" data-tally="0">0/16</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/16</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="0">0/16</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/16</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">16/16</td>
@@ -33454,7 +33656,8 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -33615,7 +33818,8 @@ return !(&apos;cause&apos; in Error.prototype);
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -33777,7 +33981,8 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -33938,7 +34143,8 @@ return !(&apos;cause&apos; in EvalError.prototype);
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -34100,7 +34306,8 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -34261,7 +34468,8 @@ return !(&apos;cause&apos; in RangeError.prototype);
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -34423,7 +34631,8 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -34584,7 +34793,8 @@ return !(&apos;cause&apos; in ReferenceError.prototype);
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -34746,7 +34956,8 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -34907,7 +35118,8 @@ return !(&apos;cause&apos; in SyntaxError.prototype);
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -35069,7 +35281,8 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -35230,7 +35443,8 @@ return !(&apos;cause&apos; in TypeError.prototype);
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -35392,7 +35606,8 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -35553,7 +35768,8 @@ return !(&apos;cause&apos; in URIError.prototype);
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -35715,7 +35931,8 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -35876,7 +36093,8 @@ return !(&apos;cause&apos; in AggregateError.prototype);
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -36034,7 +36252,8 @@ return !(&apos;cause&apos; in AggregateError.prototype);
 <td class="tally" data-browser="graalvm21_3_3" data-tally="0" data-flagged-tally="1">0/2</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="hermes0_7_0" data-tally="0">0/2</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="0">0/2</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
@@ -36195,7 +36414,8 @@ return new RegExp(&apos;a&apos;, &apos;d&apos;) instanceof RegExp;
 <td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-js-ecmascript-version-staging-note"><sup>[35]</sup></a></td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -36371,7 +36591,8 @@ return true;
 <td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-js-ecmascript-version-staging-note"><sup>[35]</sup></a></td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -36401,7 +36622,7 @@ return true;
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
 </tr>
-<tr class="category"><td colspan="159"><span>2023 features</span></td>
+<tr class="category"><td colspan="160"><span>2023 features</span></td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Array_find_from_last"><span><a class="anchor" href="#test-Array_find_from_last">&#xA7;</a><a href="https://github.com/tc39/proposal-array-find-from-last">Array find from last</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/2</td>
@@ -36531,7 +36752,8 @@ return true;
 <td class="tally" data-browser="graalvm21_3_3" data-tally="0">0/2</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="0" data-flagged-tally="1">0/2</td>
 <td class="tally obsolete" data-browser="hermes0_7_0" data-tally="0">0/2</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="0">0/2</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">2/2</td>
@@ -36693,7 +36915,8 @@ return arr.findLast(function (o) { return o.x === 1; }) === arr[2];
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no flagged" data-browser="graalvm22_2">Flag<a href="#graalvm-js-ecmascript-version-staging-note"><sup>[35]</sup></a></td>
 <td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -36855,7 +37078,8 @@ return arr.findLastIndex(function (o) { return o.x === 1; }) === 2;
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no flagged" data-browser="graalvm22_2">Flag<a href="#graalvm-js-ecmascript-version-staging-note"><sup>[35]</sup></a></td>
 <td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -37020,7 +37244,8 @@ try {
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>

--- a/es5/index.html
+++ b/es5/index.html
@@ -247,7 +247,8 @@
 <th class="platform graalvm21_3_3 engine" data-browser="graalvm21_3_3"><a href="#graalvm21_3_3" class="browser-name"><abbr title="GraalVM JavaScript 21.3.3">GraalVM 21.3.3</abbr></a><a href="#graalvm-js-intl-mode-note"><sup>[5]</sup></a></th>
 <th class="platform graalvm22_2 engine" data-browser="graalvm22_2"><a href="#graalvm22_2" class="browser-name"><abbr title="GraalVM JavaScript 22.2.0">GraalVM 22.2.0</abbr></a><a href="#graalvm-js-intl-mode-note"><sup>[5]</sup></a></th>
 <th class="platform hermes0_7_0 engine obsolete" data-browser="hermes0_7_0"><a href="#hermes0_7_0" class="browser-name"><abbr title="Hermes 0.7.0">Hermes 0.7.0</abbr></a></th>
-<th class="platform hermes0_12_0 engine" data-browser="hermes0_12_0"><a href="#hermes0_12_0" class="browser-name"><abbr title="Hermes 0.12.0">Hermes 0.12.0</abbr></a></th>
+<th class="platform hermes0_12_0 engine obsolete" data-browser="hermes0_12_0"><a href="#hermes0_12_0" class="browser-name"><abbr title="Hermes 0.12.0">Hermes 0.12.0</abbr></a></th>
+<th class="platform reactnative0_70_3 mobile" data-browser="reactnative0_70_3"><a href="#reactnative0_70_3" class="browser-name"><abbr title="Reactnative 0.70.3">Reactnative 0.70.3</abbr></a></th>
 <th class="platform deno1_19 engine obsolete" data-browser="deno1_19"><a href="#deno1_19" class="browser-name"><abbr title="Deno">Deno 1.19</abbr></a></th>
 <th class="platform deno1_20 engine obsolete" data-browser="deno1_20"><a href="#deno1_20" class="browser-name"><abbr title="Deno">Deno 1.20</abbr></a></th>
 <th class="platform deno1_21 engine obsolete" data-browser="deno1_21"><a href="#deno1_21" class="browser-name"><abbr title="Deno">Deno 1.21</abbr></a></th>
@@ -403,7 +404,8 @@
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">5/5</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="hermes0_7_0" data-tally="1">5/5</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="1">5/5</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">5/5</td>
@@ -558,7 +560,8 @@ return ({ get x(){ return 1 } }).x === 1;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -715,7 +718,8 @@ return value === 1;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -870,7 +874,8 @@ return { a: true, }.a === true;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -1025,7 +1030,8 @@ return [1,].length === 1;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -1180,7 +1186,8 @@ return ({ if: 1 }).if === 1;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -1210,7 +1217,7 @@ return ({ if: 1 }).if === 1;
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
 </tr>
-<tr><th colspan="153" class="separator"></th>
+<tr><th colspan="154" class="separator"></th>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Object_static_methods"><span><a class="anchor" href="#test-Object_static_methods">&#xA7;</a>Object static methods</span></td>
 <td class="tally" data-browser="es5shim" data-tally="0.07692307692307693" style="background-color:hsl(9,82%,50%)">1/13</td>
@@ -1334,7 +1341,8 @@ return ({ if: 1 }).if === 1;
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">13/13</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="hermes0_7_0" data-tally="1">13/13</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="1">13/13</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="1">13/13</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/13</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">13/13</td>
@@ -1491,7 +1499,8 @@ return typeof Object.create === 'function';
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -1648,7 +1657,8 @@ return typeof Object.defineProperty === 'function';
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -1805,7 +1815,8 @@ return typeof Object.defineProperties === 'function';
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -1962,7 +1973,8 @@ return typeof Object.getPrototypeOf === 'function';
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -2119,7 +2131,8 @@ return typeof Object.keys === 'function';
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -2276,7 +2289,8 @@ return typeof Object.seal === 'function';
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -2433,7 +2447,8 @@ return typeof Object.freeze === 'function';
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -2590,7 +2605,8 @@ return typeof Object.preventExtensions === 'function';
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -2747,7 +2763,8 @@ return typeof Object.isSealed === 'function';
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -2904,7 +2921,8 @@ return typeof Object.isFrozen === 'function';
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -3061,7 +3079,8 @@ return typeof Object.isExtensible === 'function';
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -3218,7 +3237,8 @@ return typeof Object.getOwnPropertyDescriptor === 'function';
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -3375,7 +3395,8 @@ return typeof Object.getOwnPropertyNames === 'function';
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -3527,7 +3548,8 @@ return typeof Object.getOwnPropertyNames === 'function';
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">13/13</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="hermes0_7_0" data-tally="0.9230769230769231" style="background-color:hsl(110,45%,50%)">12/13</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0.9230769230769231" style="background-color:hsl(110,45%,50%)">12/13</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="0.9230769230769231" style="background-color:hsl(110,45%,50%)">12/13</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/13</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">13/13</td>
@@ -3684,7 +3706,8 @@ return typeof Array.isArray === 'function';
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -3841,7 +3864,8 @@ return typeof Array.prototype.indexOf === 'function';
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -3998,7 +4022,8 @@ return typeof Array.prototype.lastIndexOf === 'function';
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -4155,7 +4180,8 @@ return typeof Array.prototype.every === 'function';
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -4312,7 +4338,8 @@ return typeof Array.prototype.some === 'function';
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -4469,7 +4496,8 @@ return typeof Array.prototype.forEach === 'function';
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -4626,7 +4654,8 @@ return typeof Array.prototype.map === 'function';
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -4783,7 +4812,8 @@ return typeof Array.prototype.filter === 'function';
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -4940,7 +4970,8 @@ return typeof Array.prototype.reduce === 'function';
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -5097,7 +5128,8 @@ return typeof Array.prototype.reduceRight === 'function';
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -5294,7 +5326,8 @@ return true;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -5461,7 +5494,8 @@ try {
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -5618,7 +5652,8 @@ return [].unshift(0) === 1;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -5770,7 +5805,8 @@ return [].unshift(0) === 1;
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">4/4</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="hermes0_7_0" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">4/4</td>
@@ -5927,7 +5963,8 @@ return "foobar"[3] === "b";
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -6108,7 +6145,8 @@ return typeof String.prototype.split === 'function'
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -6265,7 +6303,8 @@ return '0b'.substr(-1) === 'b';
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -6422,7 +6461,8 @@ return typeof String.prototype.trim === 'function';
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -6574,7 +6614,8 @@ return typeof String.prototype.trim === 'function';
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">3/3</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="hermes0_7_0" data-tally="1">3/3</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="1">3/3</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">3/3</td>
@@ -6731,7 +6772,8 @@ return typeof Date.prototype.toISOString === 'function';
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -6888,7 +6930,8 @@ return typeof Date.now === 'function';
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -7053,7 +7096,8 @@ try {
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -7210,7 +7254,8 @@ return typeof Function.prototype.bind === 'function';
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -7367,7 +7412,8 @@ return typeof JSON === 'object';
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -7397,7 +7443,7 @@ return typeof JSON === 'object';
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
 </tr>
-<tr><th colspan="153" class="separator"></th>
+<tr><th colspan="154" class="separator"></th>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Immutable_globals"><span><a class="anchor" href="#test-Immutable_globals">&#xA7;</a>Immutable globals</span></td>
 <td class="tally" data-browser="es5shim" data-tally="0">0/3</td>
@@ -7521,7 +7567,8 @@ return typeof JSON === 'object';
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">3/3</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="hermes0_7_0" data-tally="1">3/3</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="1">3/3</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">3/3</td>
@@ -7679,7 +7726,8 @@ return result;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -7837,7 +7885,8 @@ return result;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -7995,7 +8044,8 @@ return result;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -8147,7 +8197,8 @@ return result;
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">3/3</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="hermes0_7_0" data-tally="0">0/3</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="0">0/3</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">3/3</td>
@@ -8308,7 +8359,8 @@ return (-6.9e-11).toExponential(4) === '-6.9000e-11' // Edge <= 17
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -8477,7 +8529,8 @@ try {
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -8646,7 +8699,8 @@ try {
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -8798,7 +8852,8 @@ try {
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">8/8</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="hermes0_7_0" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">8/8</td>
@@ -8963,7 +9018,8 @@ try {
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -9120,7 +9176,8 @@ return parseInt('010') === 10;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -9275,7 +9332,8 @@ return !Function().propertyIsEnumerable(&apos;prototype&apos;);
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -9430,7 +9488,8 @@ return (function(){ return Object.prototype.toString.call(arguments) === &apos;[
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -9586,7 +9645,8 @@ return _\u200c\u200d;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -9743,7 +9803,8 @@ return true;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -9906,7 +9967,8 @@ return result;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="hermes0_12_0">No</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -10067,7 +10129,8 @@ catch(e) {
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -10219,7 +10282,8 @@ catch(e) {
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">19/19</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="hermes0_7_0" data-tally="0.5789473684210527" style="background-color:hsl(69,60%,50%)">11/19</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0.5789473684210527" style="background-color:hsl(69,60%,50%)">11/19</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="0.5789473684210527" style="background-color:hsl(69,60%,50%)">11/19</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/19</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">19/19</td>
@@ -10379,7 +10443,8 @@ return true;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No<a href="#hermes-eval-strict-mode-note"><sup>[9]</sup></a></td>
-<td class="no" data-browser="hermes0_12_0">No<a href="#hermes-eval-strict-mode-note"><sup>[9]</sup></a></td>
+<td class="no obsolete" data-browser="hermes0_12_0">No<a href="#hermes-eval-strict-mode-note"><sup>[9]</sup></a></td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -10535,7 +10600,8 @@ return this === void undefined &amp;&amp; (function(){ return this === void unde
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -10693,7 +10759,8 @@ return (function(){ return typeof this === &apos;string&apos; }).call(&apos;&apo
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -10865,7 +10932,8 @@ return test(String, &apos;&apos;)
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -11023,7 +11091,8 @@ return true;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No<a href="#hermes-eval-strict-mode-note"><sup>[9]</sup></a></td>
-<td class="no" data-browser="hermes0_12_0">No<a href="#hermes-eval-strict-mode-note"><sup>[9]</sup></a></td>
+<td class="no obsolete" data-browser="hermes0_12_0">No<a href="#hermes-eval-strict-mode-note"><sup>[9]</sup></a></td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -11179,7 +11248,8 @@ try { eval(&apos;__i_dont_exist = 1&apos;); } catch (err) { return err instanceo
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No<a href="#hermes-eval-strict-mode-note"><sup>[9]</sup></a></td>
-<td class="no" data-browser="hermes0_12_0">No<a href="#hermes-eval-strict-mode-note"><sup>[9]</sup></a></td>
+<td class="no obsolete" data-browser="hermes0_12_0">No<a href="#hermes-eval-strict-mode-note"><sup>[9]</sup></a></td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -11339,7 +11409,8 @@ return true;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No<a href="#hermes-eval-strict-mode-note"><sup>[9]</sup></a></td>
-<td class="no" data-browser="hermes0_12_0">No<a href="#hermes-eval-strict-mode-note"><sup>[9]</sup></a></td>
+<td class="no obsolete" data-browser="hermes0_12_0">No<a href="#hermes-eval-strict-mode-note"><sup>[9]</sup></a></td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -11499,7 +11570,8 @@ return true;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="hermes0_12_0">No</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -11661,7 +11733,8 @@ return true;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No<a href="#hermes-eval-strict-mode-note"><sup>[9]</sup></a></td>
-<td class="no" data-browser="hermes0_12_0">No<a href="#hermes-eval-strict-mode-note"><sup>[9]</sup></a></td>
+<td class="no obsolete" data-browser="hermes0_12_0">No<a href="#hermes-eval-strict-mode-note"><sup>[9]</sup></a></td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -11820,7 +11893,8 @@ return true;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -11977,7 +12051,8 @@ return true;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -12135,7 +12210,8 @@ return true;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -12297,7 +12373,8 @@ return (function(x){
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -12453,7 +12530,8 @@ try { eval(&apos;var __some_unique_variable;&apos;); __some_unique_variable; } c
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes<a href="#hermes-eval-lexical-scope-success-note"><sup>[11]</sup></a></td>
-<td class="yes" data-browser="hermes0_12_0">Yes<a href="#hermes-eval-lexical-scope-success-note"><sup>[11]</sup></a></td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes<a href="#hermes-eval-lexical-scope-success-note"><sup>[11]</sup></a></td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -12609,7 +12687,8 @@ try { eval(&apos;var x; delete x;&apos;); } catch (err) { return err instanceof 
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No<a href="#hermes-eval-strict-mode-note"><sup>[9]</sup></a></td>
-<td class="no" data-browser="hermes0_12_0">No<a href="#hermes-eval-strict-mode-note"><sup>[9]</sup></a></td>
+<td class="no obsolete" data-browser="hermes0_12_0">No<a href="#hermes-eval-strict-mode-note"><sup>[9]</sup></a></td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -12765,7 +12844,8 @@ try { delete Object.prototype; } catch (err) { return err instanceof TypeError; 
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -12921,7 +13001,8 @@ try { eval(&apos;with({}){}&apos;); } catch (err) { return err instanceof Syntax
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -13077,7 +13158,8 @@ try { eval(&apos;function f(x, x) { }&apos;); } catch (err) { return err instanc
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No<a href="#hermes-eval-strict-mode-note"><sup>[9]</sup></a></td>
-<td class="no" data-browser="hermes0_12_0">No<a href="#hermes-eval-strict-mode-note"><sup>[9]</sup></a></td>
+<td class="no obsolete" data-browser="hermes0_12_0">No<a href="#hermes-eval-strict-mode-note"><sup>[9]</sup></a></td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -13233,7 +13315,8 @@ return typeof foo === &apos;function&apos;;
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
-<td class="yes" data-browser="hermes0_12_0">Yes</td>
+<td class="yes obsolete" data-browser="hermes0_12_0">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>

--- a/esintl/index.html
+++ b/esintl/index.html
@@ -239,7 +239,8 @@
 <th class="platform graalvm21 engine obsolete" data-browser="graalvm21"><a href="#graalvm21" class="browser-name"><abbr title="GraalVM JavaScript 21.0.0">GraalVM 21.0.0</abbr></a><a href="#graalvm-node-mode-note"><sup>[3]</sup></a></th>
 <th class="platform graalvm21_3_3 engine" data-browser="graalvm21_3_3"><a href="#graalvm21_3_3" class="browser-name"><abbr title="GraalVM JavaScript 21.3.3">GraalVM 21.3.3</abbr></a><a href="#graalvm-js-intl-mode-note"><sup>[4]</sup></a></th>
 <th class="platform graalvm22_2 engine" data-browser="graalvm22_2"><a href="#graalvm22_2" class="browser-name"><abbr title="GraalVM JavaScript 22.2.0">GraalVM 22.2.0</abbr></a><a href="#graalvm-js-intl-mode-note"><sup>[4]</sup></a></th>
-<th class="platform hermes0_12_0 engine" data-browser="hermes0_12_0"><a href="#hermes0_12_0" class="browser-name"><abbr title="Hermes 0.12.0">Hermes 0.12.0</abbr></a></th>
+<th class="platform hermes0_12_0 engine obsolete" data-browser="hermes0_12_0"><a href="#hermes0_12_0" class="browser-name"><abbr title="Hermes 0.12.0">Hermes 0.12.0</abbr></a></th>
+<th class="platform reactnative0_70_3 mobile" data-browser="reactnative0_70_3"><a href="#reactnative0_70_3" class="browser-name"><abbr title="Reactnative 0.70.3">Reactnative 0.70.3</abbr></a></th>
 <th class="platform deno1_19 engine obsolete" data-browser="deno1_19"><a href="#deno1_19" class="browser-name"><abbr title="Deno">Deno 1.19</abbr></a></th>
 <th class="platform deno1_20 engine obsolete" data-browser="deno1_20"><a href="#deno1_20" class="browser-name"><abbr title="Deno">Deno 1.20</abbr></a></th>
 <th class="platform deno1_21 engine obsolete" data-browser="deno1_21"><a href="#deno1_21" class="browser-name"><abbr title="Deno">Deno 1.21</abbr></a></th>
@@ -380,7 +381,8 @@
 <td class="tally obsolete" data-browser="graalvm21" data-tally="1">2/2</td>
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">2/2</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">2/2</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="0">0/2</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">2/2</td>
@@ -520,7 +522,8 @@ return typeof Intl === &apos;object&apos;;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -660,7 +663,8 @@ return Intl.constructor === Object;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -797,7 +801,8 @@ return Intl.constructor === Object;
 <td class="tally obsolete" data-browser="graalvm21" data-tally="1">5/5</td>
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">5/5</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">5/5</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="0">0/5</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">5/5</td>
@@ -937,7 +942,8 @@ return typeof Intl.Collator === &apos;function&apos;;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -1077,7 +1083,8 @@ return new Intl.Collator() instanceof Intl.Collator;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -1217,7 +1224,8 @@ return Intl.Collator() instanceof Intl.Collator;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -1379,7 +1387,8 @@ try {
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -1536,7 +1545,8 @@ try {
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -1673,7 +1683,8 @@ try {
 <td class="tally obsolete" data-browser="graalvm21" data-tally="1">1/1</td>
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">1/1</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">1/1</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="0">0/1</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">1/1</td>
@@ -1813,7 +1824,8 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -1950,7 +1962,8 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="tally obsolete" data-browser="graalvm21" data-tally="1">1/1</td>
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">1/1</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">1/1</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="0">0/1</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">1/1</td>
@@ -2090,7 +2103,8 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -2227,7 +2241,8 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="tally obsolete" data-browser="graalvm21" data-tally="1">6/6</td>
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">6/6</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">6/6</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="0">0/6</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">6/6</td>
@@ -2367,7 +2382,8 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -2507,7 +2523,8 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -2647,7 +2664,8 @@ return new Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -2787,7 +2805,8 @@ return Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -2949,7 +2968,8 @@ try {
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -3106,7 +3126,8 @@ try {
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -3243,7 +3264,8 @@ try {
 <td class="tally obsolete" data-browser="graalvm21" data-tally="1">7/7</td>
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">7/7</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">7/7</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="0">0/7</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">7/7</td>
@@ -3383,7 +3405,8 @@ return typeof Intl.DateTimeFormat === &apos;function&apos;;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -3523,7 +3546,8 @@ return new Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -3663,7 +3687,8 @@ return Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -3825,7 +3850,8 @@ try {
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -3982,7 +4008,8 @@ try {
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -4123,7 +4150,8 @@ return tz !== void undefined &amp;&amp; tz.length &gt; 0;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -4271,7 +4299,8 @@ try {
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -4408,7 +4437,8 @@ try {
 <td class="tally obsolete" data-browser="graalvm21" data-tally="1">1/1</td>
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">1/1</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">1/1</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="0">0/1</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">1/1</td>
@@ -4548,7 +4578,8 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -4685,7 +4716,8 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="tally obsolete" data-browser="graalvm21" data-tally="1">1/1</td>
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">1/1</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">1/1</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="0">0/1</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">1/1</td>
@@ -4825,7 +4857,8 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -4962,7 +4995,8 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="graalvm21" data-tally="1">1/1</td>
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">1/1</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">1/1</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="0">0/1</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">1/1</td>
@@ -5102,7 +5136,8 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -5239,7 +5274,8 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="graalvm21" data-tally="1">1/1</td>
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">1/1</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">1/1</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="0">0/1</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">1/1</td>
@@ -5379,7 +5415,8 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -5516,7 +5553,8 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="graalvm21" data-tally="1">1/1</td>
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">1/1</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">1/1</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="0">0/1</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">1/1</td>
@@ -5656,7 +5694,8 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -5793,7 +5832,8 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="graalvm21" data-tally="1">1/1</td>
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">1/1</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">1/1</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="0">0/1</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">1/1</td>
@@ -5933,7 +5973,8 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -6070,7 +6111,8 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="graalvm21" data-tally="1">1/1</td>
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">1/1</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">1/1</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="0">0/1</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">1/1</td>
@@ -6210,7 +6252,8 @@ return typeof Date.prototype.toLocaleTimeString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -252,7 +252,8 @@
 <th class="platform graalvm21 engine obsolete" data-browser="graalvm21"><a href="#graalvm21" class="browser-name"><abbr title="GraalVM JavaScript 21.0.0">GraalVM 21.0.0</abbr></a><a href="#graalvm-node-mode-note"><sup>[3]</sup></a></th>
 <th class="platform graalvm21_3_3 engine" data-browser="graalvm21_3_3"><a href="#graalvm21_3_3" class="browser-name"><abbr title="GraalVM JavaScript 21.3.3">GraalVM 21.3.3</abbr></a><a href="#graalvm-js-intl-mode-note"><sup>[4]</sup></a></th>
 <th class="platform graalvm22_2 engine" data-browser="graalvm22_2"><a href="#graalvm22_2" class="browser-name"><abbr title="GraalVM JavaScript 22.2.0">GraalVM 22.2.0</abbr></a><a href="#graalvm-js-intl-mode-note"><sup>[4]</sup></a></th>
-<th class="platform hermes0_12_0 engine" data-browser="hermes0_12_0"><a href="#hermes0_12_0" class="browser-name"><abbr title="Hermes 0.12.0">Hermes 0.12.0</abbr></a></th>
+<th class="platform hermes0_12_0 engine obsolete" data-browser="hermes0_12_0"><a href="#hermes0_12_0" class="browser-name"><abbr title="Hermes 0.12.0">Hermes 0.12.0</abbr></a></th>
+<th class="platform reactnative0_70_3 mobile" data-browser="reactnative0_70_3"><a href="#reactnative0_70_3" class="browser-name"><abbr title="Reactnative 0.70.3">Reactnative 0.70.3</abbr></a></th>
 <th class="platform deno1_19 engine obsolete" data-browser="deno1_19"><a href="#deno1_19" class="browser-name"><abbr title="Deno">Deno 1.19</abbr></a></th>
 <th class="platform deno1_20 engine obsolete" data-browser="deno1_20"><a href="#deno1_20" class="browser-name"><abbr title="Deno">Deno 1.20</abbr></a></th>
 <th class="platform deno1_21 engine obsolete" data-browser="deno1_21"><a href="#deno1_21" class="browser-name"><abbr title="Deno">Deno 1.21</abbr></a></th>
@@ -286,7 +287,7 @@
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr class="category"><td colspan="154"><span>Stage 3</span></td>
+      <tr class="category"><td colspan="155"><span>Stage 3</span></td>
 </tr>
 <tr significance="1"><td id="test-ShadowRealm"><span><a class="anchor" href="#test-ShadowRealm">&#xA7;</a><a href="https://github.com/tc39/proposal-shadowrealm">ShadowRealm</a></span><script data-source="
 return typeof ShadowRealm === &quot;function&quot;
@@ -417,7 +418,8 @@ return typeof ShadowRealm === &quot;function&quot;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -570,7 +572,8 @@ return typeof ShadowRealm === &quot;function&quot;
 <td class="tally obsolete" data-browser="graalvm21" data-tally="1">2/2</td>
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">2/2</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">2/2</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="0">0/2</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">2/2</td>
@@ -732,7 +735,8 @@ return RegExp.lastMatch === 'x';
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -896,7 +900,8 @@ return true;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -926,7 +931,7 @@ return true;
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
 </tr>
-<tr class="category"><td colspan="154"><span>Stage 2</span></td>
+<tr class="category"><td colspan="155"><span>Stage 2</span></td>
 </tr>
 <tr significance="0.25"><td id="test-Generator_function.sent_Meta_Property"><span><a class="anchor" href="#test-Generator_function.sent_Meta_Property">&#xA7;</a><a href="https://github.com/tc39/proposal-function.sent">Generator function.sent Meta Property</a></span><script data-source="
 var result;
@@ -1060,7 +1065,8 @@ return result === &apos;tromple&apos;;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -1213,7 +1219,8 @@ return result === &apos;tromple&apos;;
 <td class="tally obsolete" data-browser="graalvm21" data-tally="0">0/1</td>
 <td class="tally" data-browser="graalvm21_3_3" data-tally="0">0/1</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="0">0/1</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="0">0/1</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="0">0/1</td>
@@ -1377,7 +1384,8 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -1530,7 +1538,8 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="tally obsolete" data-browser="graalvm21" data-tally="0">0/4</td>
 <td class="tally" data-browser="graalvm21_3_3" data-tally="0">0/4</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="0">0/4</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="0">0/4</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="0">0/4</td>
@@ -1692,7 +1701,8 @@ try {
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -1858,7 +1868,8 @@ try {
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -2019,7 +2030,8 @@ try {
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -2180,7 +2192,8 @@ try {
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -2333,7 +2346,8 @@ try {
 <td class="tally obsolete" data-browser="graalvm21" data-tally="0" data-flagged-tally="0.14285714285714285">0/7</td>
 <td class="tally" data-browser="graalvm21_3_3" data-tally="0" data-flagged-tally="1">0/7</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="0" data-flagged-tally="1">0/7</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="0">0/7</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="0">0/7</td>
@@ -2492,7 +2506,8 @@ return set.size === 2
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[9]</sup></a></td>
 <td class="no flagged" data-browser="graalvm22_2">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[9]</sup></a></td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -2652,7 +2667,8 @@ return set.size === 3
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[9]</sup></a></td>
 <td class="no flagged" data-browser="graalvm22_2">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[9]</sup></a></td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -2811,7 +2827,8 @@ return set.size === 2
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[9]</sup></a></td>
 <td class="no flagged" data-browser="graalvm22_2">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[9]</sup></a></td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -2970,7 +2987,8 @@ return set.size === 2
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[9]</sup></a></td>
 <td class="no flagged" data-browser="graalvm22_2">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[9]</sup></a></td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -3126,7 +3144,8 @@ return new Set([1, 2, 3]).isDisjointFrom([4, 5, 6]);
 <td class="no flagged obsolete" data-browser="graalvm21">Flag<a href="#graalvm-js-ecmascript-version-2021-note"><sup>[10]</sup></a></td>
 <td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[9]</sup></a></td>
 <td class="no flagged" data-browser="graalvm22_2">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[9]</sup></a></td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -3282,7 +3301,8 @@ return new Set([1, 2, 3]).isSubsetOf([5, 4, 3, 2, 1]);
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[9]</sup></a></td>
 <td class="no flagged" data-browser="graalvm22_2">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[9]</sup></a></td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -3438,7 +3458,8 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[9]</sup></a></td>
 <td class="no flagged" data-browser="graalvm22_2">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[9]</sup></a></td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -3591,7 +3612,8 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
 <td class="tally obsolete" data-browser="graalvm21" data-tally="0">0/2</td>
 <td class="tally" data-browser="graalvm21_3_3" data-tally="0">0/2</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="0">0/2</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="0">0/2</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="0">0/2</td>
@@ -3750,7 +3772,8 @@ return buffer1.byteLength === 0
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -3909,7 +3932,8 @@ return buffer1.byteLength === 0
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -4062,7 +4086,8 @@ return buffer1.byteLength === 0
 <td class="tally obsolete" data-browser="graalvm21" data-tally="0">0/2</td>
 <td class="tally" data-browser="graalvm21_3_3" data-tally="0">0/2</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="0">0/2</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="0">0/2</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="0">0/2</td>
@@ -4221,7 +4246,8 @@ return Array.from(map).join() === &apos;a,2,b,3&apos;;
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -4381,7 +4407,8 @@ return map.get(a) === 2 &amp;&amp; map.get(b) === 3;
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -4538,7 +4565,8 @@ return !Array.isTemplateObject([])
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -4691,7 +4719,8 @@ return !Array.isTemplateObject([])
 <td class="tally obsolete" data-browser="graalvm21" data-tally="0">0/35</td>
 <td class="tally" data-browser="graalvm21_3_3" data-tally="0">0/35</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="0">0/35</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/35</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="0">0/35</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="0">0/35</td>
@@ -4847,7 +4876,8 @@ return [1, 2, 3].values() instanceof Iterator;
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -5005,7 +5035,8 @@ return instance[Symbol.iterator]() === instance;
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -5164,7 +5195,8 @@ return &apos;next&apos; in iterator
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -5328,7 +5360,8 @@ return &apos;next&apos; in iterator
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -5484,7 +5517,8 @@ return Array.from([1, 2, 3].values().asIndexedPairs()).join() === &apos;0,1,1,2,
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -5640,7 +5674,8 @@ return Array.from([1, 2, 3].values().drop(1)).join() === &apos;2,3&apos;;
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -5796,7 +5831,8 @@ return [1, 2, 3].values().every(it =&gt; typeof it === &apos;number&apos;);
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -5952,7 +5988,8 @@ return Array.from([1, 2, 3].values().filter(it =&gt; it % 2)).join() === &apos;1
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -6108,7 +6145,8 @@ return [1, 2, 3].values().find(it =&gt; it % 2) === 1;
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -6264,7 +6302,8 @@ return Array.from([1, 2, 3].values().flatMap(it =&gt; [it, 0])).join() === &apos
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -6422,7 +6461,8 @@ return result === &apos;123&apos;;
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -6578,7 +6618,8 @@ return Array.from([1, 2, 3].values().map(it =&gt; it * it)).join() === &apos;1,4
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -6734,7 +6775,8 @@ return [1, 2, 3].values().reduce((a, b) =&gt; a + b) === 6;
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -6890,7 +6932,8 @@ return [1, 2, 3].values().some(it =&gt; typeof it === &apos;number&apos;);
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -7046,7 +7089,8 @@ return Array.from([1, 2, 3].values().take(2)).join() === &apos;1,2&apos;;
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -7203,7 +7247,8 @@ return Array.isArray(array) &amp;&amp; array.join() === &apos;1,2,3&apos;;
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -7359,7 +7404,8 @@ return Iterator.prototype[Symbol.toStringTag] === &apos;Iterator&apos;;
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -7515,7 +7561,8 @@ return (async function*() {})() instanceof AsyncIterator;
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -7673,7 +7720,8 @@ return instance[Symbol.asyncIterator]() === instance;
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -7841,7 +7889,8 @@ toArray(iterator).then(it =&gt; {
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -8009,7 +8058,8 @@ toArray(iterator).then(it =&gt; {
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -8177,7 +8227,8 @@ toArray(iterator).then(it =&gt; {
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -8341,7 +8392,8 @@ toArray((async function*() { yield * [1, 2, 3] })().asIndexedPairs()).then(it =&
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -8505,7 +8557,8 @@ toArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it =&gt; {
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -8663,7 +8716,8 @@ toArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it =&gt; {
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -8827,7 +8881,8 @@ toArray(async function*() { yield * [1, 2, 3] }().filter(it =&gt; it % 2)).then(
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -8985,7 +9040,8 @@ toArray(async function*() { yield * [1, 2, 3] }().filter(it =&gt; it % 2)).then(
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -9149,7 +9205,8 @@ toArray(async function*() { yield * [1, 2, 3] }().flatMap(it =&gt; [it, 0])).the
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -9308,7 +9365,8 @@ let result = &apos;&apos;;
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -9472,7 +9530,8 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -9630,7 +9689,8 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -9788,7 +9848,8 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -9952,7 +10013,8 @@ toArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it =&gt; {
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -10110,7 +10172,8 @@ toArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it =&gt; {
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -10266,7 +10329,8 @@ return AsyncIterator.prototype[Symbol.toStringTag] === &apos;AsyncIterator&apos;
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -225,7 +225,8 @@
 <th class="platform graalvm21 engine obsolete" data-browser="graalvm21"><a href="#graalvm21" class="browser-name"><abbr title="GraalVM JavaScript 21.0.0">GraalVM 21.0.0</abbr></a><a href="#graalvm-node-mode-note"><sup>[4]</sup></a></th>
 <th class="platform graalvm21_3_3 engine" data-browser="graalvm21_3_3"><a href="#graalvm21_3_3" class="browser-name"><abbr title="GraalVM JavaScript 21.3.3">GraalVM 21.3.3</abbr></a><a href="#graalvm-js-intl-mode-note"><sup>[5]</sup></a></th>
 <th class="platform graalvm22_2 engine" data-browser="graalvm22_2"><a href="#graalvm22_2" class="browser-name"><abbr title="GraalVM JavaScript 22.2.0">GraalVM 22.2.0</abbr></a><a href="#graalvm-js-intl-mode-note"><sup>[5]</sup></a></th>
-<th class="platform hermes0_12_0 engine" data-browser="hermes0_12_0"><a href="#hermes0_12_0" class="browser-name"><abbr title="Hermes 0.12.0">Hermes 0.12.0</abbr></a></th>
+<th class="platform hermes0_12_0 engine obsolete" data-browser="hermes0_12_0"><a href="#hermes0_12_0" class="browser-name"><abbr title="Hermes 0.12.0">Hermes 0.12.0</abbr></a></th>
+<th class="platform reactnative0_70_3 mobile" data-browser="reactnative0_70_3"><a href="#reactnative0_70_3" class="browser-name"><abbr title="Reactnative 0.70.3">Reactnative 0.70.3</abbr></a></th>
 <th class="platform deno1_19 engine obsolete" data-browser="deno1_19"><a href="#deno1_19" class="browser-name"><abbr title="Deno">Deno 1.19</abbr></a></th>
 <th class="platform deno1_20 engine obsolete" data-browser="deno1_20"><a href="#deno1_20" class="browser-name"><abbr title="Deno">Deno 1.20</abbr></a></th>
 <th class="platform deno1_21 engine obsolete" data-browser="deno1_21"><a href="#deno1_21" class="browser-name"><abbr title="Deno">Deno 1.21</abbr></a></th>
@@ -369,7 +370,8 @@
 <td class="tally obsolete" data-browser="graalvm21" data-tally="0">0/57</td>
 <td class="tally" data-browser="graalvm21_3_3" data-tally="0">0/57</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="0">0/57</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/57</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="0">0/57</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="0">0/57</td>
@@ -520,7 +522,8 @@ return typeof SIMD !== &apos;undefined&apos;;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -663,7 +666,8 @@ return typeof SIMD.Float32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -806,7 +810,8 @@ return typeof SIMD.Int32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -949,7 +954,8 @@ return typeof SIMD.Int16x8 === &apos;function&apos;;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -1092,7 +1098,8 @@ return typeof SIMD.Int8x16 === &apos;function&apos;;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -1235,7 +1242,8 @@ return typeof SIMD.Uint32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -1378,7 +1386,8 @@ return typeof SIMD.Uint16x8 === &apos;function&apos;;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -1521,7 +1530,8 @@ return typeof SIMD.Uint8x16 === &apos;function&apos;;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -1664,7 +1674,8 @@ return typeof SIMD.Bool32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -1807,7 +1818,8 @@ return typeof SIMD.Bool16x8 === &apos;function&apos;;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -1950,7 +1962,8 @@ return typeof SIMD.Bool8x16 === &apos;function&apos;;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -2095,7 +2108,8 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -2240,7 +2254,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -2385,7 +2400,8 @@ return simdSmallIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -2530,7 +2546,8 @@ return simdBoolIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -2675,7 +2692,8 @@ return simdBoolTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -2820,7 +2838,8 @@ return simdBoolTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -2965,7 +2984,8 @@ return simdAllTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -3110,7 +3130,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -3255,7 +3276,8 @@ return simdAllTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -3400,7 +3422,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -3545,7 +3568,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -3690,7 +3714,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -3835,7 +3860,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -3980,7 +4006,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -4125,7 +4152,8 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -4270,7 +4298,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -4415,7 +4444,8 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -4560,7 +4590,8 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -4705,7 +4736,8 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -4850,7 +4882,8 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -4995,7 +5028,8 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -5140,7 +5174,8 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -5285,7 +5320,8 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -5430,7 +5466,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -5575,7 +5612,8 @@ return simdBoolTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -5720,7 +5758,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -5865,7 +5904,8 @@ return simdBoolIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -6010,7 +6050,8 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -6155,7 +6196,8 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -6300,7 +6342,8 @@ return simdAllTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -6445,7 +6488,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -6590,7 +6634,8 @@ return simdIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -6735,7 +6780,8 @@ return simdIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -6880,7 +6926,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -7025,7 +7072,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -7170,7 +7218,8 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -7315,7 +7364,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -7460,7 +7510,8 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -7605,7 +7656,8 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -7750,7 +7802,8 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -7895,7 +7948,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -8040,7 +8094,8 @@ return simdSmallIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -8185,7 +8240,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -8330,7 +8386,8 @@ return simdBoolIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -8475,7 +8532,8 @@ return [&apos;Float32x4&apos;,&apos;Int32x4&apos;,&apos;Int8x16&apos;,&apos;Uint
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -8618,7 +8676,8 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -8648,7 +8707,7 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
 </tr>
-<tr><th colspan="141" class="separator"></th>
+<tr><th colspan="142" class="separator"></th>
 </tr>
 <tr class="supertest" significance="1"><td id="test-decompilation"><span><a class="anchor" href="#test-decompilation">&#xA7;</a>decompilation</span></td>
 <td class="tally obsolete" data-browser="konq4_13" data-tally="0">0/4</td>
@@ -8760,7 +8819,8 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="tally obsolete" data-browser="graalvm21" data-tally="0">0/4</td>
 <td class="tally" data-browser="graalvm21_3_3" data-tally="0">0/4</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="0">0/4</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="0">0/4</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="0">0/4</td>
@@ -8903,7 +8963,8 @@ return typeof uneval === &apos;function&apos;;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -9054,7 +9115,8 @@ return &apos;toSource&apos; in Object.prototype
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -9197,7 +9259,8 @@ return uneval({ toSource: function() { return &quot;pwnd!&quot; } }) === &quot;p
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -9426,7 +9489,8 @@ return true;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -9570,7 +9634,8 @@ return eval(&quot;x&quot;, { x: 2 }) === 2;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -9600,7 +9665,7 @@ return eval(&quot;x&quot;, { x: 2 }) === 2;
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
 </tr>
-<tr><th colspan="141" class="separator"></th>
+<tr><th colspan="142" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-function_caller_property"><span><a class="anchor" href="#test-function_caller_property">&#xA7;</a>function &quot;caller&quot; property <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/caller" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return &apos;caller&apos; in function(){};
@@ -9717,7 +9782,8 @@ return 'caller' in function(){};
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -9866,7 +9932,8 @@ return (function () {}).arity === 0 &&
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -10017,7 +10084,8 @@ return f(1, 'boo');
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-experimental-options-js-v8-compat-note"><sup>[7]</sup></a></td>
 <td class="no flagged" data-browser="graalvm22_2">Flag<a href="#graalvm-experimental-options-js-v8-compat-note"><sup>[7]</sup></a></td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -10162,7 +10230,8 @@ return typeof Function.prototype.isGenerator === 'function';
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -10192,7 +10261,7 @@ return typeof Function.prototype.isGenerator === 'function';
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
 </tr>
-<tr><th colspan="141" class="separator"></th>
+<tr><th colspan="142" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-class_extends_null"><span><a class="anchor" href="#test-class_extends_null">&#xA7;</a><a href="https://github.com/tc39/ecma262/issues/543">class extends null</a></span><script data-source="
 class C extends null {}
@@ -10308,7 +10377,8 @@ return new C instanceof C;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -10455,7 +10525,8 @@ return typeof ({}).__count__ === 'number' &&
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -10600,7 +10671,8 @@ return typeof ({}).__parent__ !== 'undefined';
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -10755,7 +10827,8 @@ return executed;
 <td class="no flagged obsolete" data-browser="graalvm21">Flag<a href="#graalvm-nashorn-compat-note"><sup>[8]</sup></a></td>
 <td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-experimental-options-js-nashorn-compat-note"><sup>[9]</sup></a></td>
 <td class="no flagged" data-browser="graalvm22_2">Flag<a href="#graalvm-experimental-options-js-nashorn-compat-note"><sup>[9]</sup></a></td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -10900,7 +10973,8 @@ return typeof Array.slice === 'function' && Array.slice('abc').length === 3;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -11045,7 +11119,8 @@ return typeof String.slice === 'function' && String.slice(123, 1) === "23";
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -11075,7 +11150,7 @@ return typeof String.slice === 'function' && String.slice(123, 1) === "23";
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
 </tr>
-<tr><th colspan="141" class="separator"></th>
+<tr><th colspan="142" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Array_comprehensions_(JS_1.8_style)"><span><a class="anchor" href="#test-Array_comprehensions_(JS_1.8_style)">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Predefined_Core_Objects#Array_comprehensions">Array comprehensions (JS 1.8 style)</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Array_comprehensions#Differences_to_the_older_JS1.7JS1.8_comprehensions" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var obj = { 2: true, &quot;foo&quot;: true, 4: true };
@@ -11192,7 +11267,8 @@ return a instanceof Array &amp;&amp; a[0] === 4 &amp;&amp; a[1] === 8;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -11335,7 +11411,8 @@ return [for (a of [1, 2, 3]) a * a] + &apos;&apos; === &apos;1,4,9&apos;;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -11478,7 +11555,8 @@ return (function(x)x)(1) === 1;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-experimental-options-js-nashorn-compat-note"><sup>[9]</sup></a></td>
 <td class="no flagged" data-browser="graalvm22_2">Flag<a href="#graalvm-experimental-options-js-nashorn-compat-note"><sup>[9]</sup></a></td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -11621,7 +11699,8 @@ return typeof &lt;foo/&gt; === &quot;xml&quot;;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -11768,7 +11847,8 @@ return str === &quot;foobarbaz&quot;;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-experimental-options-js-nashorn-compat-note"><sup>[9]</sup></a></td>
 <td class="no flagged" data-browser="graalvm22_2">Flag<a href="#graalvm-experimental-options-js-nashorn-compat-note"><sup>[9]</sup></a></td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -11912,7 +11992,8 @@ return arr[1] === arr;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -11942,7 +12023,7 @@ return arr[1] === arr;
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
 </tr>
-<tr><th colspan="141" class="separator"></th>
+<tr><th colspan="142" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Iterator"><span><a class="anchor" href="#test-Iterator">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators">Iterator</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 /* global Iterator */
@@ -12089,7 +12170,8 @@ catch(e) {
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -12272,7 +12354,8 @@ catch(e) {
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -12454,7 +12537,8 @@ global.test((function () {
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -12599,7 +12683,8 @@ return g.next() === 4 &amp;&amp; g.next() === 8;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -12749,7 +12834,8 @@ return passed;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -12779,7 +12865,7 @@ return passed;
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
 </tr>
-<tr><th colspan="141" class="separator"></th>
+<tr><th colspan="142" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-RegExp_x_flag"><span><a class="anchor" href="#test-RegExp_x_flag">&#xA7;</a>RegExp &quot;x&quot; flag</span><script data-source="function () {
 try {
@@ -12910,7 +12996,8 @@ try {
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -13053,7 +13140,8 @@ return /\\w/(&quot;x&quot;)[0] === &quot;x&quot;;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -13197,7 +13285,8 @@ return /(?P&lt;name&gt;a)(?P=name)/.test(&quot;aa&quot;) &amp;&amp;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -13227,7 +13316,7 @@ return /(?P&lt;name&gt;a)(?P=name)/.test(&quot;aa&quot;) &amp;&amp;
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
 </tr>
-<tr><th colspan="141" class="separator"></th>
+<tr><th colspan="142" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-String.prototype.quote"><span><a class="anchor" href="#test-String.prototype.quote">&#xA7;</a>String.prototype.quote <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/quote" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () { return typeof String.prototype.quote === &apos;function&apos; }">test(
 function () { return typeof String.prototype.quote === 'function' }())</script></td>
@@ -13340,7 +13429,8 @@ function () { return typeof String.prototype.quote === 'function' }())</script><
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -13481,7 +13571,8 @@ function () { return 'foofoo'.replace('foo', 'bar', 'g') === 'barbar' }())</scri
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -13511,7 +13602,7 @@ function () { return 'foofoo'.replace('foo', 'bar', 'g') === 'barbar' }())</scri
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
 </tr>
-<tr><th colspan="141" class="separator"></th>
+<tr><th colspan="142" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Date.prototype.toLocaleFormat"><span><a class="anchor" href="#test-Date.prototype.toLocaleFormat">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleFormat">Date.prototype.toLocaleFormat</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleFormat" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () { return typeof Date.prototype.toLocaleFormat === &apos;function&apos; }">test(
 function () { return typeof Date.prototype.toLocaleFormat === 'function' }())</script></td>
@@ -13624,7 +13715,8 @@ function () { return typeof Date.prototype.toLocaleFormat === 'function' }())</s
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -13775,7 +13867,8 @@ return !brokenOnFirefox && !brokenOnIE10 && !brokenOnChrome;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -13805,7 +13898,7 @@ return !brokenOnFirefox && !brokenOnIE10 && !brokenOnChrome;
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
 </tr>
-<tr><th colspan="141" class="separator"></th>
+<tr><th colspan="142" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Object.prototype.watch"><span><a class="anchor" href="#test-Object.prototype.watch">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/watch">Object.prototype.watch</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/watch" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () { return typeof Object.prototype.watch === &apos;function&apos; }">test(
 function () { return typeof Object.prototype.watch === 'function' }())</script></td>
@@ -13918,7 +14011,8 @@ function () { return typeof Object.prototype.watch === 'function' }())</script><
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -14059,7 +14153,8 @@ function () { return typeof Object.prototype.unwatch === 'function' }())</script
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -14200,7 +14295,8 @@ function () { return typeof Object.prototype.eval === 'function' }())</script></
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -14343,7 +14439,8 @@ return typeof Object.observe === &apos;function&apos;;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -14373,7 +14470,7 @@ return typeof Object.observe === &apos;function&apos;;
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
 </tr>
-<tr><th colspan="141" class="separator"></th>
+<tr><th colspan="142" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-error_stack"><span><a class="anchor" href="#test-error_stack">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack">error &quot;stack&quot;</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 try {
@@ -14498,7 +14595,8 @@ try {
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -14643,7 +14741,8 @@ return 'lineNumber' in new Error();
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-experimental-options-js-nashorn-compat-note"><sup>[9]</sup></a></td>
 <td class="no flagged" data-browser="graalvm22_2">Flag<a href="#graalvm-experimental-options-js-nashorn-compat-note"><sup>[9]</sup></a></td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -14788,7 +14887,8 @@ return 'columnNumber' in new Error();
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-experimental-options-js-nashorn-compat-note"><sup>[9]</sup></a></td>
 <td class="no flagged" data-browser="graalvm22_2">Flag<a href="#graalvm-experimental-options-js-nashorn-compat-note"><sup>[9]</sup></a></td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -14933,7 +15033,8 @@ return 'fileName' in new Error();
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -15078,7 +15179,8 @@ return 'description' in new Error();
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -15108,7 +15210,7 @@ return 'description' in new Error();
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
 </tr>
-<tr><th colspan="141" class="separator"></th>
+<tr><th colspan="142" class="separator"></th>
 </tr>
 <tr class="supertest" significance="1"><td id="test-global"><span><a class="anchor" href="#test-global">&#xA7;</a>global</span></td>
 <td class="tally obsolete" data-browser="konq4_13" data-tally="0">0/2</td>
@@ -15220,7 +15322,8 @@ return 'description' in new Error();
 <td class="tally obsolete" data-browser="graalvm21" data-tally="0.5">1/2</td>
 <td class="tally" data-browser="graalvm21_3_3" data-tally="0" data-flagged-tally="1">0/2</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="0" data-flagged-tally="1">0/2</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="hermes0_12_0" data-tally="0">0/2</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="0">0/2</td>
@@ -15365,7 +15468,8 @@ return typeof global === &apos;object&apos; &amp;&amp; global &amp;&amp; global 
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-experimental-options-js-global-property-note"><sup>[10]</sup></a></td>
 <td class="no flagged" data-browser="graalvm22_2">Flag<a href="#graalvm-experimental-options-js-global-property-note"><sup>[10]</sup></a></td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -15515,7 +15619,8 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-experimental-options-js-global-property-note"><sup>[10]</sup></a></td>
 <td class="no flagged" data-browser="graalvm22_2">Flag<a href="#graalvm-experimental-options-js-global-property-note"><sup>[10]</sup></a></td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -15663,7 +15768,8 @@ return Object.getOwnPropertyNames(P) + &apos;&apos; === &quot;a,a,b,b&quot;;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="unknown obsolete" data-browser="hermes0_12_0">?</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>


### PR DESCRIPTION
Hermes is a JavaScript engine optimised for React Native which is used as default JS engine for react native.  And we have a bundled Hermes version along with each react native release.

This PR,

1. Adding support to run react native bundler in hermes.js. I created a metro proxy script for this use case and is available here - [rn-bundle-proxy](https://github.com/jacdebug/rn-bundle-proxy).
2. Hide Hermes by marking obsolete true and add react native as mobile runtime. (if there is more interest in Hermes we can revert this change and show Hermes). Long term this will help to cleanup Hermes and support react native only.
3. Update data
4. Update build

Ref:

- https://reactnative.dev/blog/2022/07/08/hermes-as-the-default
- https://github.com/facebook/react-native/releases

