### PR TITLE
Adding React Native 0.70.3 using bundled Hermes and metro-react-native babel preset

### DIFF
--- a/data-es2016plus.js
+++ b/data-es2016plus.js
@@ -43,6 +43,7 @@ exports.tests = [
           jerryscript2_3_0: true,
           graalvm19: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false,
           rhino1_7_14: true,
         }
@@ -71,6 +72,7 @@ exports.tests = [
           jerryscript2_3_0: true,
           graalvm19: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false,
           rhino1_7_14: true,
         }
@@ -100,6 +102,7 @@ exports.tests = [
           jerryscript2_3_0: true,
           graalvm19: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false,
           rhino1_7_14: true,
         }
@@ -143,6 +146,7 @@ exports.tests = [
           jerryscript2_4_0: true,
           graalvm19: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false,
           rhino1_7_14: true,
         }
@@ -180,6 +184,7 @@ exports.tests = [
           jerryscript2_4_0: true,
           graalvm19: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false,
           rhino1_7_14: true,
         }
@@ -217,6 +222,7 @@ exports.tests = [
           jerryscript2_4_0: true,
           graalvm19: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -243,6 +249,7 @@ exports.tests = [
           jerryscript2_4_0: true,
           graalvm19: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       }
@@ -281,6 +288,7 @@ exports.tests = [
           jerryscript2_4_0: true,
           graalvm19: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: true
         }
       },
@@ -310,6 +318,7 @@ exports.tests = [
           jerryscript2_4_0: true,
           graalvm19: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: true
         }
       },
@@ -358,6 +367,7 @@ exports.tests = [
           jerryscript2_4_0: true,
           graalvm19: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false,
           rhino1_7_14: true,
         }
@@ -388,6 +398,7 @@ exports.tests = [
           jerryscript2_4_0: true,
           graalvm19: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       }
@@ -431,6 +442,7 @@ exports.tests = [
           jerryscript2_4_0: true,
           graalvm19: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: true
         }
       },
@@ -466,6 +478,7 @@ exports.tests = [
           jerryscript2_4_0: true,
           graalvm19: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: true
         }
       }
@@ -502,6 +515,7 @@ exports.tests = [
           jerryscript2_4_0: true,
           graalvm19: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -528,6 +542,7 @@ exports.tests = [
           jerryscript2_3_0: true,
           graalvm19: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: true
         }
       }
@@ -577,6 +592,7 @@ exports.tests = [
           graalvm19: true,
           hermes0_7_0: false,
           hermes0_12_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -617,6 +633,7 @@ exports.tests = [
           graalvm19: true,
           hermes0_7_0: false,
           hermes0_12_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -647,6 +664,7 @@ exports.tests = [
           graalvm19: true,
           hermes0_7_0: false,
           hermes0_12_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -675,6 +693,7 @@ exports.tests = [
           graalvm19: true,
           hermes0_7_0: false,
           hermes0_12_0: true,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -710,6 +729,7 @@ exports.tests = [
           graalvm19: true,
           hermes0_7_0: false,
           hermes0_12_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -747,6 +767,7 @@ exports.tests = [
           graalvm19: true,
           hermes0_7_0: false,
           hermes0_12_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -776,6 +797,7 @@ exports.tests = [
           graalvm19: true,
           hermes0_7_0: false,
           hermes0_12_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -810,6 +832,7 @@ exports.tests = [
           graalvm19: true,
           hermes0_7_0: false,
           hermes0_12_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -839,6 +862,7 @@ exports.tests = [
           jerryscript2_3_0: true,
           graalvm19: true,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -878,6 +902,7 @@ exports.tests = [
           graalvm19: true,
           hermes0_7_0: false,
           hermes0_12_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -916,6 +941,7 @@ exports.tests = [
           jerryscript2_3_0: true,
           graalvm19: true,
           hermes0_7_0: false,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -955,6 +981,7 @@ exports.tests = [
           jerryscript2_3_0: true,
           graalvm19: true,
           hermes0_7_0: false,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -990,6 +1017,7 @@ exports.tests = [
           jerryscript2_3_0: true,
           graalvm19: true,
           hermes0_7_0: false,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -1021,6 +1049,7 @@ exports.tests = [
           graalvm19: true,
           hermes0_7_0: false,
           hermes0_12_0: true,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -1049,6 +1078,7 @@ exports.tests = [
           graalvm19: true,
           hermes0_7_0: false,
           hermes0_12_0: true,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -1087,6 +1117,7 @@ exports.tests = [
           graalvm19: true,
           hermes0_7_0: false,
           hermes0_12_0: true,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       }
@@ -1156,6 +1187,7 @@ exports.tests = [
           jerryscript2_3_0: false,
           graalvm19: true,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -1190,6 +1222,7 @@ exports.tests = [
           jerryscript2_3_0: false,
           graalvm19: true,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -1227,6 +1260,7 @@ exports.tests = [
           jerryscript2_3_0: false,
           graalvm19: true,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -1263,6 +1297,7 @@ exports.tests = [
           jerryscript2_3_0: false,
           graalvm19: true,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -1299,6 +1334,7 @@ exports.tests = [
           jerryscript2_3_0: false,
           graalvm19: true,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -1336,6 +1372,7 @@ exports.tests = [
           jerryscript2_3_0: false,
           graalvm19: true,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -1373,6 +1410,7 @@ exports.tests = [
           jerryscript2_3_0: false,
           graalvm19: true,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -1410,6 +1448,7 @@ exports.tests = [
           jerryscript2_3_0: false,
           graalvm19: true,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -1447,6 +1486,7 @@ exports.tests = [
           jerryscript2_3_0: false,
           graalvm19: true,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -1484,6 +1524,7 @@ exports.tests = [
           jerryscript2_3_0: false,
           graalvm19: true,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -1522,6 +1563,7 @@ exports.tests = [
           graalvm19: false,
           graalvm20: true,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -1559,6 +1601,7 @@ exports.tests = [
           jerryscript2_3_0: false,
           graalvm19: true,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -1596,6 +1639,7 @@ exports.tests = [
           jerryscript2_3_0: false,
           graalvm19: true,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -1633,6 +1677,7 @@ exports.tests = [
           jerryscript2_3_0: false,
           graalvm19: true,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -1670,6 +1715,7 @@ exports.tests = [
           jerryscript2_3_0: false,
           graalvm19: true,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -1707,6 +1753,7 @@ exports.tests = [
           jerryscript2_3_0: false,
           graalvm19: true,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -1744,6 +1791,7 @@ exports.tests = [
           jerryscript2_3_0: false,
           graalvm19: true,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       }
@@ -1783,6 +1831,7 @@ exports.tests = [
       jerryscript2_3_0: true,
       graalvm19: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }
   },
@@ -1832,6 +1881,7 @@ exports.tests = [
       jerryscript2_3_0: true,
       graalvm19: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: true
     }
   },
@@ -1867,6 +1917,7 @@ exports.tests = [
       jerryscript2_3_0: true,
       graalvm19: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }
   },
@@ -1902,6 +1953,7 @@ exports.tests = [
       jerryscript2_3_0: true,
       graalvm19: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }
   },
@@ -1937,6 +1989,7 @@ exports.tests = [
       jerryscript2_3_0: true,
       graalvm19: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }
   },
@@ -1977,6 +2030,7 @@ exports.tests = [
       jerryscript2_4_0: true,
       graalvm19: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }
   },
@@ -2010,6 +2064,7 @@ exports.tests = [
       jerryscript2_4_0: true,
       graalvm19: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }
   },
@@ -2049,6 +2104,7 @@ exports.tests = [
         jerryscript2_4_0: true,
         graalvm19: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -2082,6 +2138,7 @@ exports.tests = [
           jerryscript2_4_0: true,
           graalvm19: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -2115,6 +2172,7 @@ exports.tests = [
           jerryscript2_4_0: true,
           graalvm19: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: true
         }
       },
@@ -2149,6 +2207,7 @@ exports.tests = [
           jerryscript2_4_0: true,
           graalvm19: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: true
         }
       },
@@ -2182,6 +2241,7 @@ exports.tests = [
           jerryscript2_4_0: true,
           graalvm19: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -2215,6 +2275,7 @@ exports.tests = [
           jerryscript2_4_0: true,
           graalvm19: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: true
         }
       },
@@ -2250,6 +2311,7 @@ exports.tests = [
           jerryscript2_4_0: true,
           graalvm19: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: true
         }
       },
@@ -2285,6 +2347,7 @@ exports.tests = [
           jerryscript2_4_0: true,
           graalvm19: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: true
         }
       },
@@ -2320,6 +2383,7 @@ exports.tests = [
           jerryscript2_4_0: true,
           graalvm19: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -2351,6 +2415,7 @@ exports.tests = [
           jerryscript2_4_0: true,
           graalvm19: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -2382,6 +2447,7 @@ exports.tests = [
           jerryscript2_4_0: true,
           graalvm19: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: true
         }
       },
@@ -2417,6 +2483,7 @@ exports.tests = [
           jerryscript2_4_0: true,
           graalvm19: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: true
         }
       },
@@ -2452,6 +2519,7 @@ exports.tests = [
           jerryscript2_4_0: true,
           graalvm19: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: true
         }
       },
@@ -2487,6 +2555,7 @@ exports.tests = [
           jerryscript2_4_0: true,
           graalvm19: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -2518,6 +2587,7 @@ exports.tests = [
           jerryscript2_4_0: true,
           graalvm19: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -2549,6 +2619,7 @@ exports.tests = [
           jerryscript2_4_0: true,
           graalvm19: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: true
         }
       }
@@ -2581,6 +2652,7 @@ exports.tests = [
         jerryscript2_4_0: true,
         graalvm19: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2606,6 +2678,7 @@ exports.tests = [
           jerryscript2_4_0: true,
           graalvm19: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -2637,6 +2710,7 @@ exports.tests = [
           jerryscript2_4_0: true,
           graalvm19: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -2668,6 +2742,7 @@ exports.tests = [
           jerryscript2_4_0: true,
           graalvm19: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       }
@@ -2704,6 +2779,7 @@ exports.tests = [
       graalvm19: false,
       graalvm20: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }
   },
@@ -2731,6 +2807,7 @@ exports.tests = [
       jerryscript2_4_0: true,
       graalvm19: true,
       hermes0_7_0: false,
+      reactnative0_70_3: false,
       rhino1_7_13: false
     }
   },
@@ -2768,6 +2845,7 @@ exports.tests = [
       jerryscript2_3_0: false,
       graalvm19: true,
       hermes0_7_0: true,
+      reactnative0_70_3: false,
       rhino1_7_13: true
     }
   },
@@ -2798,6 +2876,7 @@ exports.tests = [
       jerryscript2_4_0: true,
       graalvm19: true,
       hermes0_7_0: false,
+      reactnative0_70_3: false,
       rhino1_7_13: false
     }
   },
@@ -2839,6 +2918,7 @@ exports.tests = [
           jerryscript2_4_0: true,
           graalvm19: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -2874,6 +2954,7 @@ exports.tests = [
           jerryscript2_4_0: true,
           graalvm19: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       }
@@ -2939,6 +3020,7 @@ exports.tests = [
           graalvm19: true,
           hermes0_7_0: false,
           hermes0_12_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -2987,6 +3069,7 @@ exports.tests = [
           graalvm19: true,
           hermes0_7_0: false,
           hermes0_12_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -3037,6 +3120,7 @@ exports.tests = [
           graalvm19: true,
           hermes0_7_0: false,
           hermes0_12_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       }
@@ -3074,6 +3158,7 @@ exports.tests = [
       jerryscript2_3_0: false,
       graalvm19: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false,
       rhino1_7_14: true,
     }
@@ -3121,6 +3206,7 @@ exports.tests = [
       ios4: null,
       graalvm19: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }
   },
@@ -3155,6 +3241,7 @@ exports.tests = [
       jerryscript2_3_0: false,
       graalvm19: true,
       hermes0_7_0: false,
+      reactnative0_70_3: false,
       rhino1_7_13: false
     }
   },
@@ -3182,6 +3269,7 @@ exports.tests = [
       jerryscript2_3_0: false,
       graalvm19: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }
   },
@@ -3210,6 +3298,7 @@ exports.tests = [
       jerryscript2_3_0: false,
       graalvm19: true,
       hermes0_7_0: false,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }
   },
@@ -3250,6 +3339,7 @@ exports.tests = [
           jerryscript2_4_0: true,
           graalvm19: true,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -3295,6 +3385,7 @@ exports.tests = [
           jerryscript2_4_0: true,
           graalvm19: true,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       }
@@ -3337,6 +3428,7 @@ exports.tests = [
           jerryscript2_4_0: true,
           graalvm19: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -3373,6 +3465,7 @@ exports.tests = [
           graalvm19: true,
           hermes0_7_0: false,
           hermes0_12_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -3411,6 +3504,7 @@ exports.tests = [
           jerryscript2_4_0: true,
           graalvm20: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       }
@@ -3451,6 +3545,7 @@ exports.tests = [
           graalvm19: true,
           hermes0_7_0: false,
           hermes0_12_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -3482,6 +3577,7 @@ exports.tests = [
           graalvm19: true,
           hermes0_7_0: false,
           hermes0_12_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -3512,6 +3608,7 @@ exports.tests = [
           jerryscript2_4_0: true,
           graalvm19: true,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       }
@@ -3541,6 +3638,7 @@ exports.tests = [
         jerryscript2_3_0: false,
         graalvm19: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }, {
@@ -3565,6 +3663,7 @@ exports.tests = [
         jerryscript2_3_0: false,
         graalvm19: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }, {
@@ -3589,6 +3688,7 @@ exports.tests = [
         jerryscript2_3_0: false,
         graalvm19: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     }, {
@@ -3610,6 +3710,7 @@ exports.tests = [
         jerryscript2_3_0: false,
         graalvm19: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }, {
@@ -3631,6 +3732,7 @@ exports.tests = [
         jerryscript2_3_0: false,
         graalvm19: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }, {
@@ -3650,6 +3752,7 @@ exports.tests = [
         jerryscript2_3_0: false,
         graalvm19: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }, {
@@ -3671,6 +3774,7 @@ exports.tests = [
         jerryscript2_3_0: false,
         graalvm19: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }]
@@ -3703,6 +3807,7 @@ exports.tests = [
           jerryscript2_4_0: true,
           graalvm19: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false,
           rhino1_7_14: true,
         }
@@ -3729,6 +3834,7 @@ exports.tests = [
           jerryscript2_4_0: true,
           graalvm19: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false,
           rhino1_7_14: true,
         }
@@ -3766,6 +3872,7 @@ exports.tests = [
       chrome73: true,
       chrome74: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false,
       rhino1_7_14: true,
     }
@@ -3802,6 +3909,7 @@ exports.tests = [
       jerryscript2_4_0: true,
       graalvm19: true,
       hermes0_7_0: false,
+      reactnative0_70_3: false,
       rhino1_7_13: false
     }
   },
@@ -3850,6 +3958,7 @@ exports.tests = [
           jerryscript2_4_0: true,
           graalvm19: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: true
         }
       },
@@ -3892,6 +4001,7 @@ exports.tests = [
           jerryscript2_4_0: true,
           graalvm19: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: true
         }
       },
@@ -3924,6 +4034,7 @@ exports.tests = [
           jerryscript2_4_0: true,
           graalvm19: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: true
         }
       },
@@ -3956,6 +4067,7 @@ exports.tests = [
           jerryscript2_4_0: true,
           graalvm19: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: true
         }
       }
@@ -4004,6 +4116,7 @@ exports.tests = [
           jerryscript2_4_0: true,
           graalvm19: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -4033,6 +4146,7 @@ exports.tests = [
           jerryscript2_4_0: true,
           graalvm19: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -4064,6 +4178,7 @@ exports.tests = [
           jerryscript2_4_0: true,
           graalvm19: true,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       }
@@ -4115,6 +4230,7 @@ exports.tests = [
           graalvm20: graalvm.es2020flag,
           graalvm20_1: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -4156,6 +4272,7 @@ exports.tests = [
           graalvm20: graalvm.es2020flag,
           graalvm20_1: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       }
@@ -4189,6 +4306,7 @@ exports.tests = [
           graalvm19: true,
           hermes0_7_0: false,
           hermes0_12_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false,
           rhino1_7_14: true,
         }
@@ -4214,6 +4332,7 @@ exports.tests = [
           graalvm19: true,
           hermes0_7_0: false,
           hermes0_12_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false,
           rhino1_7_14: true,
         }
@@ -4238,6 +4357,7 @@ exports.tests = [
           graalvm19: true,
           hermes0_7_0: false,
           hermes0_12_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false,
           rhino1_7_14: true,
         }
@@ -4262,6 +4382,7 @@ exports.tests = [
           graalvm19: true,
           hermes0_7_0: false,
           hermes0_12_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false,
           rhino1_7_14: true,
         }
@@ -4289,6 +4410,7 @@ exports.tests = [
           graalvm19: true,
           hermes0_7_0: false,
           hermes0_12_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -4315,6 +4437,7 @@ exports.tests = [
           graalvm19: true,
           hermes0_7_0: false,
           hermes0_12_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -4342,6 +4465,7 @@ exports.tests = [
           graalvm19: true,
           hermes0_7_0: false,
           hermes0_12_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -4369,6 +4493,7 @@ exports.tests = [
           graalvm19: true,
           hermes0_7_0: false,
           hermes0_12_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       }
@@ -4413,6 +4538,7 @@ exports.tests = [
       graalvm20: graalvm.es2020flag,
       graalvm20_1: true,
       hermes0_7_0: false,
+      reactnative0_70_3: false,
       rhino1_7_13: false
     }
   },
@@ -4462,6 +4588,7 @@ exports.tests = [
         jerryscript2_4_0: true,
         graalvm19: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false,
         rhino1_7_14: true,
       }
@@ -4509,6 +4636,7 @@ exports.tests = [
         jerryscript2_4_0: true,
         graalvm19: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false,
         rhino1_7_14: true,
       }
@@ -4549,6 +4677,7 @@ exports.tests = [
           graalvm20: graalvm.es2020flag,
           graalvm20_1: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -4580,6 +4709,7 @@ exports.tests = [
           graalvm20: graalvm.es2020flag,
           graalvm20_1: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -4611,6 +4741,7 @@ exports.tests = [
           graalvm20: graalvm.es2020flag,
           graalvm20_1: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -4644,6 +4775,7 @@ exports.tests = [
           graalvm20: graalvm.es2020flag,
           graalvm20_1: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -4674,6 +4806,7 @@ exports.tests = [
           safaritp: true,
           duktape2_0: false,
           graalvm21_3_3: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       }
@@ -4714,6 +4847,7 @@ exports.tests = [
       graalvm20: graalvm.es2020flag,
       graalvm20_1: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }
   },
@@ -4753,6 +4887,7 @@ exports.tests = [
       graalvm21: true,
       ios13_4: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }
   },
@@ -4796,6 +4931,7 @@ exports.tests = [
           graalvm20_3: graalvm.es2021flag,
           graalvm21: true,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -4829,6 +4965,7 @@ exports.tests = [
           safaritp: true,
           duktape2_0: false,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false,
           jerryscript2_3_0: false,
           graalvm20_3: graalvm.es2021flag,
@@ -4874,6 +5011,7 @@ exports.tests = [
           graalvm20: graalvm.es2021flag,
           graalvm21: true,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -4902,6 +5040,7 @@ exports.tests = [
           graalvm20_3: graalvm.es2021flag,
           graalvm21: true,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       }
@@ -4945,6 +5084,7 @@ exports.tests = [
           graalvm20_3: graalvm.es2021flag,
           graalvm21: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -4976,6 +5116,7 @@ exports.tests = [
           graalvm20_3: graalvm.es2021flag,
           graalvm21: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -5007,6 +5148,7 @@ exports.tests = [
           graalvm20_3: graalvm.es2021flag,
           graalvm21: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -5042,6 +5184,7 @@ exports.tests = [
           graalvm20_3: graalvm.es2021flag,
           graalvm21: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -5073,6 +5216,7 @@ exports.tests = [
           graalvm20_3: graalvm.es2021flag,
           graalvm21: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -5104,6 +5248,7 @@ exports.tests = [
           graalvm20_3: graalvm.es2021flag,
           graalvm21: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -5139,6 +5284,7 @@ exports.tests = [
           graalvm20_3: graalvm.es2021flag,
           graalvm21: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -5170,6 +5316,7 @@ exports.tests = [
           graalvm20_3: graalvm.es2021flag,
           graalvm21: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -5201,6 +5348,7 @@ exports.tests = [
           graalvm20_3: graalvm.es2021flag,
           graalvm21: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       }
@@ -5239,6 +5387,7 @@ exports.tests = [
       graalvm20: graalvm.es2020flag,
       graalvm20_1: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false,
       rhino1_7_14: true,
     }
@@ -5274,6 +5423,7 @@ exports.tests = [
           duktape2_0: false,
           graalvm19: false,
           graalvm20: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -5307,6 +5457,7 @@ exports.tests = [
           duktape2_0: false,
           graalvm19: false,
           graalvm20: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -5336,6 +5487,7 @@ exports.tests = [
           duktape2_0: false,
           graalvm19: false,
           graalvm20: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -5369,6 +5521,7 @@ exports.tests = [
           graalvm20: false,
           graalvm20_3: true,
           typescript3_8corejs3: false,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -5403,6 +5556,7 @@ exports.tests = [
           graalvm20: false,
           graalvm20_3: true,
           typescript3_8corejs3: false,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -5428,6 +5582,7 @@ exports.tests = [
           duktape2_0: false,
           graalvm19: false,
           graalvm20: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       }
@@ -5464,6 +5619,7 @@ exports.tests = [
           duktape2_0: false,
           graalvm19: false,
           graalvm20: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -5498,7 +5654,8 @@ exports.tests = [
           safari15: true,
           duktape2_0: false,
           graalvm21_3_3: false,
-          graalvm22_2: true
+          graalvm22_2: true,
+          reactnative0_70_3: true
         }
       },
       {
@@ -5526,6 +5683,7 @@ exports.tests = [
           duktape2_0: false,
           graalvm19: false,
           graalvm20: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -5550,6 +5708,7 @@ exports.tests = [
           duktape2_0: false,
           graalvm19: false,
           graalvm20: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       }
@@ -5593,6 +5752,7 @@ exports.tests = [
           safaritp: true,
           graalvm20: false,
           graalvm20_1: true,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -5627,6 +5787,7 @@ exports.tests = [
           safaritp: true,
           graalvm20: false,
           graalvm20_1: true,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -5664,6 +5825,7 @@ exports.tests = [
           safaritp: true,
           graalvm20: false,
           graalvm20_1: true,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -5701,6 +5863,7 @@ exports.tests = [
           safaritp: true,
           graalvm20: false,
           graalvm20_1: true,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       }
@@ -5736,6 +5899,7 @@ exports.tests = [
       duktape2_0: false,
       graalvm21_3_3: graalvm.esStagingFlag,
       graalvm22_2: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }
   },
@@ -5785,6 +5949,7 @@ exports.tests = [
           graalvm21: graalvm.es2022flag,
           graalvm21_3_3: graalvm.esStagingFlag,
           graalvm22_2: true,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -5826,6 +5991,7 @@ exports.tests = [
           graalvm21: graalvm.es2022flag,
           graalvm21_3_3: graalvm.esStagingFlag,
           graalvm22_2: true,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -5883,6 +6049,7 @@ exports.tests = [
           graalvm21: graalvm.es2022flag,
           graalvm21_3_3: graalvm.esStagingFlag,
           graalvm22_2: true,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       }
@@ -5920,6 +6087,7 @@ exports.tests = [
           duktape2_0: false,
           graalvm21_3_3: graalvm.esStagingFlag,
           graalvm22_2: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -5954,6 +6122,7 @@ exports.tests = [
           duktape2_0: false,
           graalvm21_3_3: graalvm.esStagingFlag,
           graalvm22_2: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       }
@@ -5998,6 +6167,7 @@ exports.tests = [
       duktape2_0: false,
       graalvm21_3_3: graalvm.esStagingFlag,
       graalvm22_2: true,
+      reactnative0_70_3: false,
       rhino1_7_13: false
     },
   },
@@ -6027,6 +6197,7 @@ exports.tests = [
           duktape2_0: false,
           graalvm21_3_3: false,
           graalvm22_2: true,
+          reactnative0_70_3: true,
           rhino1_7_14: false,
         }
       },
@@ -6049,6 +6220,7 @@ exports.tests = [
           safari15: true,
           duktape2_0: true,
           graalvm21_3_3: true,
+          reactnative0_70_3: true,
           rhino1_7_14: true,
         }
       },
@@ -6072,6 +6244,7 @@ exports.tests = [
           duktape2_0: false,
           graalvm21_3_3: false,
           graalvm22_2: true,
+          reactnative0_70_3: true,
           rhino1_7_14: false,
         }
       },
@@ -6094,6 +6267,7 @@ exports.tests = [
           safari15: true,
           duktape2_0: true,
           graalvm21_3_3: true,
+          reactnative0_70_3: true,
           rhino1_7_14: true,
         }
       },
@@ -6117,6 +6291,7 @@ exports.tests = [
           duktape2_0: false,
           graalvm21_3_3: false,
           graalvm22_2: true,
+          reactnative0_70_3: true,
           rhino1_7_14: false,
         }
       },
@@ -6139,6 +6314,7 @@ exports.tests = [
           safari15: true,
           duktape2_0: true,
           graalvm21_3_3: true,
+          reactnative0_70_3: true,
           rhino1_7_14: true,
         }
       },
@@ -6162,6 +6338,7 @@ exports.tests = [
           duktape2_0: false,
           graalvm21_3_3: false,
           graalvm22_2: true,
+          reactnative0_70_3: true,
           rhino1_7_14: false,
         }
       },
@@ -6184,6 +6361,7 @@ exports.tests = [
           safari15: true,
           duktape2_0: true,
           graalvm21_3_3: true,
+          reactnative0_70_3: true,
           rhino1_7_14: true,
         }
       },
@@ -6207,6 +6385,7 @@ exports.tests = [
           duktape2_0: false,
           graalvm21_3_3: false,
           graalvm22_2: true,
+          reactnative0_70_3: true,
           rhino1_7_14: false,
         }
       },
@@ -6229,6 +6408,7 @@ exports.tests = [
           safari15: true,
           duktape2_0: true,
           graalvm21_3_3: true,
+          reactnative0_70_3: true,
           rhino1_7_14: true,
         }
       },
@@ -6252,6 +6432,7 @@ exports.tests = [
           duktape2_0: false,
           graalvm21_3_3: false,
           graalvm22_2: true,
+          reactnative0_70_3: true,
           rhino1_7_14: false,
         }
       },
@@ -6274,6 +6455,7 @@ exports.tests = [
           safari15: true,
           duktape2_0: true,
           graalvm21_3_3: true,
+          reactnative0_70_3: true,
           rhino1_7_14: true,
         }
       },
@@ -6297,6 +6479,7 @@ exports.tests = [
           duktape2_0: false,
           graalvm21_3_3: false,
           graalvm22_2: true,
+          reactnative0_70_3: true,
           rhino1_7_14: false,
         }
       },
@@ -6319,6 +6502,7 @@ exports.tests = [
           safari15: true,
           duktape2_0: true,
           graalvm21_3_3: true,
+          reactnative0_70_3: true,
           rhino1_7_14: true,
         }
       },
@@ -6342,6 +6526,7 @@ exports.tests = [
           duktape2_0: false,
           graalvm21_3_3: false,
           graalvm22_2: true,
+          reactnative0_70_3: false,
           rhino1_7_14: false,
         }
       },
@@ -6364,6 +6549,7 @@ exports.tests = [
           safari15: true,
           duktape2_0: false,
           graalvm21_3_3: true,
+          reactnative0_70_3: false,
           rhino1_7_14: false,
         }
       },
@@ -6388,6 +6574,7 @@ exports.tests = [
           chrome90: true,
           graalvm21_3_3: graalvm.esStagingFlag,
           graalvm22_2: true,
+          reactnative0_70_3: false
         }
       },
       {
@@ -6419,6 +6606,7 @@ exports.tests = [
           chrome90: false,
           graalvm21_3_3: graalvm.esStagingFlag,
           graalvm22_2: true,
+          reactnative0_70_3: false
         }
       }
     ]
@@ -6460,6 +6648,7 @@ exports.tests = [
           duktape2_0: false,
           graalvm21_3_3: false,
           graalvm22_2: graalvm.esStagingFlag,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -6490,6 +6679,7 @@ exports.tests = [
           duktape2_0: false,
           graalvm21_3_3: false,
           graalvm22_2: graalvm.esStagingFlag,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       }
@@ -6525,6 +6715,7 @@ exports.tests = [
       babel7corejs3: false,
       typescript3_2corejs3: false,
       closure: false,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }
   },

--- a/data-es5.js
+++ b/data-es5.js
@@ -33,7 +33,8 @@ exports.tests = [
       nashorn9: true,
       graalvm19: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -60,7 +61,8 @@ exports.tests = [
       nashorn9: true,
       graalvm19: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -87,7 +89,8 @@ exports.tests = [
       nashorn10: true,
       graalvm19: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -114,7 +117,8 @@ exports.tests = [
       nashorn10: true,
       graalvm19: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -145,7 +149,8 @@ exports.tests = [
       nashorn10: true,
       graalvm19: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   }],
   separator: 'after'
@@ -178,7 +183,8 @@ exports.tests = [
       nashorn10: true,
       graalvm19: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -218,7 +224,8 @@ exports.tests = [
       nashorn10: true,
       graalvm19: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -246,7 +253,8 @@ exports.tests = [
       nashorn10: true,
       graalvm19: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -276,7 +284,8 @@ exports.tests = [
       nashorn10: true,
       graalvm19: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -307,7 +316,8 @@ exports.tests = [
       nashorn10: true,
       graalvm19: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -335,7 +345,8 @@ exports.tests = [
       nashorn10: true,
       graalvm19: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -363,7 +374,8 @@ exports.tests = [
       nashorn10: true,
       graalvm19: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -391,7 +403,8 @@ exports.tests = [
       nashorn10: true,
       graalvm19: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -419,7 +432,8 @@ exports.tests = [
       nashorn10: true,
       graalvm19: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -447,7 +461,8 @@ exports.tests = [
       nashorn10: true,
       graalvm19: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -475,7 +490,8 @@ exports.tests = [
       nashorn10: true,
       graalvm19: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -511,7 +527,8 @@ exports.tests = [
       nashorn10: true,
       graalvm19: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -541,7 +558,8 @@ exports.tests = [
       nashorn10: true,
       graalvm19: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     },
     separator: 'after'
   }],
@@ -577,7 +595,8 @@ exports.tests = [
         nashorn10: true,
         graalvm19: true,
         jerryscript1_0: true,
-        hermes0_7_0: true
+        hermes0_7_0: true,
+        reactnative0_70_3: true
       }
     },
     {
@@ -605,7 +624,8 @@ exports.tests = [
         nashorn10: true,
         graalvm19: true,
         jerryscript1_0: true,
-        hermes0_7_0: true
+        hermes0_7_0: true,
+        reactnative0_70_3: true
       }
     },
     {
@@ -633,7 +653,8 @@ exports.tests = [
         nashorn10: true,
         graalvm19: true,
         jerryscript1_0: true,
-        hermes0_7_0: true
+        hermes0_7_0: true,
+        reactnative0_70_3: true
       }
     },
     {
@@ -661,7 +682,8 @@ exports.tests = [
         nashorn10: true,
         graalvm19: true,
         jerryscript1_0: true,
-        hermes0_7_0: true
+        hermes0_7_0: true,
+        reactnative0_70_3: true
       }
     },
     {
@@ -689,7 +711,8 @@ exports.tests = [
         nashorn10: true,
         graalvm19: true,
         jerryscript1_0: true,
-        hermes0_7_0: true
+        hermes0_7_0: true,
+        reactnative0_70_3: true
       }
     },
     {
@@ -717,7 +740,8 @@ exports.tests = [
         nashorn10: true,
         graalvm19: true,
         jerryscript1_0: true,
-        hermes0_7_0: true
+        hermes0_7_0: true,
+        reactnative0_70_3: true
       }
     },
     {
@@ -745,7 +769,8 @@ exports.tests = [
         nashorn10: true,
         graalvm19: true,
         jerryscript1_0: true,
-        hermes0_7_0: true
+        hermes0_7_0: true,
+        reactnative0_70_3: true
       }
     },
     {
@@ -773,7 +798,8 @@ exports.tests = [
         nashorn10: true,
         graalvm19: true,
         jerryscript1_0: true,
-        hermes0_7_0: true
+        hermes0_7_0: true,
+        reactnative0_70_3: true
       }
     },
     {
@@ -801,7 +827,8 @@ exports.tests = [
         nashorn10: true,
         graalvm19: true,
         jerryscript1_0: true,
-        hermes0_7_0: true
+        hermes0_7_0: true,
+        reactnative0_70_3: true
       }
     },
     {
@@ -829,7 +856,8 @@ exports.tests = [
         nashorn10: true,
         graalvm19: true,
         jerryscript1_0: true,
-        hermes0_7_0: true
+        hermes0_7_0: true,
+        reactnative0_70_3: true
       }
     },
     {
@@ -884,7 +912,8 @@ exports.tests = [
         nashorn10: true,
         graalvm19: true,
         jerryscript1_0: true,
-        hermes0_7_0: true
+        hermes0_7_0: true,
+        reactnative0_70_3: true
       }
     },
     {
@@ -919,7 +948,8 @@ exports.tests = [
         nashorn10: true,
         graalvm19: true,
         jerryscript1_0: true,
-        hermes0_7_0: true
+        hermes0_7_0: true,
+        reactnative0_70_3: true
       }
     },
     {
@@ -943,7 +973,8 @@ exports.tests = [
         opera12: true,
         safari4: true,
         safari15: true,
-        graalvm21_3_3: true
+        graalvm21_3_3: true,
+        reactnative0_70_3: true
       }
     }
   ],
@@ -976,7 +1007,8 @@ exports.tests = [
       nashorn10: true,
       graalvm19: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -1027,6 +1059,7 @@ exports.tests = [
       jerryscript1_0: false,
       jerryscript2_2_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }
   },
@@ -1045,7 +1078,8 @@ exports.tests = [
       chrome15: true,
       firefox3: true,
       opera11: true,
-      graalvm21_3_3: true
+      graalvm21_3_3: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -1075,7 +1109,8 @@ exports.tests = [
       nashorn10: true,
       graalvm19: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     },
     separator: 'after'
   }
@@ -1109,7 +1144,8 @@ exports.tests = [
       nashorn10: true,
       graalvm19: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -1136,7 +1172,8 @@ exports.tests = [
       nashorn10: true,
       graalvm19: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -1175,7 +1212,8 @@ exports.tests = [
       nashorn10: true,
       graalvm19: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   }]
 },
@@ -1208,7 +1246,8 @@ exports.tests = [
     nashorn10: true,
     graalvm19: true,
     jerryscript1_0: true,
-    hermes0_7_0: true
+    hermes0_7_0: true,
+    reactnative0_70_3: true
   },
 },
 {
@@ -1243,7 +1282,8 @@ exports.tests = [
     nashorn10: true,
     graalvm19: true,
     jerryscript1_0: true,
-    hermes0_7_0: true
+    hermes0_7_0: true,
+    reactnative0_70_3: true
   },
   separator: 'after'
 },
@@ -1281,7 +1321,8 @@ exports.tests = [
       nashorn10: true,
       graalvm19: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -1314,7 +1355,8 @@ exports.tests = [
       nashorn10: true,
       graalvm19: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -1347,7 +1389,8 @@ exports.tests = [
       nashorn10: true,
       graalvm19: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   }]
 },
@@ -1384,6 +1427,7 @@ exports.tests = [
       edge80: true,
       duktape2_0: true,
       graalvm21_3_3: true,
+      reactnative0_70_3: true,
       rhino1_7_14: true,
     }
   }, {
@@ -1415,6 +1459,7 @@ exports.tests = [
       edge80: true,
       duktape2_0: true,
       graalvm21_3_3: true,
+      reactnative0_70_3: true,
       rhino1_7_14: true,
     }
   }, {
@@ -1441,6 +1486,7 @@ exports.tests = [
       safari11: true,
       duktape2_0: true,
       graalvm21_3_3: true,
+      reactnative0_70_3: true,
       rhino1_7_14: true,
     }
   }],
@@ -1479,7 +1525,8 @@ exports.tests = [
       nashorn10: true,
       graalvm19: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -1509,7 +1556,8 @@ exports.tests = [
       nashorn10: true,
       graalvm19: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -1539,7 +1587,8 @@ exports.tests = [
       nashorn10: true,
       graalvm19: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -1570,7 +1619,8 @@ exports.tests = [
       nashorn10: true,
       graalvm19: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -1605,7 +1655,8 @@ exports.tests = [
       graalvm19: true,
       jerryscript1_0: false,
       jerryscript2_2_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -1635,7 +1686,8 @@ exports.tests = [
       nashorn10: true,
       graalvm19: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -1676,7 +1728,8 @@ exports.tests = [
       graalvm19: true,
       jerryscript1_0: false,
       jerryscript2_0: true,
-      hermes0_7_0: false
+      hermes0_7_0: false,
+      reactnative0_70_3: false
     }
   },
   {
@@ -1709,7 +1762,8 @@ exports.tests = [
       nashorn10: true,
       graalvm19: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   }]
 },
@@ -1747,6 +1801,7 @@ exports.tests = [
       graalvm19: true,
       jerryscript1_0: true,
       hermes0_7_0: hermes.evalStrictMode,
+      reactnative0_70_3: false,
       rhino1_7_13: true
     }
   },
@@ -1779,6 +1834,7 @@ exports.tests = [
       graalvm19: true,
       jerryscript1_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }
   },
@@ -1809,6 +1865,7 @@ exports.tests = [
       graalvm19: true,
       jerryscript1_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }
   },
@@ -1852,6 +1909,7 @@ exports.tests = [
       jerryscript1_0: false,
       jerryscript2_3_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }
   },
@@ -1883,6 +1941,7 @@ exports.tests = [
       graalvm19: true,
       jerryscript1_0: true,
       hermes0_7_0: hermes.evalStrictMode,
+      reactnative0_70_3: false,
       rhino1_7_13: false
     }
   },
@@ -1912,6 +1971,7 @@ exports.tests = [
       graalvm19: true,
       jerryscript1_0: true,
       hermes0_7_0: hermes.evalStrictMode,
+      reactnative0_70_3: false,
       rhino1_7_13: true
     }
   },
@@ -1945,6 +2005,7 @@ exports.tests = [
       graalvm19: true,
       jerryscript1_0: true,
       hermes0_7_0: hermes.evalStrictMode,
+      reactnative0_70_3: false,
       rhino1_7_13: false
     }
   },
@@ -1976,6 +2037,7 @@ exports.tests = [
       jerryscript1_0: false,
       jerryscript2_0: true,
       hermes0_7_0: false,
+      reactnative0_70_3: false,
       rhino1_7_13: false
     }
   },
@@ -2011,6 +2073,7 @@ exports.tests = [
       graalvm19: true,
       jerryscript1_0: true,
       hermes0_7_0: hermes.evalStrictMode,
+      reactnative0_70_3: false,
       rhino1_7_13: true
     }
   },
@@ -2043,6 +2106,7 @@ exports.tests = [
       graalvm19: true,
       jerryscript1_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: true
     }
   },
@@ -2073,6 +2137,7 @@ exports.tests = [
       graalvm19: true,
       jerryscript1_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: true
     }
   },
@@ -2104,6 +2169,7 @@ exports.tests = [
       graalvm19: true,
       jerryscript1_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }
   },
@@ -2139,6 +2205,7 @@ exports.tests = [
       graalvm19: true,
       jerryscript1_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: true
     }
   },
@@ -2168,6 +2235,7 @@ exports.tests = [
       graalvm19: true,
       jerryscript1_0: true,
       hermes0_7_0: hermes.evalLexicalScopeSuccess,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }
   },
@@ -2197,6 +2265,7 @@ exports.tests = [
       graalvm19: true,
       jerryscript1_0: true,
       hermes0_7_0: hermes.evalStrictMode,
+      reactnative0_70_3: false,
       rhino1_7_13: false
     }
   },
@@ -2226,6 +2295,7 @@ exports.tests = [
       graalvm19: true,
       jerryscript1_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: true
     }
   },
@@ -2255,6 +2325,7 @@ exports.tests = [
       graalvm19: true,
       jerryscript1_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: true
     }
   },
@@ -2284,6 +2355,7 @@ exports.tests = [
       graalvm19: true,
       jerryscript1_0: true,
       hermes0_7_0: hermes.evalStrictMode,
+      reactnative0_70_3: false,
       rhino1_7_13: true
     }
   },
@@ -2319,6 +2391,7 @@ exports.tests = [
       jerryscript1_0: false,
       jerryscript2_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: true
     }
   }]

--- a/data-es6.js
+++ b/data-es6.js
@@ -60,6 +60,7 @@ exports.tests = [
         graalvm19: false,
         jerryscript2_0: false,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: true
       }
     },
@@ -96,6 +97,7 @@ exports.tests = [
         graalvm19: false,
         jerryscript2_0: false,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: true
       }
     }
@@ -139,6 +141,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -174,6 +177,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -209,6 +213,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -240,6 +245,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -271,6 +277,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -302,6 +309,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -334,6 +342,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -364,6 +373,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -394,6 +404,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -420,6 +431,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: true
       }
     },
@@ -464,6 +476,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -505,6 +518,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -532,6 +546,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -578,6 +593,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -614,6 +630,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -652,6 +669,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -691,6 +709,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -729,6 +748,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -765,6 +785,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -800,6 +821,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -835,6 +857,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -869,6 +892,7 @@ exports.tests = [
         jerryscript2_2_0: true,
         hermes0_7_0: true,
         hermes0_12_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -908,6 +932,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -945,6 +970,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -984,6 +1010,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -1024,6 +1051,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -1063,6 +1091,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -1100,6 +1129,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -1136,6 +1166,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -1172,6 +1203,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -1207,6 +1239,7 @@ exports.tests = [
         jerryscript2_2_0: true,
         hermes0_7_0: true,
         hermes0_12_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }
@@ -1255,6 +1288,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -1291,6 +1325,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -1329,6 +1364,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -1368,6 +1404,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -1404,6 +1441,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -1438,6 +1476,7 @@ exports.tests = [
         jerryscript2_2_0: true,
         hermes0_7_0: true,
         hermes0_12_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -1480,6 +1519,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -1517,6 +1557,7 @@ exports.tests = [
         jerryscript2_2_0: true,
         graalvm19: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -1553,6 +1594,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -1590,6 +1632,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -1629,6 +1672,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -1669,6 +1713,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -1706,6 +1751,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -1741,6 +1787,7 @@ exports.tests = [
         jerryscript2_2_0: true,
         hermes0_7_0: true,
         hermes0_12_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -1784,6 +1831,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -1821,6 +1869,7 @@ exports.tests = [
         jerryscript2_2_0: true,
         graalvm19: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     }
@@ -1863,6 +1912,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -1896,6 +1946,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -1929,6 +1980,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -1967,6 +2019,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2005,6 +2058,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -2038,6 +2092,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2069,6 +2124,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         jerryscript2_2_0: true,
         rhino1_7_13: false
       }
@@ -2113,6 +2169,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2144,6 +2201,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2182,6 +2240,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2219,6 +2278,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2247,6 +2307,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -2289,6 +2350,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2320,6 +2382,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2354,6 +2417,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2382,6 +2446,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2412,6 +2477,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2441,6 +2507,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2470,6 +2537,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2498,6 +2566,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2530,6 +2599,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2560,6 +2630,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2597,6 +2668,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2629,6 +2701,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2662,6 +2735,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2694,6 +2768,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2728,6 +2803,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -2770,6 +2846,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2807,6 +2884,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2839,6 +2917,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2871,6 +2950,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2907,6 +2987,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2943,6 +3024,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2979,6 +3061,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3015,6 +3098,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3055,6 +3139,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3091,6 +3176,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3127,6 +3213,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3165,6 +3252,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3201,6 +3289,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3239,6 +3328,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3275,6 +3365,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3311,6 +3402,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3343,6 +3435,7 @@ exports.tests = [
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
         hermes0_12_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -3375,6 +3468,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3409,6 +3503,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -3441,6 +3536,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3487,6 +3583,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3528,6 +3625,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3563,6 +3661,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3600,6 +3699,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -3648,6 +3748,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3686,6 +3787,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3725,6 +3827,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3763,6 +3866,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3803,6 +3907,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3836,6 +3941,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3878,6 +3984,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3920,6 +4027,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -3960,6 +4068,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3994,6 +4103,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false,
         rhino1_7_14: true,
       }
@@ -4028,6 +4138,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -4059,6 +4170,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -4090,6 +4202,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -4123,6 +4236,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -4168,7 +4282,8 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
-        hermes0_7_0: false
+        hermes0_7_0: false,
+        reactnative0_70_3: false
       }
     },
     {
@@ -4199,7 +4314,8 @@ exports.tests = [
         graalvm19: true,
         jerryscript1_0: true,
         jerryscript2_2_0: true,
-        hermes0_7_0: false
+        hermes0_7_0: false,
+        reactnative0_70_3: false
       }
     },
     {
@@ -4231,7 +4347,8 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: false,
         jerryscript2_1_0: true,
-        hermes0_7_0: false
+        hermes0_7_0: false,
+        reactnative0_70_3: false
       }
     }
   ],
@@ -4271,7 +4388,8 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
-        hermes0_7_0: true
+        hermes0_7_0: true,
+        reactnative0_70_3: true
       }
     },
     {
@@ -4302,6 +4420,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -4332,6 +4451,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -4361,6 +4481,7 @@ exports.tests = [
         jerryscript2_3_0: true,
         hermes0_7_0: false,
         hermes0_12_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -4389,6 +4510,7 @@ exports.tests = [
         jerryscript2_3_0: true,
         hermes0_7_0: false,
         hermes0_12_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     }
@@ -4432,6 +4554,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -4468,6 +4591,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -4501,6 +4625,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -4533,6 +4658,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -4568,6 +4694,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -4604,6 +4731,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -4640,6 +4768,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -4672,6 +4801,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -4706,6 +4836,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -4756,6 +4887,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -4797,6 +4929,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -4840,6 +4973,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -4872,6 +5006,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -4911,6 +5046,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -4948,6 +5084,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -4988,6 +5125,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -5026,6 +5164,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -5068,6 +5207,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -5107,6 +5247,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -5145,6 +5286,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -5185,6 +5327,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -5225,6 +5368,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -5265,6 +5409,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -5304,6 +5449,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -5346,6 +5492,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -5388,6 +5535,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -5430,6 +5578,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -5471,6 +5620,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -5516,6 +5666,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -5558,6 +5709,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -5600,6 +5752,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -5642,6 +5795,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -5684,6 +5838,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -5725,6 +5880,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -5767,6 +5923,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -5803,6 +5960,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -5849,6 +6007,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -5885,6 +6044,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -5921,6 +6081,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -5959,6 +6120,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -5995,6 +6157,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }
@@ -6037,6 +6200,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -6071,6 +6235,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -6100,6 +6265,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -6129,6 +6295,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     }
@@ -6170,6 +6337,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -6201,6 +6369,7 @@ exports.tests = [
         jerryscript2_2_0: true,
         hermes0_7_0: false,
         hermes0_12_0: true,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -6247,6 +6416,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false,
         rhino1_7_14: true,
       }
@@ -6282,6 +6452,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: false,
         rhino1_7_13: false,
         rhino1_7_14: true,
       }
@@ -6321,6 +6492,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false,
         rhino1_7_14: true,
       }
@@ -6368,6 +6540,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false,
         rhino1_7_14: true,
       }
@@ -6414,6 +6587,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false,
         rhino1_7_14: true,
       }
@@ -6458,6 +6632,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -6493,6 +6668,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -6520,6 +6696,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -6548,6 +6725,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -6575,6 +6753,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -6601,6 +6780,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -6645,6 +6825,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -6680,6 +6861,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -6717,6 +6899,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -6752,6 +6935,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -6787,6 +6971,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -6822,6 +7007,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -6857,6 +7043,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -6892,6 +7079,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -6928,6 +7116,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -6963,6 +7152,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -6998,6 +7188,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -7033,6 +7224,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -7068,6 +7260,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -7103,6 +7296,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -7138,6 +7332,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -7173,6 +7368,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -7208,6 +7404,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -7236,6 +7433,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -7288,6 +7486,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -7329,6 +7528,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -7381,6 +7581,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -7405,6 +7606,7 @@ exports.tests = [
       graalvm19: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }},
     {
@@ -7428,7 +7630,8 @@ exports.tests = [
       graalvm19: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
-        rhino1_7_13: false
+      reactnative0_70_3: true,
+      rhino1_7_13: false
     }},
     {
       name: '.prototype.subarray',
@@ -7459,6 +7662,7 @@ exports.tests = [
       graalvm19: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: true
     }},
     {
@@ -7482,6 +7686,7 @@ exports.tests = [
       graalvm19: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }},
     {
@@ -7506,7 +7711,8 @@ exports.tests = [
       jerryscript2_0: false,
       jerryscript2_1_0: true,
       hermes0_7_0: true,
-        rhino1_7_13: false
+      reactnative0_70_3: true,
+      rhino1_7_13: false
     }},
     {
       name: '.prototype.lastIndexOf',
@@ -7530,6 +7736,7 @@ exports.tests = [
       jerryscript2_0: false,
       jerryscript2_1_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }},
     {
@@ -7553,6 +7760,7 @@ exports.tests = [
       jerryscript2_0: false,
       jerryscript2_1_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }},
     {
@@ -7576,6 +7784,7 @@ exports.tests = [
       graalvm19: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }},
     {
@@ -7598,6 +7807,7 @@ exports.tests = [
       graalvm19: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }},
     {
@@ -7621,6 +7831,7 @@ exports.tests = [
       graalvm19: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }},
     {
@@ -7643,6 +7854,7 @@ exports.tests = [
       graalvm19: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }},
     {
@@ -7666,6 +7878,7 @@ exports.tests = [
       graalvm19: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }},
     {
@@ -7689,6 +7902,7 @@ exports.tests = [
       graalvm19: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }},
     {
@@ -7712,6 +7926,7 @@ exports.tests = [
       graalvm19: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }},
     {
@@ -7735,6 +7950,7 @@ exports.tests = [
       graalvm19: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }},
     {
@@ -7757,6 +7973,7 @@ exports.tests = [
       graalvm19: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }},
     {
@@ -7781,6 +7998,7 @@ exports.tests = [
       jerryscript2_0: false,
       jerryscript2_1_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }},
     {
@@ -7804,6 +8022,7 @@ exports.tests = [
       graalvm19: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }},
     {
@@ -7827,6 +8046,7 @@ exports.tests = [
       graalvm19: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }},
     {
@@ -7850,6 +8070,7 @@ exports.tests = [
       graalvm19: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }},
     {
@@ -7873,6 +8094,7 @@ exports.tests = [
       graalvm19: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }},
     {
@@ -7896,6 +8118,7 @@ exports.tests = [
       graalvm19: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }},
     {
@@ -7918,6 +8141,7 @@ exports.tests = [
       graalvm19: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }},
     {
@@ -7943,6 +8167,7 @@ exports.tests = [
       graalvm19: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: true
     }},
     {
@@ -7967,6 +8192,7 @@ exports.tests = [
       jerryscript2_0: false,
       jerryscript2_2_0: true,
       hermes0_7_0: false,
+      reactnative0_70_3: false,
       rhino1_7_13: false
     }}
     ].map(function(m) {
@@ -8029,6 +8255,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -8065,6 +8292,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -8099,6 +8327,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -8133,6 +8362,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -8172,6 +8402,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -8204,6 +8435,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -8237,6 +8469,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -8275,6 +8508,7 @@ exports.tests = [
         jerryscript2_3_0: true,
         hermes0_7_0: false,
         hermes0_12_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -8312,6 +8546,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -8344,6 +8579,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -8376,6 +8612,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -8408,6 +8645,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -8441,6 +8679,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -8474,6 +8713,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -8507,6 +8747,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -8539,6 +8780,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -8577,6 +8819,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -8616,6 +8859,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -8644,6 +8888,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }
@@ -8690,6 +8935,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -8725,6 +8971,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -8759,6 +9006,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -8791,6 +9039,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -8830,6 +9079,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -8865,6 +9115,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -8897,6 +9148,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -8936,6 +9188,7 @@ exports.tests = [
         jerryscript2_3_0: true,
         hermes0_7_0: false,
         hermes0_12_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -8975,6 +9228,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -9007,6 +9261,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -9039,6 +9294,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -9071,6 +9327,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -9103,6 +9360,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -9136,6 +9394,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -9169,6 +9428,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -9202,6 +9462,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -9240,6 +9501,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -9279,6 +9541,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -9307,6 +9570,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }
@@ -9352,6 +9616,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -9387,6 +9652,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -9421,6 +9687,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -9455,6 +9722,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -9493,6 +9761,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -9527,6 +9796,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -9559,6 +9829,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -9593,6 +9864,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -9625,6 +9897,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -9665,6 +9938,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -9696,6 +9970,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -9733,6 +10008,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     }
@@ -9780,6 +10056,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -9813,6 +10090,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -9848,6 +10126,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -9881,6 +10160,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -9919,6 +10199,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -9951,6 +10232,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -9984,6 +10266,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -10016,6 +10299,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -10053,6 +10337,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -10084,6 +10369,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -10122,6 +10408,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     }
@@ -10165,6 +10452,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -10190,6 +10478,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -10221,6 +10510,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -10256,6 +10546,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -10307,6 +10598,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -10340,6 +10632,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -10372,6 +10665,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -10423,6 +10717,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -10455,6 +10750,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -10486,6 +10782,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -10534,6 +10831,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -10566,6 +10864,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -10605,6 +10904,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -10648,6 +10948,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -10721,6 +11022,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -10758,6 +11060,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -10810,6 +11113,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -10842,6 +11146,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -10879,6 +11184,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -10916,6 +11222,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -10955,6 +11262,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -10989,6 +11297,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -11034,6 +11343,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -11069,6 +11379,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -11106,6 +11417,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -11147,6 +11459,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -11202,6 +11515,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -11237,6 +11551,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -11274,6 +11589,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -11307,6 +11623,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -11354,6 +11671,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -11386,6 +11704,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -11411,6 +11730,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -11438,6 +11758,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -11476,6 +11797,7 @@ exports.tests = [
         jerryscript2_3_0: true,
         hermes0_7_0: true,
         hermes0_12_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -11504,6 +11826,7 @@ exports.tests = [
         jerryscript2_3_0: true,
         hermes0_7_0: true,
         hermes0_12_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -11533,6 +11856,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -11563,6 +11887,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -11590,6 +11915,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -11618,6 +11944,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -11656,6 +11983,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -11691,6 +12019,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -11717,6 +12046,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -11743,6 +12073,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -11769,6 +12100,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -11796,6 +12128,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -11824,6 +12157,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -11853,6 +12187,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -11894,6 +12229,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -11920,6 +12256,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -11947,6 +12284,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -11975,6 +12313,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12003,6 +12342,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12035,6 +12375,7 @@ exports.tests = [
         safaritp: true,
         webkit: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -12064,6 +12405,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -12091,6 +12433,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12126,6 +12469,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -12165,6 +12509,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12192,6 +12537,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12218,6 +12564,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12245,6 +12592,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12275,6 +12623,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -12302,6 +12651,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12329,6 +12679,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12357,6 +12708,7 @@ exports.tests = [
         jerryscript2_3_0: true,
         hermes0_7_0: false,
         hermes0_12_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12385,6 +12737,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12414,6 +12767,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12442,6 +12796,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12471,6 +12826,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12499,6 +12855,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -12535,6 +12892,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12562,6 +12920,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12589,6 +12948,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12615,6 +12975,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12641,6 +13002,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12667,6 +13029,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12693,6 +13056,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12719,6 +13083,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12747,6 +13112,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12775,6 +13141,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12803,6 +13170,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -12839,6 +13207,7 @@ exports.tests = [
         jerryscript2_3_0: true,
         hermes0_7_0: true,
         hermes0_12_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -12865,6 +13234,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }
@@ -12900,6 +13270,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12929,6 +13300,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12957,6 +13329,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12985,6 +13358,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -13013,6 +13387,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -13041,6 +13416,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -13079,6 +13455,7 @@ exports.tests = [
         jerryscript2_3_0: true,
         hermes0_7_0: true,
         hermes0_12_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -13106,6 +13483,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -13134,6 +13512,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -13161,6 +13540,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -13197,6 +13577,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -13224,6 +13605,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -13251,6 +13633,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -13291,6 +13674,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -13322,6 +13706,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -13351,6 +13736,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -13381,6 +13767,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -13412,6 +13799,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -13442,6 +13830,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -13470,6 +13859,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -13500,6 +13890,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -13529,6 +13920,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -13559,6 +13951,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -13592,6 +13985,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -13630,6 +14024,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -13658,6 +14053,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -13688,6 +14084,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -13716,6 +14113,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -13745,6 +14143,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -13772,6 +14171,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -13801,6 +14201,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -13827,6 +14228,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -13871,6 +14273,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }
@@ -13917,6 +14320,7 @@ exports.tests = [
     jerryscript2_0: false,
     jerryscript2_3_0: true,
     hermes0_7_0: false,
+    reactnative0_70_3: true,
     rhino1_7_13: false
   }
 },
@@ -13957,6 +14361,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -13990,6 +14395,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -14023,6 +14429,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -14054,6 +14461,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -14085,6 +14493,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -14117,6 +14526,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -14149,6 +14559,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -14181,6 +14592,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -14213,6 +14625,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -14251,6 +14664,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -14287,6 +14701,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -14321,6 +14736,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -14368,6 +14784,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -14400,6 +14817,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -14434,6 +14852,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -14469,6 +14888,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -14500,6 +14920,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -14533,6 +14954,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -14569,6 +14991,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.catchDestructuring,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -14604,6 +15027,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -14639,6 +15063,7 @@ exports.tests = [
         jerryscript2_2_0: true,
         hermes0_7_0: true,
         hermes0_12_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -14678,6 +15103,7 @@ exports.tests = [
         jerryscript2_2_0: true,
         hermes0_7_0: true,
         hermes0_12_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }
@@ -14721,6 +15147,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -14755,6 +15182,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -14789,6 +15217,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -14821,6 +15250,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -14853,6 +15283,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -14886,6 +15317,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -14919,6 +15351,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -14951,6 +15384,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -14983,6 +15417,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -15016,6 +15451,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -15050,6 +15486,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -15089,6 +15526,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false,
         rhino1_7_14: true,
       }
@@ -15129,6 +15567,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false,
         rhino1_7_14: true,
       }
@@ -15167,6 +15606,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false,
         rhino1_7_14: true,
       }
@@ -15200,6 +15640,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false,
         rhino1_7_14: true,
       }
@@ -15238,6 +15679,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -15274,6 +15716,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false,
         rhino1_7_14: true,
       }
@@ -15323,6 +15766,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false,
         rhino1_7_14: true,
       }
@@ -15356,6 +15800,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -15395,6 +15840,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false,
         rhino1_7_14: true,
       }
@@ -15432,6 +15878,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -15463,6 +15910,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -15497,6 +15945,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -15532,6 +15981,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -15575,6 +16025,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -15609,6 +16060,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -15643,6 +16095,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -15675,6 +16128,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -15708,6 +16162,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -15741,6 +16196,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -15774,6 +16230,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -15805,6 +16262,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -15839,6 +16297,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -15878,6 +16337,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -15914,6 +16374,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -15949,6 +16410,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -15990,6 +16452,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -16023,6 +16486,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -16058,6 +16522,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -16093,6 +16558,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -16123,6 +16589,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },{
@@ -16154,6 +16621,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -16189,6 +16657,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -16222,6 +16691,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -16256,6 +16726,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -16288,6 +16759,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -16317,6 +16789,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -16350,6 +16823,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -16383,6 +16857,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -16421,6 +16896,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -16482,6 +16958,7 @@ exports.tests = [
         jerryscript2_2_0: true,
         hermes0_7_0: false,
         hermes0_12_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -16516,6 +16993,7 @@ exports.tests = [
         jerryscript2_0: true,
         hermes0_7_0: false,
         hermes0_12_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false,
         rhino1_7_14: true,
       }
@@ -16551,6 +17029,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false,
         rhino1_7_14: true,
       }
@@ -16596,6 +17075,7 @@ exports.tests = [
         jerryscript2_2_0: true,
         hermes0_7_0: false,
         hermes0_12_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -16637,6 +17117,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -16682,6 +17163,7 @@ exports.tests = [
         jerryscript2_2_0: true,
         hermes0_7_0: false,
         hermes0_12_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -16723,6 +17205,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -16750,6 +17233,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false,
         rhino1_7_14: true,
       }
@@ -16790,6 +17274,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -16825,6 +17310,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -16864,6 +17350,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -16895,6 +17382,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     }
@@ -16933,6 +17421,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -16962,6 +17451,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -16994,6 +17484,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -17023,6 +17514,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -17052,6 +17544,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -17081,6 +17574,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -17110,6 +17604,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -17139,6 +17634,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -17168,6 +17664,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -17198,6 +17695,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     }
@@ -17239,7 +17737,8 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
-        hermes0_7_0: true
+        hermes0_7_0: true,
+        reactnative0_70_3: true
       }
     },
     {
@@ -17270,7 +17769,8 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
-        hermes0_7_0: true
+        hermes0_7_0: true,
+        reactnative0_70_3: true
       }
     },
     {
@@ -17299,6 +17799,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript1_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -17329,6 +17830,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -17364,6 +17866,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -17394,6 +17897,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -17439,6 +17943,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -17474,6 +17979,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -17502,6 +18008,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -17529,6 +18036,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -17557,6 +18065,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -17588,6 +18097,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -17616,6 +18126,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -17646,6 +18157,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -17674,6 +18186,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -17707,6 +18220,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -17740,6 +18254,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -17767,6 +18282,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -17798,6 +18314,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -17829,6 +18346,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -17858,6 +18376,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -17887,6 +18406,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -17914,6 +18434,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -17953,6 +18474,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false,
         rhino1_7_14: true,
       }
@@ -17987,6 +18509,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     }
@@ -18028,6 +18551,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -18055,6 +18579,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: false,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -18088,6 +18613,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -18122,6 +18648,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -18159,6 +18686,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -18193,6 +18721,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -18230,6 +18759,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -18269,6 +18799,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -18300,6 +18831,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -18338,6 +18870,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -18382,7 +18915,8 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: true,
         jerryscript2_0: false,
-        hermes0_7_0: false
+        hermes0_7_0: false,
+        reactnative0_70_3: false
       }
     },
     {
@@ -18417,7 +18951,8 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: true,
         jerryscript2_0: false,
-        hermes0_7_0: false
+        hermes0_7_0: false,
+        reactnative0_70_3: false
       }
     },
     {
@@ -18451,6 +18986,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: false,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false,
         rhino1_7_14: true,
       }
@@ -18490,6 +19026,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -18517,6 +19054,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_4_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -18543,6 +19081,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_4_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -18566,6 +19105,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_4_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -18609,6 +19149,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -18645,6 +19186,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -18689,6 +19231,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -18719,6 +19262,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -18759,6 +19303,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -18799,6 +19344,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -18833,6 +19379,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -18872,6 +19419,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -18896,6 +19444,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -18931,6 +19480,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -18966,6 +19516,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -19006,6 +19557,7 @@ exports.tests = [
         jerryscript2_0: true,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -19054,6 +19606,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -19084,6 +19637,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     }
@@ -19133,6 +19687,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -19166,6 +19721,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -19202,7 +19758,8 @@ exports.tests = [
         firefox60: true,
         firefox70: true,
         firefox99: true,
-        graalvm21_3_3: true
+        graalvm21_3_3: true,
+        reactnative0_70_3: true
       }
     },
     {
@@ -19235,6 +19792,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -19266,6 +19824,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -19293,6 +19852,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: true
       }
     },
@@ -19327,6 +19887,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -19361,6 +19922,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -19395,6 +19957,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -19429,6 +19992,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -19463,6 +20027,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -19499,6 +20064,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -19530,6 +20096,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false,
         rhino1_7_14: true,
       }
@@ -19562,6 +20129,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -19593,6 +20161,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -19624,6 +20193,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -19655,6 +20225,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -19685,6 +20256,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -19716,6 +20288,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -19747,6 +20320,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -19778,6 +20352,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -19814,6 +20389,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -19845,6 +20421,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -19894,6 +20471,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -19943,6 +20521,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -19972,6 +20551,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -20007,6 +20587,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }
@@ -20045,6 +20626,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_1_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -20072,6 +20654,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -20099,6 +20682,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -20126,6 +20710,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -20153,6 +20738,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -20181,6 +20767,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }
@@ -20220,7 +20807,8 @@ exports.tests = [
         nashorn10: true,
         graalvm19: true,
         jerryscript1_0: true,
-        hermes0_7_0: false
+        hermes0_7_0: false,
+        reactnative0_70_3: false
       }
     },
     {
@@ -20249,7 +20837,8 @@ exports.tests = [
         nashorn10: true,
         graalvm19: true,
         jerryscript2_0: true,
-        hermes0_7_0: false
+        hermes0_7_0: false,
+        reactnative0_70_3: false
       }
     }
   ]
@@ -20285,7 +20874,8 @@ exports.tests = [
         nashorn10: true,
         graalvm19: true,
         jerryscript1_0: true,
-        hermes0_7_0: true
+        hermes0_7_0: true,
+        reactnative0_70_3: true
       }
     },
     {
@@ -20312,7 +20902,8 @@ exports.tests = [
         nashorn10: true,
         graalvm19: true,
         jerryscript1_0: true,
-        hermes0_7_0: true
+        hermes0_7_0: true,
+        reactnative0_70_3: true
       }
     },
     {
@@ -20338,7 +20929,8 @@ exports.tests = [
         nashorn10: true,
         graalvm19: true,
         jerryscript1_0: true,
-        hermes0_7_0: false
+        hermes0_7_0: false,
+        reactnative0_70_3: false
       }
     },
     {
@@ -20366,7 +20958,8 @@ exports.tests = [
         nashorn10: true,
         graalvm19: true,
         jerryscript2_0: true,
-        hermes0_7_0: true
+        hermes0_7_0: true,
+        reactnative0_70_3: true
       }
     },
     {
@@ -20393,7 +20986,8 @@ exports.tests = [
         nashorn10: true,
         graalvm19: true,
         jerryscript2_0: true,
-        hermes0_7_0: true
+        hermes0_7_0: true,
+        reactnative0_70_3: true
       }
     },
     {
@@ -20423,7 +21017,8 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
-        hermes0_7_0: true
+        hermes0_7_0: true,
+        reactnative0_70_3: true
       }
     },
     {
@@ -20450,7 +21045,8 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
-        hermes0_7_0: true
+        hermes0_7_0: true,
+        reactnative0_70_3: true
       }
     },
     {
@@ -20479,7 +21075,8 @@ exports.tests = [
         nashorn10: true,
         graalvm19: true,
         jerryscript1_0: true,
-        hermes0_7_0: true
+        hermes0_7_0: true,
+        reactnative0_70_3: true
       }
     }
   ],
@@ -20518,6 +21115,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -20549,6 +21147,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -20580,6 +21179,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -20610,6 +21210,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -20641,6 +21242,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -20673,6 +21275,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -20705,6 +21308,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -20736,6 +21340,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -20769,6 +21374,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -20803,6 +21409,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -20831,6 +21438,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }
@@ -20869,6 +21477,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -20901,6 +21510,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -20933,6 +21543,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -20966,6 +21577,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -20999,6 +21611,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -21061,6 +21674,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -21094,6 +21708,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -21167,7 +21782,8 @@ exports.tests = [
         safari5: false,
         safari5_1: true,
         safari15: true,
-        graalvm21_3_3: true
+        graalvm21_3_3: true,
+        reactnative0_70_3: true
       }
     },
     {
@@ -21207,6 +21823,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -21244,6 +21861,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -21279,6 +21897,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }
@@ -21321,6 +21940,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_1_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -21354,6 +21974,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_1_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -21387,6 +22008,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_1_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -21421,6 +22043,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_1_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -21450,6 +22073,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false,
         rhino1_7_14: true,
       }
@@ -21480,6 +22104,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false,
         rhino1_7_14: true,
       }
@@ -21513,6 +22138,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false,
         rhino1_7_14: true,
       }
@@ -21547,6 +22173,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -21580,6 +22207,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     }
@@ -21616,6 +22244,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       },
       'imul': {
@@ -21648,6 +22277,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       },
       'sign': {
@@ -21674,6 +22304,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       },
       'log10': {
@@ -21699,6 +22330,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       },
       'log2': {
@@ -21725,6 +22357,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       },
       'log1p': {
@@ -21751,6 +22384,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       },
       'expm1': {
@@ -21776,6 +22410,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       },
       'cosh': {
@@ -21802,6 +22437,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       },
       'sinh': {
@@ -21828,6 +22464,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       },
       'tanh': {
@@ -21854,6 +22491,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       },
       'acosh': {
@@ -21880,6 +22518,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       },
       'asinh': {
@@ -21905,6 +22544,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       },
       'atanh': {
@@ -21931,6 +22571,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       },
       'trunc': {
@@ -21956,6 +22597,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       },
       'fround': {
@@ -21986,6 +22628,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       },
       'cbrt': {
@@ -22012,6 +22655,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     };
@@ -22057,6 +22701,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     });
@@ -22092,6 +22737,7 @@ exports.tests = [
     jerryscript2_0: false,
     jerryscript2_2_0: true,
     hermes0_7_0: true,
+    reactnative0_70_3: true,
     rhino1_7_13: false
   }
 },
@@ -22130,6 +22776,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -22161,6 +22808,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -22191,6 +22839,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -22218,6 +22867,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -22246,6 +22896,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -22274,6 +22925,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -22302,6 +22954,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -22331,6 +22984,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -22360,6 +23014,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -22390,6 +23045,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -22420,6 +23076,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -22458,6 +23115,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -22489,6 +23147,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -22519,6 +23178,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -22549,6 +23209,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -22585,6 +23246,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -22613,6 +23275,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -22643,6 +23306,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -22671,6 +23335,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -22699,6 +23364,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -22727,6 +23393,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }
@@ -22784,6 +23451,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -22814,6 +23482,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -22855,6 +23524,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -22896,6 +23566,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }
@@ -22934,6 +23605,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -22964,6 +23636,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -22996,6 +23669,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -23026,6 +23700,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -23059,6 +23734,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -23093,6 +23769,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -23163,7 +23840,8 @@ exports.tests = [
         nashorn10: true,
         graalvm19: true,
         jerryscript1_0: true,
-        hermes0_7_0: true
+        hermes0_7_0: true,
+        reactnative0_70_3: true
       }
     },
     {
@@ -23205,6 +23883,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript1_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -23252,6 +23931,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -23299,6 +23979,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript1_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -23339,6 +24020,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript1_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -23386,6 +24068,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -23430,6 +24113,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -23483,7 +24167,8 @@ exports.tests = [
         jerryscript1_0: true,
         jerryscript2_0: false,
         jerryscript2_4_0: true,
-        hermes0_7_0: false
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
       }
     },
     {
@@ -23524,7 +24209,8 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: false,
         jerryscript2_4_0: true,
-        hermes0_7_0: true
+        hermes0_7_0: true,
+        reactnative0_70_3: true
       }
     },
     {
@@ -23569,7 +24255,8 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
-        hermes0_7_0: false
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
       }
     }
   ],
@@ -23604,6 +24291,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -23634,7 +24322,8 @@ exports.tests = [
         nashorn10: true,
         graalvm19: true,
         jerryscript1_0: true,
-        hermes0_7_0: true
+        hermes0_7_0: true,
+        reactnative0_70_3: true
       }
     },
     {
@@ -23669,6 +24358,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -23698,6 +24388,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -23729,7 +24420,8 @@ exports.tests = [
         nashorn10: true,
         graalvm19: true,
         jerryscript1_0: true,
-        hermes0_7_0: true
+        hermes0_7_0: true,
+        reactnative0_70_3: true
       }
     },
     {
@@ -23755,6 +24447,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -23781,6 +24474,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -23818,6 +24512,7 @@ exports.tests = [
         jerryscript2_3_0: true,
         hermes0_7_0: false,
         hermes0_12_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -23850,6 +24545,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -23885,7 +24581,8 @@ exports.tests = [
     duktape2_1: true,
     graalvm19: true,
     jerryscript2_0: false,
-    hermes0_7_0: false
+    hermes0_7_0: false,
+    reactnative0_70_3: false
   }
 },
 ];

--- a/data-esintl.js
+++ b/data-esintl.js
@@ -29,6 +29,7 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -49,6 +50,7 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -76,6 +78,7 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -97,6 +100,7 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -118,6 +122,7 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -181,6 +186,7 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -215,6 +221,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: false,
         graalvm20_1: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     }
@@ -242,6 +249,7 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -269,6 +277,7 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -296,6 +305,7 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -316,6 +326,7 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -337,6 +348,7 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -358,6 +370,7 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -421,6 +434,7 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -454,6 +468,7 @@ exports.tests = [
         safari14: true,
         duktape2_0: false,
         graalvm19: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     }
@@ -481,6 +496,7 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -502,6 +518,7 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -523,6 +540,7 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -586,6 +604,7 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -619,6 +638,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: false,
         graalvm20_1: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -647,6 +667,7 @@ exports.tests = [
         ios7: false,
         duktape2_0: false,
         graalvm19: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -675,6 +696,7 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -706,6 +728,7 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     }
@@ -737,6 +760,7 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     }
@@ -768,6 +792,7 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     }
@@ -799,6 +824,7 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     }
@@ -830,6 +856,7 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     }
@@ -861,6 +888,7 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     }
@@ -892,6 +920,7 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     }

--- a/data-esnext.js
+++ b/data-esnext.js
@@ -35,6 +35,7 @@ exports.tests = [
     chrome77: false,
     duktape2_0: false,
     graalvm19: false,
+    reactnative0_70_3: false,
     rhino1_7_13: false
   }
 },
@@ -67,6 +68,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm19: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }
@@ -91,6 +93,7 @@ exports.tests = [
     chrome77: false,
     duktape2_0: false,
     graalvm19: false,
+    reactnative0_70_3: false,
     rhino1_7_13: false
   }
 },
@@ -120,6 +123,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm19: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -147,6 +151,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm19: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -169,6 +174,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm19: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -191,6 +197,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm19: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }
@@ -221,6 +228,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: false,
         graalvm21_3_3: graalvm.newSetMethodsFlag,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -244,6 +252,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: false,
         graalvm21_3_3: graalvm.newSetMethodsFlag,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -266,6 +275,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: false,
         graalvm21_3_3: graalvm.newSetMethodsFlag,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -288,6 +298,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: false,
         graalvm21_3_3: graalvm.newSetMethodsFlag,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -308,6 +319,7 @@ exports.tests = [
         graalvm19: false,
         graalvm20_1: graalvm.es2021flag,
         graalvm21_3_3: graalvm.newSetMethodsFlag,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -327,6 +339,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: false,
         graalvm21_3_3: graalvm.newSetMethodsFlag,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -346,6 +359,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: false,
         graalvm21_3_3: graalvm.newSetMethodsFlag,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }
@@ -373,6 +387,7 @@ exports.tests = [
         safari12: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -392,6 +407,7 @@ exports.tests = [
         safari12: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }
@@ -429,6 +445,7 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
+        reactnative0_70_3: true
       }
     },
     {
@@ -457,7 +474,8 @@ exports.tests = [
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
-        graalvm19: true
+        graalvm19: true,
+        reactnative0_70_3: true
       }
     }
   ]
@@ -487,6 +505,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -510,6 +529,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }
@@ -535,6 +555,7 @@ exports.tests = [
     chrome77: false,
     duktape2_0: false,
     graalvm21_3_3: false,
+    reactnative0_70_3: false,
     rhino1_7_13: false
   }
 },
@@ -560,6 +581,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -581,6 +603,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -603,6 +626,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -630,6 +654,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -649,6 +674,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -668,6 +694,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -687,6 +714,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -706,6 +734,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -725,6 +754,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -744,6 +774,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -765,6 +796,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -784,6 +816,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -803,6 +836,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -822,6 +856,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -841,6 +876,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -861,6 +897,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -880,6 +917,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -899,6 +937,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -920,6 +959,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -951,6 +991,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -982,6 +1023,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -1013,6 +1055,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -1040,6 +1083,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -1067,6 +1111,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -1088,6 +1133,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -1115,6 +1161,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -1136,6 +1183,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -1163,6 +1211,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -1185,6 +1234,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -1212,6 +1262,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -1233,6 +1284,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -1254,6 +1306,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -1281,6 +1334,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -1302,6 +1356,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -1321,6 +1376,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }

--- a/data-non-standard.js
+++ b/data-non-standard.js
@@ -42,6 +42,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs", note_html: "The feature has to be enabled via <code>--experimental-options --js.simdjs</code> flag"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -65,6 +66,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -88,6 +90,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -111,6 +114,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -134,6 +138,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -157,6 +162,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -180,6 +186,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -203,6 +210,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -226,6 +234,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -249,6 +258,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -272,6 +282,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -297,6 +308,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -322,6 +334,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -347,6 +360,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -372,6 +386,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -397,6 +412,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -422,6 +438,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -447,6 +464,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -472,6 +490,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -497,6 +516,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -522,6 +542,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -547,6 +568,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -572,6 +594,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -597,6 +620,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -622,6 +646,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -647,6 +672,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -672,6 +698,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -696,6 +723,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -720,6 +748,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -744,6 +773,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -769,6 +799,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -795,6 +826,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -820,6 +852,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -846,6 +879,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -871,6 +905,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -896,6 +931,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -921,6 +957,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -946,6 +983,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -971,6 +1009,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -996,6 +1035,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -1021,6 +1061,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -1046,6 +1087,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -1071,6 +1113,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -1096,6 +1139,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -1121,6 +1165,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -1146,6 +1191,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -1171,6 +1217,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -1196,6 +1243,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -1220,6 +1268,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -1244,6 +1293,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -1268,6 +1318,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -1293,6 +1344,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -1318,6 +1370,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -1343,6 +1396,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -1368,6 +1422,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -1393,6 +1448,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -1416,6 +1472,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }
@@ -1438,6 +1495,7 @@ exports.tests = [
         firefox74: false,
         opera10_50: false,
         chrome77: false,
+        reactnative0_70_3: false,
         rhino1_7_13: true,
         duktape2_0: false,
         graalvm19: false
@@ -1465,6 +1523,7 @@ exports.tests = [
         opera10_50: false,
         chrome77: false,
         besen: true,
+        reactnative0_70_3: false,
         rhino1_7_13: true,
         duktape2_0: false,
         graalvm19: false
@@ -1481,6 +1540,7 @@ exports.tests = [
         firefox74: false,
         opera10_50: false,
         chrome77: false,
+        reactnative0_70_3: false,
         rhino1_7_13: true,
         duktape2_0: false,
         graalvm19: false
@@ -1584,6 +1644,7 @@ exports.tests = [
         opera10_50: false,
         chrome77: false,
         besen: null,
+        reactnative0_70_3: false,
         rhino1_7_13: false,
         duktape2_0: false,
         graalvm19: false
@@ -1606,6 +1667,7 @@ exports.tests = [
     firefox4: false,
     opera10_50: false,
     chrome77: false,
+    reactnative0_70_3: false,
     rhino1_7_13: false,
     duktape2_0: false,
     graalvm19: false
@@ -1628,6 +1690,7 @@ exports.tests = [
     safari3_1: true,
     konq4_4: true,
     besen: false,
+    reactnative0_70_3: false,
     rhino1_7_13: false,
     phantom1_9: true,
     android4_0: true,
@@ -1654,6 +1717,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
+    reactnative0_70_3: false,
     rhino1_7_13: true,
     phantom1_9: false,
     duktape2_0: false,
@@ -1679,6 +1743,7 @@ exports.tests = [
     safari3_1: true,
     konq4_4: true,
     besen: false,
+    reactnative0_70_3: false,
     rhino1_7_13: true,
     phantom1_9: true,
     android4_0: true,
@@ -1707,6 +1772,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
+    reactnative0_70_3: false,
     rhino1_7_13: false,
     phantom1_9: false,
     duktape2_0: false,
@@ -1732,6 +1798,7 @@ exports.tests = [
     chrome77: false,
     duktape2_0: false,
     graalvm19: false,
+    reactnative0_70_3: false,
     rhino1_7_13: false
   },
 },
@@ -1754,6 +1821,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
+    reactnative0_70_3: false,
     rhino1_7_13: false,
     phantom1_9: false,
     duktape2_0: false,
@@ -1778,6 +1846,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
+    reactnative0_70_3: false,
     rhino1_7_13: true,
     phantom1_9: false,
     duktape2_0: false,
@@ -1807,6 +1876,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
+    reactnative0_70_3: false,
     rhino1_7_13: true,
     phantom1_9: false,
     duktape2_0: false,
@@ -1838,6 +1908,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
+    reactnative0_70_3: false,
     rhino1_7_13: true,
     phantom1_9: false,
     duktape2_0: false,
@@ -1861,6 +1932,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
+    reactnative0_70_3: false,
     rhino1_7_13: true,
     phantom1_9: false,
     duktape2_0: false,
@@ -1889,6 +1961,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
+    reactnative0_70_3: false,
     rhino1_7_13: true,
     phantom1_9: false,
     duktape2_0: false,
@@ -1914,6 +1987,7 @@ exports.tests = [
     chrome77: false,
     duktape2_0: false,
     graalvm19: false,
+    reactnative0_70_3: false,
     rhino1_7_13: false
   }
 },
@@ -1935,6 +2009,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: true,
+    reactnative0_70_3: false,
     rhino1_7_13: true,
     phantom1_9: false,
     duktape2_0: false,
@@ -1963,6 +2038,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
+    reactnative0_70_3: false,
     rhino1_7_13: true,
     phantom1_9: false,
     duktape2_0: false,
@@ -1991,6 +2067,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
+    reactnative0_70_3: false,
     rhino1_7_13: true,
     phantom1_9: false,
     duktape2_0: false,
@@ -2020,6 +2097,7 @@ exports.tests = [
     konq4_4: null,
     konq4_9: false,
     besen: null,
+    reactnative0_70_3: false,
     rhino1_7_13: false,
     phantom1_9: false,
     duktape2_0: false,
@@ -2060,6 +2138,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
+    reactnative0_70_3: false,
     rhino1_7_13: true,
     phantom1_9: false,
     duktape2_0: false,
@@ -2102,6 +2181,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
+    reactnative0_70_3: false,
     rhino1_7_13: true,
     phantom1_9: false,
     duktape2_0: false,
@@ -2154,6 +2234,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
+    reactnative0_70_3: false,
     rhino1_7_13: true,
     phantom1_9: false,
     duktape2_0: false,
@@ -2180,6 +2261,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
+    reactnative0_70_3: false,
     rhino1_7_13: false,
     phantom1_9: false,
     duktape2_0: false,
@@ -2211,6 +2293,7 @@ exports.tests = [
     chrome77: false,
     duktape2_0: false,
     graalvm19: false,
+    reactnative0_70_3: false,
     rhino1_7_13: false
   },
   separator: 'after'
@@ -2238,6 +2321,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
+    reactnative0_70_3: false,
     rhino1_7_13: false,
     phantom1_9: false,
     duktape2_0: false,
@@ -2259,6 +2343,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
+    reactnative0_70_3: false,
     rhino1_7_13: false,
     phantom1_9: false,
     duktape2_0: false,
@@ -2282,6 +2367,7 @@ exports.tests = [
     konq4_4: null,
     konq4_9: true,
     besen: null,
+    reactnative0_70_3: false,
     rhino1_7_13: false,
     phantom1_9: false,
     duktape2_0: false,
@@ -2304,6 +2390,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: null,
+    reactnative0_70_3: false,
     rhino1_7_13: false,
     phantom1_9: false,
     duktape2_0: false,
@@ -2322,6 +2409,7 @@ exports.tests = [
     opera7_5: false,
     opera10_50: false,
     chrome77: false,
+    reactnative0_70_3: false,
     rhino1_7_13: false,
     phantom1_9: false,
     duktape2_0: false,
@@ -2345,6 +2433,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
+    reactnative0_70_3: false,
     rhino1_7_13: false,
     phantom1_9: false,
     duktape2_0: false,
@@ -2371,6 +2460,7 @@ exports.tests = [
     chrome77: false,
     konq4_3: true,
     besen: true,
+    reactnative0_70_3: false,
     rhino1_7_13: true,
     ejs: true,
     android4_0: true,
@@ -2395,6 +2485,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
+    reactnative0_70_3: false,
     rhino1_7_13: false,
     phantom1_9: false,
     duktape2_0: false,
@@ -2417,6 +2508,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
+    reactnative0_70_3: false,
     rhino1_7_13: false,
     phantom1_9: false,
     duktape2_0: false,
@@ -2438,6 +2530,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: true,
+    reactnative0_70_3: false,
     rhino1_7_13: false,
     phantom1_9: false,
     duktape2_0: false,
@@ -2462,6 +2555,7 @@ exports.tests = [
     android5_0: true,
     duktape2_0: false,
     graalvm19: false,
+    reactnative0_70_3: false,
     rhino1_7_13: false
   },
   separator: 'after'
@@ -2489,6 +2583,7 @@ exports.tests = [
     safari7_1: true,
     konq4_4: false,
     besen: false,
+    reactnative0_70_3: true,
     rhino1_7_13: false,
     rhino1_7_14: true,
     phantom1_9: false,
@@ -2517,6 +2612,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
+    reactnative0_70_3: false,
     rhino1_7_13: true,
     phantom1_9: false,
     duktape2_0: true,
@@ -2545,6 +2641,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
+    reactnative0_70_3: false,
     rhino1_7_13: false,
     phantom1_9: false,
     duktape2_0: false,
@@ -2572,6 +2669,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
+    reactnative0_70_3: false,
     rhino1_7_13: true,
     phantom1_9: false,
     duktape2_0: true,
@@ -2597,6 +2695,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
+    reactnative0_70_3: false,
     rhino1_7_13: false,
     phantom1_9: false,
     duktape2_0: false,
@@ -2637,6 +2736,7 @@ exports.tests = [
         duktape2_5: false,
         graalvm19: true,
         graalvm21_3_3: graalvm.globalPropertyFlag,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }, {
@@ -2675,6 +2775,7 @@ exports.tests = [
         duktape2_5: false,
         graalvm19: false,
         graalvm21_3_3: graalvm.globalPropertyFlag,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }]
@@ -2712,6 +2813,7 @@ exports.tests = [
     duktape2_0: true,
     graalvm19: true,
     graalvm20: false,
+    reactnative0_70_3: false,
     rhino1_7_13: false
   },
 },

--- a/environments.json
+++ b/environments.json
@@ -6712,5 +6712,13 @@
     "equals": "chrome104",
     "release": "2022-09-02",
     "obsolete": false
+  },
+  "reactnative0_70_3": {
+    "full": "React Native 0.70.3 (Using bundled Hermes and metro-react-native babel preset)",
+    "family": "React-Native",
+    "short": "React Native 0.70.3 (Hermes + Babel)",
+    "platformtype": "mobile",
+    "release": "2022-10-12",
+    "obsolete": false
   }
 }

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -280,12 +280,13 @@
 <th class="platform opera_mobile69 mobile obsolete" data-browser="opera_mobile69"><a href="#opera_mobile69" class="browser-name"><abbr title="Opera Mobile for Android 69">Opera Mobile 69</abbr></a></th>
 <th class="platform opera_mobile70 mobile" data-browser="opera_mobile70"><a href="#opera_mobile70" class="browser-name"><abbr title="Opera Mobile for Android 70">Opera Mobile 70</abbr></a></th>
 <th class="platform opera_mobile71 mobile" data-browser="opera_mobile71"><a href="#opera_mobile71" class="browser-name"><abbr title="Opera Mobile for Android 71">Opera Mobile 71</abbr></a></th>
+<th class="platform reactnative0_70_3 mobile" data-browser="reactnative0_70_3"><a href="#reactnative0_70_3" class="browser-name"><abbr title="React Native 0.70.3 (Using bundled Hermes and metro-react-native babel preset)">React Native 0.70.3 (Hermes + Babel)</abbr></a></th>
 </tr>
 
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr class="category"><td colspan="159"><span>2016 features</span></td>
+      <tr class="category"><td colspan="160"><span>2016 features</span></td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-exponentiation_(**)_operator"><span><a class="anchor" href="#test-exponentiation_(**)_operator">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-exp-operator">exponentiation (**) operator</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Exponentiation_(**)" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -444,6 +445,7 @@
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">3/3</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">3/3</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">3/3</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="1">3/3</td>
 </tr>
 <tr class="subtest" data-parent="exponentiation_(**)_operator" id="test-exponentiation_(**)_operator_basic_support"><td><span><a class="anchor" href="#test-exponentiation_(**)_operator_basic_support">&#xA7;</a>basic support</span><script data-source="
 return 2 ** 3 === 8 &amp;&amp; -(5 ** 2) === -25 &amp;&amp; (-5) ** 2 === 25;
@@ -605,6 +607,7 @@ return 2 ** 3 === 8 &amp;&amp; -(5 ** 2) === -25 &amp;&amp; (-5) ** 2 === 25;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="exponentiation_(**)_operator" id="test-exponentiation_(**)_operator_assignment"><td><span><a class="anchor" href="#test-exponentiation_(**)_operator_assignment">&#xA7;</a>assignment</span><script data-source="
 var a = 2; a **= 3; return a === 8;
@@ -766,6 +769,7 @@ var a = 2; a **= 3; return a === 8;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="exponentiation_(**)_operator" id="test-exponentiation_(**)_operator_early_syntax_error_for_unary_negation_without_parens"><td><span><a class="anchor" href="#test-exponentiation_(**)_operator_early_syntax_error_for_unary_negation_without_parens">&#xA7;</a>early syntax error for unary negation without parens</span><script data-source="
 if (2 ** 3 !== 8) { return false; }
@@ -932,6 +936,7 @@ return true;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Array.prototype.includes"><span><a class="anchor" href="#test-Array.prototype.includes">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-array.prototype.includes">Array.prototype.includes</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/4</td>
@@ -1090,6 +1095,7 @@ return true;
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">4/4</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">4/4</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">4/4</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="1">4/4</td>
 </tr>
 <tr class="subtest" data-parent="Array.prototype.includes" id="test-Array.prototype.includes_Array.prototype.includes_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Array.prototype.includes_Array.prototype.includes_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Array.prototype.includes <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return [1, 2, 3].includes(1)
@@ -1254,6 +1260,7 @@ return [1, 2, 3].includes(1)
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Array.prototype.includes" id="test-Array.prototype.includes_Array.prototype.includes_handles_sparse_arrays_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Array.prototype.includes_Array.prototype.includes_handles_sparse_arrays_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Array.prototype.includes handles sparse arrays <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return [,].includes()
@@ -1416,6 +1423,7 @@ return [,].includes()
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Array.prototype.includes" id="test-Array.prototype.includes_Array.prototype.includes_is_generic"><td><span><a class="anchor" href="#test-Array.prototype.includes_Array.prototype.includes_is_generic">&#xA7;</a>Array.prototype.includes is generic</span><script data-source="
 var passed = 0;
@@ -1599,6 +1607,7 @@ return 24;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Array.prototype.includes" id="test-Array.prototype.includes_%TypedArray%.prototype.includes_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/includes_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Array.prototype.includes_%TypedArray%.prototype.includes_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/includes_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>%TypedArray%.prototype.includes <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/includes" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return [Int8Array, Uint8Array, Uint8ClampedArray, Int16Array, Uint16Array,
@@ -1765,8 +1774,9 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
-<tr class="category"><td colspan="159"><span>2016 misc</span></td>
+<tr class="category"><td colspan="160"><span>2016 misc</span></td>
 </tr>
 <tr significance="0.125"><td id="test-generator_functions_can&apos;t_be_used_with_new"><span><a class="anchor" href="#test-generator_functions_can&apos;t_be_used_with_new">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-createdynamicfunction">generator functions can&apos;t be used with &quot;new&quot;</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*#Generators_are_not_constructable" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;<a href="#new-gen-fn-note"><sup>[7]</sup></a></span><script data-source="
 function * generator() {
@@ -1935,6 +1945,7 @@ return true;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr significance="0.125"><td id="test-generator_throw()_caught_by_inner_generator"><span><a class="anchor" href="#test-generator_throw()_caught_by_inner_generator">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-generatorfunction-objects">generator throw() caught by inner generator</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*#IteratorResult_object_returned_instead_of_throwing" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;<a href="#gen-throw-note"><sup>[8]</sup></a></span><script data-source="
 function * generator() {
@@ -2109,6 +2120,7 @@ return iter[&apos;throw&apos;]().value === &apos;bar&apos;;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr significance="0.125"><td id="test-strict_fn_w/_non-strict_non-simple_params_is_error"><span><a class="anchor" href="#test-strict_fn_w/_non-strict_non-simple_params_is_error">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-functiondeclarationinstantiation">strict fn w/ non-strict non-simple params is error</a><a href="#strict-fn-non-strict-params-note"><sup>[10]</sup></a></span><script data-source="
 function foo(...a){}
@@ -2275,6 +2287,7 @@ return true;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr significance="0.125"><td id="test-nested_rest_destructuring,_declarations"><span><a class="anchor" href="#test-nested_rest_destructuring,_declarations">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-destructuring-assignment">nested rest destructuring, declarations</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#Nested_object_and_array_destructuring" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;<a href="#nested-rest-destruct-decl-note"><sup>[11]</sup></a></span><script data-source="
 var [x, ...[y, ...z]] = [1,2,3,4];
@@ -2437,6 +2450,7 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr significance="0.125"><td id="test-nested_rest_destructuring,_parameters"><span><a class="anchor" href="#test-nested_rest_destructuring,_parameters">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-destructuring-assignment">nested rest destructuring, parameters</a><a href="#nested-rest-destruct-params-note"><sup>[12]</sup></a></span><script data-source="
 return function([x, ...[y, ...z]]) {
@@ -2600,6 +2614,7 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr significance="0.125"><td id="test-Proxy,_enumerate_handler_removed"><span><a class="anchor" href="#test-Proxy,_enumerate_handler_removed">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-proxy-objects">Proxy, &quot;enumerate&quot; handler removed</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/enumerate" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;<a href="#proxy-enumerate-removed-note"><sup>[13]</sup></a></span><script data-source="
 var passed = true;
@@ -2768,6 +2783,7 @@ return passed;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr significance="0.125"><td id="test-Proxy_internal_calls,_Array.prototype.includes"><span><a class="anchor" href="#test-Proxy_internal_calls,_Array.prototype.includes">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-array.prototype.includes">Proxy internal calls, Array.prototype.includes</a></span><script data-source="
 // Array.prototype.includes -&gt; Get -&gt; [[Get]]
@@ -2938,8 +2954,9 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
-<tr class="category"><td colspan="159"><span>2017 features</span></td>
+<tr class="category"><td colspan="160"><span>2017 features</span></td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-Object_static_methods"><span><a class="anchor" href="#test-Object_static_methods">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-properties-of-the-object-constructor">Object static methods</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/4</td>
@@ -3098,6 +3115,7 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">4/4</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">4/4</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">4/4</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="1">4/4</td>
 </tr>
 <tr class="subtest" data-parent="Object_static_methods" id="test-Object_static_methods_a_href=_https://tc39.github.io/ecma262/#sec-object.values_Object.values_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/values_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Object_static_methods_a_href=_https://tc39.github.io/ecma262/#sec-object.values_Object.values_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/values_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-object.values">Object.values</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/values" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var obj = Object.create({ a: &quot;qux&quot;, d: &quot;qux&quot; });
@@ -3262,6 +3280,7 @@ return Array.isArray(v) &amp;&amp; String(v) === &quot;foo,bar,baz&quot;;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Object_static_methods" id="test-Object_static_methods_a_href=_https://tc39.github.io/ecma262/#sec-object.entries_Object.entries_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Object_static_methods_a_href=_https://tc39.github.io/ecma262/#sec-object.entries_Object.entries_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-object.entries">Object.entries</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var obj = Object.create({ a: &quot;qux&quot;, d: &quot;qux&quot; });
@@ -3430,6 +3449,7 @@ return Array.isArray(e)
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Object_static_methods" id="test-Object_static_methods_a_href=_https://tc39.github.io/ecma262/#sec-object.getownpropertydescriptors_Object.getOwnPropertyDescriptors_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptors_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Object_static_methods_a_href=_https://tc39.github.io/ecma262/#sec-object.getownpropertydescriptors_Object.getOwnPropertyDescriptors_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptors_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-object.getownpropertydescriptors">Object.getOwnPropertyDescriptors</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptors" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var object = {a: 1};
@@ -3599,6 +3619,7 @@ return D.a.value === 1 &amp;&amp; D.a.enumerable === true &amp;&amp; D.a.configu
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Object_static_methods" id="test-Object_static_methods_Object.getOwnPropertyDescriptors_doesn&apos;t_provide_undefined_descriptors"><td><span><a class="anchor" href="#test-Object_static_methods_Object.getOwnPropertyDescriptors_doesn&apos;t_provide_undefined_descriptors">&#xA7;</a>Object.getOwnPropertyDescriptors doesn&apos;t provide undefined descriptors</span><script data-source="
 var P = new Proxy({a:1}, {
@@ -3763,6 +3784,7 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-String_padding"><span><a class="anchor" href="#test-String_padding">&#xA7;</a><a href="https://github.com/tc39/proposal-string-pad-start-end">String padding</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/2</td>
@@ -3921,6 +3943,7 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">2/2</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">2/2</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">2/2</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="1">2/2</td>
 </tr>
 <tr class="subtest" data-parent="String_padding" id="test-String_padding_a_href=_https://tc39.github.io/ecma262/#sec-string.prototype.padstart_String.prototype.padStart_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padStart_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-String_padding_a_href=_https://tc39.github.io/ecma262/#sec-string.prototype.padstart_String.prototype.padStart_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padStart_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-string.prototype.padstart">String.prototype.padStart</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padStart" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return &apos;hello&apos;.padStart(10) === &apos;     hello&apos;
@@ -4087,6 +4110,7 @@ return &apos;hello&apos;.padStart(10) === &apos;     hello&apos;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="String_padding" id="test-String_padding_a_href=_https://tc39.github.io/ecma262/#sec-string.prototype.padend_String.prototype.padEnd_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padEnd_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-String_padding_a_href=_https://tc39.github.io/ecma262/#sec-string.prototype.padend_String.prototype.padEnd_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padEnd_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-string.prototype.padend">String.prototype.padEnd</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padEnd" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
@@ -4253,6 +4277,7 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-trailing_commas_in_function_syntax"><span><a class="anchor" href="#test-trailing_commas_in_function_syntax">&#xA7;</a><a href="https://github.com/tc39/proposal-trailing-function-commas">trailing commas in function syntax</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/2</td>
@@ -4411,6 +4436,7 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">2/2</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">2/2</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">2/2</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="1">2/2</td>
 </tr>
 <tr class="subtest" data-parent="trailing_commas_in_function_syntax" id="test-trailing_commas_in_function_syntax_in_parameter_lists_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas#Parameter_definitions_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-trailing_commas_in_function_syntax_in_parameter_lists_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas#Parameter_definitions_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>in parameter lists <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas#Parameter_definitions" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof function f( a, b, ){} === &apos;function&apos;;
@@ -4572,6 +4598,7 @@ return typeof function f( a, b, ){} === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="trailing_commas_in_function_syntax" id="test-trailing_commas_in_function_syntax_in_argument_lists_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas#Function_calls_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-trailing_commas_in_function_syntax_in_argument_lists_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas#Function_calls_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>in argument lists <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas#Function_calls" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return Math.min(1,2,3,) === 1;
@@ -4733,6 +4760,7 @@ return Math.min(1,2,3,) === 1;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-async_functions"><span><a class="anchor" href="#test-async_functions">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-async-function-definitions">async functions</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0.25" style="background-color:hsl(30,75%,50%)">4/16</td>
@@ -4891,6 +4919,7 @@ return Math.min(1,2,3,) === 1;
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">16/16</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">16/16</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">16/16</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0.6875" style="background-color:hsl(82,55%,50%)">11/16</td>
 </tr>
 <tr class="subtest" data-parent="async_functions" id="test-async_functions_return"><td><span><a class="anchor" href="#test-async_functions_return">&#xA7;</a>return</span><script data-source="
 async function a(){
@@ -5063,6 +5092,7 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="async_functions" id="test-async_functions_throw"><td><span><a class="anchor" href="#test-async_functions_throw">&#xA7;</a>throw</span><script data-source="
 async function a(){
@@ -5235,6 +5265,7 @@ p.catch(function(result) {
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="async_functions" id="test-async_functions_no_line_break_between_async_and_function"><td><span><a class="anchor" href="#test-async_functions_no_line_break_between_async_and_function">&#xA7;</a>no line break between async and function</span><script data-source="
 async function a(){}
@@ -5397,6 +5428,7 @@ try { Function(&quot;async\n function a(){await 0}&quot;)(); } catch(e) { return
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="async_functions" id="test-async_functions_no_prototype_property"><td><span><a class="anchor" href="#test-async_functions_no_prototype_property">&#xA7;</a>no &quot;prototype&quot; property</span><script data-source="
 async function a(){};
@@ -5559,6 +5591,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="async_functions" id="test-async_functions_await_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-async_functions_await_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>await <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 (async function (){
@@ -5727,6 +5760,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="async_functions" id="test-async_functions_await,_rejection"><td><span><a class="anchor" href="#test-async_functions_await,_rejection">&#xA7;</a>await, rejection</span><script data-source="
 (async function (){
@@ -5897,6 +5931,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="async_functions" id="test-async_functions_must_await_a_value"><td><span><a class="anchor" href="#test-async_functions_must_await_a_value">&#xA7;</a>must await a value</span><script data-source="
 async function a(){ await Promise.resolve(); }
@@ -6059,6 +6094,7 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="async_functions" id="test-async_functions_can_await_non-Promise_values"><td><span><a class="anchor" href="#test-async_functions_can_await_non-Promise_values">&#xA7;</a>can await non-Promise values</span><script data-source="
 (async function (){
@@ -6226,6 +6262,7 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="async_functions" id="test-async_functions_cannot_await_in_parameters"><td><span><a class="anchor" href="#test-async_functions_cannot_await_in_parameters">&#xA7;</a>cannot await in parameters</span><script data-source="
 async function a(){ await Promise.resolve(); }
@@ -6388,6 +6425,7 @@ try { Function(&quot;(async function a(b = await Promise.resolve()){}())&quot;)(
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="async_functions" id="test-async_functions_async_methods,_object_literals"><td><span><a class="anchor" href="#test-async_functions_async_methods,_object_literals">&#xA7;</a>async methods, object literals</span><script data-source="
 var o = {
@@ -6560,6 +6598,7 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="async_functions" id="test-async_functions_async_methods,_classes"><td><span><a class="anchor" href="#test-async_functions_async_methods,_classes">&#xA7;</a>async methods, classes</span><script data-source="
 class C {
@@ -6732,6 +6771,7 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="async_functions" id="test-async_functions_async_arrow_functions_in_methods,_classes"><td><span><a class="anchor" href="#test-async_functions_async_arrow_functions_in_methods,_classes">&#xA7;</a>async arrow functions in methods, classes</span><script data-source="
 function doSomething(callback) {
@@ -6904,6 +6944,7 @@ var p = new C().a();
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="async_functions" id="test-async_functions_async_arrow_functions"><td><span><a class="anchor" href="#test-async_functions_async_arrow_functions">&#xA7;</a>async arrow functions</span><script data-source="
 var a = async () =&gt; await Promise.resolve(&quot;foo&quot;);
@@ -7074,6 +7115,7 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="async_functions" id="test-async_functions_correct_prototype_chain"><td><span><a class="anchor" href="#test-async_functions_correct_prototype_chain">&#xA7;</a>correct prototype chain</span><script data-source="
 var asyncFunctionProto = Object.getPrototypeOf(async function (){});
@@ -7237,6 +7279,7 @@ return asyncFunctionProto !== function(){}.prototype
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="async_functions" id="test-async_functions_async_function_prototype,_Symbol.toStringTag"><td><span><a class="anchor" href="#test-async_functions_async_function_prototype,_Symbol.toStringTag">&#xA7;</a>async function prototype, Symbol.toStringTag</span><script data-source="
 return Object.getPrototypeOf(async function (){})[Symbol.toStringTag] === &quot;AsyncFunction&quot;;
@@ -7398,6 +7441,7 @@ return Object.getPrototypeOf(async function (){})[Symbol.toStringTag] === &quot;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="async_functions" id="test-async_functions_async_function_constructor"><td><span><a class="anchor" href="#test-async_functions_async_function_constructor">&#xA7;</a>async function constructor</span><script data-source="
 var a = async function (){}.constructor(&quot;return &apos;foo&apos;;&quot;);
@@ -7568,6 +7612,7 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-shared_memory_and_atomics"><span><a class="anchor" href="#test-shared_memory_and_atomics">&#xA7;</a>shared memory and atomics</span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/17</td>
@@ -7726,6 +7771,7 @@ p.then(function(result) {
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">17/17</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">17/17</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">17/17</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/17</td>
 </tr>
 <tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-sharedarraybuffer-objects_SharedArrayBuffer_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-sharedarraybuffer-objects_SharedArrayBuffer_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-sharedarraybuffer-objects">SharedArrayBuffer</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SharedArrayBuffer === &apos;function&apos;;
@@ -7887,6 +7933,7 @@ return typeof SharedArrayBuffer === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_SharedArrayBuffer[Symbol.species]"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_SharedArrayBuffer[Symbol.species]">&#xA7;</a>SharedArrayBuffer[Symbol.species]</span><script data-source="
 return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
@@ -8048,6 +8095,7 @@ return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-get-sharedarraybuffer.prototype.bytelength_SharedArrayBuffer.prototype.byteLength_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/byteLength_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-get-sharedarraybuffer.prototype.bytelength_SharedArrayBuffer.prototype.byteLength_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/byteLength_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-get-sharedarraybuffer.prototype.bytelength">SharedArrayBuffer.prototype.byteLength</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/byteLength" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
@@ -8209,6 +8257,7 @@ return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-sharedarraybuffer.prototype.slice_SharedArrayBuffer.prototype.slice_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/slice_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-sharedarraybuffer.prototype.slice_SharedArrayBuffer.prototype.slice_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/slice_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-sharedarraybuffer.prototype.slice">SharedArrayBuffer.prototype.slice</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/slice" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
@@ -8370,6 +8419,7 @@ return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-sharedarraybuffer.prototype.toString_SharedArrayBuffer.prototype[Symbol.toStringTag]_/a"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-sharedarraybuffer.prototype.toString_SharedArrayBuffer.prototype[Symbol.toStringTag]_/a">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-sharedarraybuffer.prototype.toString">SharedArrayBuffer.prototype[Symbol.toStringTag]</a></span><script data-source="
 return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuffer&apos;;
@@ -8531,6 +8581,7 @@ return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuff
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.add_Atomics.add_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/add_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.add_Atomics.add_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/add_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-atomics.add">Atomics.add</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/add" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof Atomics.add === &apos;function&apos;;
@@ -8692,6 +8743,7 @@ return typeof Atomics.add === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.and_Atomics.and_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/and_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.and_Atomics.and_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/and_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-atomics.and">Atomics.and</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/and" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof Atomics.and === &apos;function&apos;;
@@ -8853,6 +8905,7 @@ return typeof Atomics.and === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.compareExchange_Atomics.compareExchange_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/compareExchange_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.compareExchange_Atomics.compareExchange_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/compareExchange_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-atomics.compareExchange">Atomics.compareExchange</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/compareExchange" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof Atomics.compareExchange === &apos;function&apos;;
@@ -9014,6 +9067,7 @@ return typeof Atomics.compareExchange === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.exchange_Atomics.exchange_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/exchange_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.exchange_Atomics.exchange_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/exchange_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-atomics.exchange">Atomics.exchange</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/exchange" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof Atomics.exchange === &apos;function&apos;;
@@ -9175,6 +9229,7 @@ return typeof Atomics.exchange === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.wait_Atomics.wait_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/wait_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.wait_Atomics.wait_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/wait_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-atomics.wait">Atomics.wait</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/wait" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof Atomics.wait === &apos;function&apos;;
@@ -9336,6 +9391,7 @@ return typeof Atomics.wait === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.notify_Atomics.notify_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/notify_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.notify_Atomics.notify_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/notify_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-atomics.notify">Atomics.notify</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/notify" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof Atomics.notify === &apos;function&apos;;
@@ -9497,6 +9553,7 @@ return typeof Atomics.notify === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.isLockFree_Atomics.isLockFree_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/isLockFree_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.isLockFree_Atomics.isLockFree_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/isLockFree_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-atomics.isLockFree">Atomics.isLockFree</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/isLockFree" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof Atomics.isLockFree === &apos;function&apos;;
@@ -9658,6 +9715,7 @@ return typeof Atomics.isLockFree === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.load_Atomics.load_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/load_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.load_Atomics.load_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/load_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-atomics.load">Atomics.load</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/load" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof Atomics.load === &apos;function&apos;;
@@ -9819,6 +9877,7 @@ return typeof Atomics.load === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.or_Atomics.or_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/or_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.or_Atomics.or_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/or_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-atomics.or">Atomics.or</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/or" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof Atomics.or === &apos;function&apos;;
@@ -9980,6 +10039,7 @@ return typeof Atomics.or === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.store_Atomics.store_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/store_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.store_Atomics.store_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/store_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-atomics.store">Atomics.store</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/store" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof Atomics.store === &apos;function&apos;;
@@ -10141,6 +10201,7 @@ return typeof Atomics.store === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.sub_Atomics.sub_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/sub_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.sub_Atomics.sub_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/sub_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-atomics.sub">Atomics.sub</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/sub" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof Atomics.sub === &apos;function&apos;;
@@ -10302,6 +10363,7 @@ return typeof Atomics.sub === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.xor_Atomics.xor_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/xor_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.xor_Atomics.xor_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/xor_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-atomics.xor">Atomics.xor</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/xor" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof Atomics.xor === &apos;function&apos;;
@@ -10463,8 +10525,9 @@ return typeof Atomics.xor === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
-<tr class="category"><td colspan="159"><span>2017 misc</span></td>
+<tr class="category"><td colspan="160"><span>2017 misc</span></td>
 </tr>
 <tr significance="0.125"><td id="test-RegExp_u_flag,_case_folding"><span><a class="anchor" href="#test-RegExp_u_flag,_case_folding">&#xA7;</a><a href="https://github.com/tc39/ecma262/pull/525">RegExp &quot;u&quot; flag, case folding</a></span><script data-source="
 return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/\W/iu)
@@ -10629,6 +10692,7 @@ return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr significance="0.125"><td id="test-arguments.caller_removed"><span><a class="anchor" href="#test-arguments.caller_removed">&#xA7;</a><a href="https://github.com/tc39/ecma262/pull/689">arguments.caller removed</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments/caller" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return (function(){
@@ -10793,8 +10857,9 @@ return (function(){
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
-<tr class="category"><td colspan="159"><span>2017 annex b</span></td>
+<tr class="category"><td colspan="160"><span>2017 annex b</span></td>
 </tr>
 <tr class="supertest optional-feature" significance="0.125"><td id="test-Object.prototype_getter/setter_methods"><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-object.prototype.__defineGetter__">Object.prototype getter/setter methods</a></span></td>
 <td class="tally obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
@@ -10953,6 +11018,7 @@ return (function(){
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">16/16</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">16/16</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">16/16</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="1">16/16</td>
 </tr>
 <tr class="subtest" data-parent="Object.prototype_getter/setter_methods" id="test-Object.prototype_getter/setter_methods___defineGetter___a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__defineGetter___title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods___defineGetter___a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__defineGetter___title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>__defineGetter__ <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__defineGetter__" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var obj = {};
@@ -11119,6 +11185,7 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Object.prototype_getter/setter_methods" id="test-Object.prototype_getter/setter_methods___defineGetter__,_symbols"><td><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods___defineGetter__,_symbols">&#xA7;</a>__defineGetter__, symbols</span><script data-source="
 var obj = {};
@@ -11286,6 +11353,7 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Object.prototype_getter/setter_methods" id="test-Object.prototype_getter/setter_methods___defineGetter__,_ToObject(this)"><td><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods___defineGetter__,_ToObject(this)">&#xA7;</a>__defineGetter__, ToObject(this)</span><script data-source="
 var key = &apos;__accessors_test__&apos;;
@@ -11453,6 +11521,7 @@ return true;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Object.prototype_getter/setter_methods" id="test-Object.prototype_getter/setter_methods___defineSetter___a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__defineSetter___title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods___defineSetter___a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__defineSetter___title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>__defineSetter__ <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__defineSetter__" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var obj = {};
@@ -11619,6 +11688,7 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Object.prototype_getter/setter_methods" id="test-Object.prototype_getter/setter_methods___defineSetter__,_symbols"><td><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods___defineSetter__,_symbols">&#xA7;</a>__defineSetter__, symbols</span><script data-source="
 var obj = {};
@@ -11786,6 +11856,7 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Object.prototype_getter/setter_methods" id="test-Object.prototype_getter/setter_methods___defineSetter__,_ToObject(this)"><td><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods___defineSetter__,_ToObject(this)">&#xA7;</a>__defineSetter__, ToObject(this)</span><script data-source="
 var key = &apos;__accessors_test__&apos;;
@@ -11953,6 +12024,7 @@ return true;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Object.prototype_getter/setter_methods" id="test-Object.prototype_getter/setter_methods___lookupGetter___a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__lookupGetter___title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods___lookupGetter___a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__lookupGetter___title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>__lookupGetter__ <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__lookupGetter__" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var obj = {
@@ -12121,6 +12193,7 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Object.prototype_getter/setter_methods" id="test-Object.prototype_getter/setter_methods___lookupGetter__,_prototype_chain"><td><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods___lookupGetter__,_prototype_chain">&#xA7;</a>__lookupGetter__, prototype chain</span><script data-source="
 var obj = {
@@ -12289,6 +12362,7 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Object.prototype_getter/setter_methods" id="test-Object.prototype_getter/setter_methods___lookupGetter__,_symbols"><td><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods___lookupGetter__,_symbols">&#xA7;</a>__lookupGetter__, symbols</span><script data-source="
 var sym = Symbol();
@@ -12458,6 +12532,7 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Object.prototype_getter/setter_methods" id="test-Object.prototype_getter/setter_methods___lookupGetter__,_ToObject(this)"><td><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods___lookupGetter__,_ToObject(this)">&#xA7;</a>__lookupGetter__, ToObject(this)</span><script data-source="
 __lookupGetter__.call(1, &apos;key&apos;);
@@ -12624,6 +12699,7 @@ return true;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Object.prototype_getter/setter_methods" id="test-Object.prototype_getter/setter_methods___lookupGetter__,_data_properties_can_shadow_accessors"><td><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods___lookupGetter__,_data_properties_can_shadow_accessors">&#xA7;</a>__lookupGetter__, data properties can shadow accessors</span><script data-source="
 var a = { };
@@ -12789,6 +12865,7 @@ return b.__lookupGetter__(&quot;foo&quot;) === void undefined
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Object.prototype_getter/setter_methods" id="test-Object.prototype_getter/setter_methods___lookupSetter___a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__lookupSetter___title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods___lookupSetter___a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__lookupSetter___title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>__lookupSetter__ <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__lookupSetter__" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var obj = {
@@ -12957,6 +13034,7 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Object.prototype_getter/setter_methods" id="test-Object.prototype_getter/setter_methods___lookupSetter__,_prototype_chain"><td><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods___lookupSetter__,_prototype_chain">&#xA7;</a>__lookupSetter__, prototype chain</span><script data-source="
 var obj = {
@@ -13125,6 +13203,7 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Object.prototype_getter/setter_methods" id="test-Object.prototype_getter/setter_methods___lookupSetter__,_symbols"><td><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods___lookupSetter__,_symbols">&#xA7;</a>__lookupSetter__, symbols</span><script data-source="
 var sym = Symbol();
@@ -13294,6 +13373,7 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Object.prototype_getter/setter_methods" id="test-Object.prototype_getter/setter_methods___lookupSetter__,_ToObject(this)"><td><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods___lookupSetter__,_ToObject(this)">&#xA7;</a>__lookupSetter__, ToObject(this)</span><script data-source="
 __lookupSetter__.call(1, &apos;key&apos;);
@@ -13460,6 +13540,7 @@ return true;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Object.prototype_getter/setter_methods" id="test-Object.prototype_getter/setter_methods___lookupSetter__,_data_properties_can_shadow_accessors"><td><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods___lookupSetter__,_data_properties_can_shadow_accessors">&#xA7;</a>__lookupSetter__, data properties can shadow accessors</span><script data-source="
 var a = { };
@@ -13625,6 +13706,7 @@ return b.__lookupSetter__(&quot;foo&quot;) === void undefined
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.125"><td id="test-Proxy_internal_calls,_getter/setter_methods"><span><a class="anchor" href="#test-Proxy_internal_calls,_getter/setter_methods">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-object.prototype.__defineGetter__">Proxy internal calls, getter/setter methods</a></span></td>
 <td class="tally obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
@@ -13783,6 +13865,7 @@ return b.__lookupSetter__(&quot;foo&quot;) === void undefined
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">4/4</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">4/4</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">4/4</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="1">4/4</td>
 </tr>
 <tr class="subtest" data-parent="Proxy_internal_calls,_getter/setter_methods" id="test-Proxy_internal_calls,_getter/setter_methods___defineGetter__"><td><span><a class="anchor" href="#test-Proxy_internal_calls,_getter/setter_methods___defineGetter__">&#xA7;</a>__defineGetter__</span><script data-source="
 // Object.prototype.__defineGetter__ -&gt; DefinePropertyOrThrow -&gt; [[DefineOwnProperty]]
@@ -13948,6 +14031,7 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Proxy_internal_calls,_getter/setter_methods" id="test-Proxy_internal_calls,_getter/setter_methods___defineSetter__"><td><span><a class="anchor" href="#test-Proxy_internal_calls,_getter/setter_methods___defineSetter__">&#xA7;</a>__defineSetter__</span><script data-source="
 // Object.prototype.__defineSetter__ -&gt; DefinePropertyOrThrow -&gt; [[DefineOwnProperty]]
@@ -14113,6 +14197,7 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Proxy_internal_calls,_getter/setter_methods" id="test-Proxy_internal_calls,_getter/setter_methods___lookupGetter__"><td><span><a class="anchor" href="#test-Proxy_internal_calls,_getter/setter_methods___lookupGetter__">&#xA7;</a>__lookupGetter__</span><script data-source="
 // Object.prototype.__lookupGetter__ -&gt; [[GetOwnProperty]]
@@ -14283,6 +14368,7 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Proxy_internal_calls,_getter/setter_methods" id="test-Proxy_internal_calls,_getter/setter_methods___lookupSetter__"><td><span><a class="anchor" href="#test-Proxy_internal_calls,_getter/setter_methods___lookupSetter__">&#xA7;</a>__lookupSetter__</span><script data-source="
 // Object.prototype.__lookupSetter__ -&gt; [[GetOwnProperty]]
@@ -14453,6 +14539,7 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr significance="0.125" class="optional-feature"><td id="test-assignments_allowed_in_for-in_head_in_non-strict_mode"><span><a class="anchor" href="#test-assignments_allowed_in_for-in_head_in_non-strict_mode">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-initializers-in-forin-statement-heads">assignments allowed in for-in head in non-strict mode</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...in#Compatibility_Initializer_expressions_in_strict_mode" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 for (var i = 0 in {}) {}
@@ -14615,8 +14702,9 @@ return i === 0;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
-<tr class="category"><td colspan="159"><span>2018 features</span></td>
+<tr class="category"><td colspan="160"><span>2018 features</span></td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-object_rest/spread_properties"><span><a class="anchor" href="#test-object_rest/spread_properties">&#xA7;</a><a href="https://github.com/tc39/proposal-object-rest-spread">object rest/spread properties</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/2</td>
@@ -14775,6 +14863,7 @@ return i === 0;
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">2/2</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">2/2</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">2/2</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="1">2/2</td>
 </tr>
 <tr class="subtest" data-parent="object_rest/spread_properties" id="test-object_rest/spread_properties_object_rest_properties"><td><span><a class="anchor" href="#test-object_rest/spread_properties_object_rest_properties">&#xA7;</a>object rest properties</span><script data-source="
 var {a, ...rest} = {a: 1, b: 2, c: 3};
@@ -14937,6 +15026,7 @@ return a === 1 &amp;&amp; rest.a === void undefined &amp;&amp; rest.b === 2 &amp
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="object_rest/spread_properties" id="test-object_rest/spread_properties_object_spread_properties"><td><span><a class="anchor" href="#test-object_rest/spread_properties_object_spread_properties">&#xA7;</a>object spread properties</span><script data-source="
 var spread = {b: 2, c: 3};
@@ -15100,6 +15190,7 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-Promise.prototype.finally"><span><a class="anchor" href="#test-Promise.prototype.finally">&#xA7;</a><a href="https://github.com/tc39/proposal-promise-finally">Promise.prototype.finally</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/finally" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/3</td>
@@ -15258,6 +15349,7 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">3/3</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">3/3</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">3/3</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="1">3/3</td>
 </tr>
 <tr class="subtest" data-parent="Promise.prototype.finally" id="test-Promise.prototype.finally_basic_support"><td><span><a class="anchor" href="#test-Promise.prototype.finally_basic_support">&#xA7;</a>basic support</span><script data-source="
 var p1 = Promise.resolve(&quot;foo&quot;);
@@ -15445,6 +15537,7 @@ function check() {
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Promise.prototype.finally" id="test-Promise.prototype.finally_don&apos;t_change_resolution_value"><td><span><a class="anchor" href="#test-Promise.prototype.finally_don&apos;t_change_resolution_value">&#xA7;</a>don&apos;t change resolution value</span><script data-source="
 var score = 0;
@@ -15624,6 +15717,7 @@ function check() {
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Promise.prototype.finally" id="test-Promise.prototype.finally_change_rejection_value"><td><span><a class="anchor" href="#test-Promise.prototype.finally_change_rejection_value">&#xA7;</a>change rejection value</span><script data-source="
 var score = 0;
@@ -15805,6 +15899,7 @@ function check() {
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr significance="0.25"><td id="test-s_(dotAll)_flag_for_regular_expressions"><span><a class="anchor" href="#test-s_(dotAll)_flag_for_regular_expressions">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-get-regexp.prototype.dotAll">s (dotAll) flag for regular expressions</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/dotAll" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 const regex = /foo.bar/s;
@@ -15967,6 +16062,7 @@ return regex.test(&apos;foo\nbar&apos;);
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr significance="0.25"><td id="test-RegExp_named_capture_groups"><span><a class="anchor" href="#test-RegExp_named_capture_groups">&#xA7;</a><a href="https://github.com/tc39/proposal-regexp-named-groups">RegExp named capture groups</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Groups_and_Ranges" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var result = /(?&lt;year&gt;\d{4})-(?&lt;month&gt;\d{2})-(?&lt;day&gt;\d{2})/.exec(&apos;2016-03-11&apos;);
@@ -16135,6 +16231,7 @@ return result.groups.year === &apos;2016&apos;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr significance="0.25"><td id="test-RegExp_Lookbehind_Assertions"><span><a class="anchor" href="#test-RegExp_Lookbehind_Assertions">&#xA7;</a><a href="https://github.com/tc39/proposal-regexp-lookbehind">RegExp Lookbehind Assertions</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Assertions" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&apos;) &amp;&amp;
@@ -16297,6 +16394,7 @@ return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&a
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr significance="0.25"><td id="test-RegExp_Unicode_Property_Escapes"><span><a class="anchor" href="#test-RegExp_Unicode_Property_Escapes">&#xA7;</a><a href="https://github.com/tc39/proposal-regexp-unicode-property-escapes">RegExp Unicode Property Escapes</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Unicode_Property_Escapes" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 const regexGreekSymbol = /\p{Script=Greek}/u;
@@ -16459,6 +16557,7 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-Asynchronous_Iterators"><span><a class="anchor" href="#test-Asynchronous_Iterators">&#xA7;</a><a href="https://github.com/tc39/proposal-async-iteration">Asynchronous Iterators</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/2</td>
@@ -16617,6 +16716,7 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">2/2</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">2/2</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">2/2</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/2</td>
 </tr>
 <tr class="subtest" data-parent="Asynchronous_Iterators" id="test-Asynchronous_Iterators_async_generators"><td><span><a class="anchor" href="#test-Asynchronous_Iterators_async_generators">&#xA7;</a>async generators</span><script data-source="
 async function*generator(){
@@ -16785,6 +16885,7 @@ iterator.next().then(function(step){
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Asynchronous_Iterators" id="test-Asynchronous_Iterators_for-await-of_loops_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Asynchronous_Iterators_for-await-of_loops_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>for-await-of loops <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var asyncIterable = {};
@@ -16963,8 +17064,9 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
-<tr class="category"><td colspan="159"><span>2018 misc</span></td>
+<tr class="category"><td colspan="160"><span>2018 misc</span></td>
 </tr>
 <tr significance="0.125"><td id="test-Proxy_ownKeys_handler,_duplicate_keys_for_non-extensible_targets"><span><a class="anchor" href="#test-Proxy_ownKeys_handler,_duplicate_keys_for_non-extensible_targets">&#xA7;</a><a href="https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-ownpropertykeys">Proxy &quot;ownKeys&quot; handler, duplicate keys for non-extensible targets</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/ownKeys" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var p = new Proxy({}, {
@@ -17136,6 +17238,7 @@ return false;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr significance="0.25"><td id="test-template_literal_revision"><span><a class="anchor" href="#test-template_literal_revision">&#xA7;</a><a href="https://github.com/tc39/proposal-template-literal-revision">template literal revision</a></span><script data-source="
 function tag(strings, a) {
@@ -17304,8 +17407,9 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
-<tr class="category"><td colspan="159"><span>2019 features</span></td>
+<tr class="category"><td colspan="160"><span>2019 features</span></td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Symbol.prototype.description"><span><a class="anchor" href="#test-Symbol.prototype.description">&#xA7;</a><a href="https://github.com/tc39/proposal-Symbol-description">Symbol.prototype.description</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/description" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/3</td>
@@ -17464,6 +17568,7 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">3/3</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">3/3</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">3/3</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 </tr>
 <tr class="subtest" data-parent="Symbol.prototype.description" id="test-Symbol.prototype.description_basic"><td><span><a class="anchor" href="#test-Symbol.prototype.description_basic">&#xA7;</a>basic</span><script data-source="
 return Symbol(&apos;foo&apos;).description === &apos;foo&apos;;
@@ -17625,6 +17730,7 @@ return Symbol(&apos;foo&apos;).description === &apos;foo&apos;;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Symbol.prototype.description" id="test-Symbol.prototype.description_empty_description"><td><span><a class="anchor" href="#test-Symbol.prototype.description_empty_description">&#xA7;</a>empty description</span><script data-source="
 return Symbol(&apos;&apos;).description === &apos;&apos;;
@@ -17786,6 +17892,7 @@ return Symbol(&apos;&apos;).description === &apos;&apos;;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Symbol.prototype.description" id="test-Symbol.prototype.description_undefined_description"><td><span><a class="anchor" href="#test-Symbol.prototype.description_undefined_description">&#xA7;</a>undefined description</span><script data-source="
 return Symbol.prototype.hasOwnProperty(&apos;description&apos;)
@@ -17948,6 +18055,7 @@ return Symbol.prototype.hasOwnProperty(&apos;description&apos;)
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr significance="0.25"><td id="test-Object.fromEntries"><span><a class="anchor" href="#test-Object.fromEntries">&#xA7;</a><a href="https://github.com/tc39/proposal-object-from-entries">Object.fromEntries</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/fromEntries" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var object = Object.fromEntries(new Map([[&apos;foo&apos;, 42], [&apos;bar&apos;, 23]]));
@@ -18110,6 +18218,7 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-string_trimming"><span><a class="anchor" href="#test-string_trimming">&#xA7;</a><a href="https://github.com/tc39/proposal-string-left-right-trim">string trimming</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/4</td>
@@ -18268,6 +18377,7 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">4/4</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">4/4</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">4/4</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="1">4/4</td>
 </tr>
 <tr class="subtest" data-parent="string_trimming" id="test-string_trimming_String.prototype.trimLeft_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/TrimLeft_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-string_trimming_String.prototype.trimLeft_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/TrimLeft_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>String.prototype.trimLeft <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/TrimLeft" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return &apos; \t \n abc   \t\n&apos;.trimLeft() === &apos;abc   \t\n&apos;;
@@ -18429,6 +18539,7 @@ return &apos; \t \n abc   \t\n&apos;.trimLeft() === &apos;abc   \t\n&apos;;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="string_trimming" id="test-string_trimming_String.prototype.trimRight_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/TrimRight_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-string_trimming_String.prototype.trimRight_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/TrimRight_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>String.prototype.trimRight <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/TrimRight" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return &apos; \t \n abc   \t\n&apos;.trimRight() === &apos; \t \n abc&apos;;
@@ -18590,6 +18701,7 @@ return &apos; \t \n abc   \t\n&apos;.trimRight() === &apos; \t \n abc&apos;;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="string_trimming" id="test-string_trimming_String.prototype.trimStart_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trimStart_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-string_trimming_String.prototype.trimStart_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trimStart_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>String.prototype.trimStart <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trimStart" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return &apos; \t \n abc   \t\n&apos;.trimStart() === &apos;abc   \t\n&apos;;
@@ -18751,6 +18863,7 @@ return &apos; \t \n abc   \t\n&apos;.trimStart() === &apos;abc   \t\n&apos;;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="string_trimming" id="test-string_trimming_String.prototype.trimEnd_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trimEnd_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-string_trimming_String.prototype.trimEnd_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trimEnd_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>String.prototype.trimEnd <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trimEnd" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
@@ -18912,6 +19025,7 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-Array.prototype.{flat,_flatMap}"><span><a class="anchor" href="#test-Array.prototype.{flat,_flatMap}">&#xA7;</a><a href="https://tc39.github.io/proposal-flatMap/">Array.prototype.{flat, flatMap}</a><a href="#flatten-compat-issue-note"><sup>[22]</sup></a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/3</td>
@@ -19070,6 +19184,7 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">3/3</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">3/3</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">3/3</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 </tr>
 <tr class="subtest" data-parent="Array.prototype.{flat,_flatMap}" id="test-Array.prototype.{flat,_flatMap}_Array.prototype.flat_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Array.prototype.{flat,_flatMap}_Array.prototype.flat_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Array.prototype.flat <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return [1, [2, 3], [4, [5, 6]]].flat().join(&apos;&apos;) === &apos;12345,6&apos;;
@@ -19231,6 +19346,7 @@ return [1, [2, 3], [4, [5, 6]]].flat().join(&apos;&apos;) === &apos;12345,6&apos
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Array.prototype.{flat,_flatMap}" id="test-Array.prototype.{flat,_flatMap}_Array.prototype.flatMap_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Array.prototype.{flat,_flatMap}_Array.prototype.flatMap_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Array.prototype.flatMap <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
@@ -19394,6 +19510,7 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Array.prototype.{flat,_flatMap}" id="test-Array.prototype.{flat,_flatMap}_flat_and_flatMap_in_Array.prototype[@@unscopables]"><td><span><a class="anchor" href="#test-Array.prototype.{flat,_flatMap}_flat_and_flatMap_in_Array.prototype[@@unscopables]">&#xA7;</a>flat and flatMap in Array.prototype[@@unscopables]</span><script data-source="
 return Array.prototype[Symbol.unscopables].flat
@@ -19556,8 +19673,9 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
-<tr class="category"><td colspan="159"><span>2019 misc</span></td>
+<tr class="category"><td colspan="160"><span>2019 misc</span></td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-optional_catch_binding"><span><a class="anchor" href="#test-optional_catch_binding">&#xA7;</a><a href="https://github.com/tc39/proposal-optional-catch-binding">optional catch binding</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/3</td>
@@ -19716,6 +19834,7 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">3/3</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">3/3</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">3/3</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="1">3/3</td>
 </tr>
 <tr class="subtest" data-parent="optional_catch_binding" id="test-optional_catch_binding_basic"><td><span><a class="anchor" href="#test-optional_catch_binding_basic">&#xA7;</a>basic</span><script data-source="
 try {
@@ -19883,6 +20002,7 @@ return false;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="optional_catch_binding" id="test-optional_catch_binding_await"><td><span><a class="anchor" href="#test-optional_catch_binding_await">&#xA7;</a>await</span><script data-source="
 (async function (){
@@ -20051,6 +20171,7 @@ return false;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="optional_catch_binding" id="test-optional_catch_binding_yield"><td><span><a class="anchor" href="#test-optional_catch_binding_yield">&#xA7;</a>yield</span><script data-source="
 function *foo() {
@@ -20223,6 +20344,7 @@ return it.throw().value;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Function.prototype.toString_revision"><span><a class="anchor" href="#test-Function.prototype.toString_revision">&#xA7;</a><a href="https://github.com/tc39/Function-prototype-toString-revision">Function.prototype.toString revision</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/toString" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/7</td>
@@ -20381,6 +20503,7 @@ return it.throw().value;
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">7/7</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">7/7</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">7/7</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
 </tr>
 <tr class="subtest" data-parent="Function.prototype.toString_revision" id="test-Function.prototype.toString_revision_functions_created_with_the_Function_constructor"><td><span><a class="anchor" href="#test-Function.prototype.toString_revision_functions_created_with_the_Function_constructor">&#xA7;</a>functions created with the Function constructor</span><script data-source="
 var fn = Function(&apos;a&apos;, &apos; /\x2A a \x2A/ b, c /\x2A b \x2A/ //&apos;, &apos;/\x2A c \x2A/ ; /\x2A d \x2A/ //&apos;);
@@ -20544,6 +20667,7 @@ return fn + &apos;&apos; === str;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Function.prototype.toString_revision" id="test-Function.prototype.toString_revision_arrows"><td><span><a class="anchor" href="#test-Function.prototype.toString_revision_arrows">&#xA7;</a>arrows</span><script data-source="
 var str = &apos;a =&gt; b&apos;;
@@ -20706,6 +20830,7 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Function.prototype.toString_revision" id="test-Function.prototype.toString_revision_[native_code]"><td><span><a class="anchor" href="#test-Function.prototype.toString_revision_[native_code]">&#xA7;</a>[native code]</span><script data-source="
 const NATIVE_EVAL_RE = /\bfunction\b[\s\S]*\beval\b[\s\S]*\([\s\S]*\)[\s\S]*\{[\s\S]*\[[\s\S]*\bnative\b[\s\S]+\bcode\b[\s\S]*\][\s\S]*\}/;
@@ -20868,6 +20993,7 @@ return NATIVE_EVAL_RE.test(eval + &apos;&apos;);
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Function.prototype.toString_revision" id="test-Function.prototype.toString_revision_class_expression_with_implicit_constructor"><td><span><a class="anchor" href="#test-Function.prototype.toString_revision_class_expression_with_implicit_constructor">&#xA7;</a>class expression with implicit constructor</span><script data-source="
 var str = &apos;class A {}&apos;;
@@ -21030,6 +21156,7 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Function.prototype.toString_revision" id="test-Function.prototype.toString_revision_class_expression_with_explicit_constructor"><td><span><a class="anchor" href="#test-Function.prototype.toString_revision_class_expression_with_explicit_constructor">&#xA7;</a>class expression with explicit constructor</span><script data-source="
 var str = &apos;class /\x2A a \x2A/ A /\x2A b \x2A/ extends /\x2A c \x2A/ function B(){} /\x2A d \x2A/ { /\x2A e \x2A/ constructor /\x2A f \x2A/ ( /\x2A g \x2A/ ) /\x2A h \x2A/ { /\x2A i \x2A/ ; /\x2A j \x2A/ } /\x2A k \x2A/ m /\x2A l \x2A/ ( /\x2A m \x2A/ ) /\x2A n \x2A/ { /\x2A o \x2A/ } /\x2A p \x2A/ }&apos;;
@@ -21192,6 +21319,7 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Function.prototype.toString_revision" id="test-Function.prototype.toString_revision_unicode_escape_sequences_in_identifiers"><td><span><a class="anchor" href="#test-Function.prototype.toString_revision_unicode_escape_sequences_in_identifiers">&#xA7;</a>unicode escape sequences in identifiers</span><script data-source="
 var str = &apos;function \\u0061(\\u{62}, \\u0063) { \\u0062 = \\u{00063}; return b; }&apos;;
@@ -21354,6 +21482,7 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Function.prototype.toString_revision" id="test-Function.prototype.toString_revision_methods_and_computed_property_names"><td><span><a class="anchor" href="#test-Function.prototype.toString_revision_methods_and_computed_property_names">&#xA7;</a>methods and computed property names</span><script data-source="
 var str = &apos;[ /\x2A a \x2A/ &quot;f&quot; /\x2A b \x2A/ ] /\x2A c \x2A/ ( /\x2A d \x2A/ ) /\x2A e \x2A/ { /\x2A f \x2A/ }&apos;;
@@ -21516,6 +21645,7 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-JSON_superset"><span><a class="anchor" href="#test-JSON_superset">&#xA7;</a><a href="https://github.com/tc39/proposal-json-superset">JSON superset</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/2</td>
@@ -21674,6 +21804,7 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">2/2</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">2/2</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">2/2</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="1">2/2</td>
 </tr>
 <tr class="subtest" data-parent="JSON_superset" id="test-JSON_superset_LINE_SEPARATOR_can_appear_in_string_literals"><td><span><a class="anchor" href="#test-JSON_superset_LINE_SEPARATOR_can_appear_in_string_literals">&#xA7;</a>LINE SEPARATOR can appear in string literals</span><script data-source="
 return eval(&quot;&apos;\u2028&apos;&quot;) === &quot;\u2028&quot;;
@@ -21835,6 +21966,7 @@ return eval(&quot;&apos;\u2028&apos;&quot;) === &quot;\u2028&quot;;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="JSON_superset" id="test-JSON_superset_PARAGRAPH_SEPARATOR_can_appear_in_string_literals"><td><span><a class="anchor" href="#test-JSON_superset_PARAGRAPH_SEPARATOR_can_appear_in_string_literals">&#xA7;</a>PARAGRAPH SEPARATOR can appear in string literals</span><script data-source="
 return eval(&quot;&apos;\u2029&apos;&quot;) === &quot;\u2029&quot;;
@@ -21996,6 +22128,7 @@ return eval(&quot;&apos;\u2029&apos;&quot;) === &quot;\u2029&quot;;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr significance="0.25"><td id="test-Well-formed_JSON.stringify"><span><a class="anchor" href="#test-Well-formed_JSON.stringify">&#xA7;</a><a href="https://github.com/tc39/proposal-well-formed-stringify">Well-formed JSON.stringify</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#Well-formed_JSON.stringify()" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\&quot;&quot;
@@ -22158,8 +22291,9 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
-<tr class="category"><td colspan="159"><span>2020 features</span></td>
+<tr class="category"><td colspan="160"><span>2020 features</span></td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-String.prototype.matchAll"><span><a class="anchor" href="#test-String.prototype.matchAll">&#xA7;</a><a href="https://github.com/tc39/String.prototype.matchAll">String.prototype.matchAll</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/matchAll" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/2</td>
@@ -22318,6 +22452,7 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">2/2</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">2/2</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">2/2</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="1">2/2</td>
 </tr>
 <tr class="subtest" data-parent="String.prototype.matchAll" id="test-String.prototype.matchAll_basic_functionality"><td><span><a class="anchor" href="#test-String.prototype.matchAll_basic_functionality">&#xA7;</a>basic functionality</span><script data-source="
 var iterator = &apos;11a2bb&apos;.matchAll(/(\d)(\D)/g);
@@ -22489,6 +22624,7 @@ return a === &apos;1a2b&apos;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="String.prototype.matchAll" id="test-String.prototype.matchAll_throws_on_non-global_regex"><td><span><a class="anchor" href="#test-String.prototype.matchAll_throws_on_non-global_regex">&#xA7;</a>throws on non-global regex</span><script data-source="
 if (typeof String.prototype.matchAll !== &apos;function&apos;) return false;
@@ -22655,6 +22791,7 @@ try {
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-BigInt"><span><a class="anchor" href="#test-BigInt">&#xA7;</a><a href="https://github.com/tc39/proposal-bigint">BigInt</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/8</td>
@@ -22813,6 +22950,7 @@ try {
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">8/8</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">8/8</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">8/8</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="1">8/8</td>
 </tr>
 <tr class="subtest" data-parent="BigInt" id="test-BigInt_basic_functionality"><td><span><a class="anchor" href="#test-BigInt_basic_functionality">&#xA7;</a>basic functionality</span><script data-source="
 return (1n + 2n) === 3n;
@@ -22974,6 +23112,7 @@ return (1n + 2n) === 3n;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="BigInt" id="test-BigInt_constructor"><td><span><a class="anchor" href="#test-BigInt_constructor">&#xA7;</a>constructor</span><script data-source="
 return BigInt(&quot;3&quot;) === 3n;
@@ -23135,6 +23274,7 @@ return BigInt(&quot;3&quot;) === 3n;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="BigInt" id="test-BigInt_BigInt.asUintN"><td><span><a class="anchor" href="#test-BigInt_BigInt.asUintN">&#xA7;</a>BigInt.asUintN</span><script data-source="
 return typeof BigInt.asUintN === &apos;function&apos;;
@@ -23296,6 +23436,7 @@ return typeof BigInt.asUintN === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="BigInt" id="test-BigInt_BigInt.asIntN"><td><span><a class="anchor" href="#test-BigInt_BigInt.asIntN">&#xA7;</a>BigInt.asIntN</span><script data-source="
 return typeof BigInt.asIntN === &apos;function&apos;;
@@ -23457,6 +23598,7 @@ return typeof BigInt.asIntN === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="BigInt" id="test-BigInt_BigInt64Array"><td><span><a class="anchor" href="#test-BigInt_BigInt64Array">&#xA7;</a>BigInt64Array</span><script data-source="
 var buffer = new ArrayBuffer(64);
@@ -23621,6 +23763,7 @@ return view[0] === -0x8000000000000000n;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="BigInt" id="test-BigInt_BigUint64Array"><td><span><a class="anchor" href="#test-BigInt_BigUint64Array">&#xA7;</a>BigUint64Array</span><script data-source="
 var buffer = new ArrayBuffer(64);
@@ -23785,6 +23928,7 @@ return view[0] === 0n;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="BigInt" id="test-BigInt_DataView.prototype.getBigInt64"><td><span><a class="anchor" href="#test-BigInt_DataView.prototype.getBigInt64">&#xA7;</a>DataView.prototype.getBigInt64</span><script data-source="
 var buffer = new ArrayBuffer(64);
@@ -23949,6 +24093,7 @@ return view.getBigInt64(0) === 1n;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="BigInt" id="test-BigInt_DataView.prototype.getBigUint64"><td><span><a class="anchor" href="#test-BigInt_DataView.prototype.getBigUint64">&#xA7;</a>DataView.prototype.getBigUint64</span><script data-source="
 var buffer = new ArrayBuffer(64);
@@ -24113,6 +24258,7 @@ return view.getBigUint64(0) === 1n;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr significance="0.25"><td id="test-Promise.allSettled"><span><a class="anchor" href="#test-Promise.allSettled">&#xA7;</a><a href="https://github.com/tc39/proposal-promise-allSettled">Promise.allSettled</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 Promise.allSettled([
@@ -24285,6 +24431,7 @@ Promise.allSettled([
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-globalThis"><span><a class="anchor" href="#test-globalThis">&#xA7;</a><a href="https://github.com/tc39/proposal-global">globalThis</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/2</td>
@@ -24443,6 +24590,7 @@ Promise.allSettled([
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">2/2</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">2/2</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">2/2</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="1">2/2</td>
 </tr>
 <tr class="subtest" data-parent="globalThis" id="test-globalThis_globalThis_global_property_is_global_object"><td><span><a class="anchor" href="#test-globalThis_globalThis_global_property_is_global_object">&#xA7;</a>&quot;globalThis&quot; global property is global object</span><script data-source="
 var actualGlobal = Function(&apos;return this&apos;)();
@@ -24606,6 +24754,7 @@ return typeof globalThis === &apos;object&apos; &amp;&amp; globalThis &amp;&amp;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="globalThis" id="test-globalThis_globalThis_global_property_has_correct_property_descriptor"><td><span><a class="anchor" href="#test-globalThis_globalThis_global_property_has_correct_property_descriptor">&#xA7;</a>&quot;globalThis&quot; global property has correct property descriptor</span><script data-source="
 var actualGlobal = Function(&apos;return this&apos;)();
@@ -24773,6 +24922,7 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-optional_chaining_operator_(?.)"><span><a class="anchor" href="#test-optional_chaining_operator_(?.)">&#xA7;</a><a href="https://github.com/tc39/proposal-optional-chaining">optional chaining operator (?.)</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/5</td>
@@ -24931,6 +25081,7 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">5/5</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">5/5</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">5/5</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="1">5/5</td>
 </tr>
 <tr class="subtest" data-parent="optional_chaining_operator_(?.)" id="test-optional_chaining_operator_(?.)_optional_property_access"><td><span><a class="anchor" href="#test-optional_chaining_operator_(?.)_optional_property_access">&#xA7;</a>optional property access</span><script data-source="
 var foo = { baz: 42 };
@@ -25094,6 +25245,7 @@ return foo?.baz === 42 &amp;&amp; bar?.baz === void undefined;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="optional_chaining_operator_(?.)" id="test-optional_chaining_operator_(?.)_optional_bracket_access"><td><span><a class="anchor" href="#test-optional_chaining_operator_(?.)_optional_bracket_access">&#xA7;</a>optional bracket access</span><script data-source="
 var foo = { baz: 42 };
@@ -25257,6 +25409,7 @@ return foo?.[&apos;baz&apos;] === 42 &amp;&amp; bar?.[&apos;baz&apos;] === void 
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="optional_chaining_operator_(?.)" id="test-optional_chaining_operator_(?.)_optional_method_call"><td><span><a class="anchor" href="#test-optional_chaining_operator_(?.)_optional_method_call">&#xA7;</a>optional method call</span><script data-source="
 var foo = { baz: function () { return this.value; }, value: 42 };
@@ -25420,6 +25573,7 @@ return foo?.baz() === 42 &amp;&amp; bar?.baz() === void undefined;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="optional_chaining_operator_(?.)" id="test-optional_chaining_operator_(?.)_optional_function_call"><td><span><a class="anchor" href="#test-optional_chaining_operator_(?.)_optional_function_call">&#xA7;</a>optional function call</span><script data-source="
 var foo = { baz: function () { return 42; } };
@@ -25585,6 +25739,7 @@ return foo.baz?.() === 42 &amp;&amp; bar.baz?.() === void undefined &amp;&amp; b
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="optional_chaining_operator_(?.)" id="test-optional_chaining_operator_(?.)_spread_parameters_after_optional_chaining"><td><span><a class="anchor" href="#test-optional_chaining_operator_(?.)_spread_parameters_after_optional_chaining">&#xA7;</a>spread parameters after optional chaining</span><script data-source="
 var fn = null;
@@ -25750,6 +25905,7 @@ return fn?.(...[], 1) === void undefined &amp;&amp; fn?.(...[], ...[]) === void 
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr significance="0.25"><td id="test-nullish_coalescing_operator_(??)"><span><a class="anchor" href="#test-nullish_coalescing_operator_(??)">&#xA7;</a><a href="https://github.com/tc39/proposal-nullish-coalescing">nullish coalescing operator (??)</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return (null ?? 42) === 42 &amp;&amp;
@@ -25916,8 +26072,9 @@ return (null ?? 42) === 42 &amp;&amp;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
-<tr class="category"><td colspan="159"><span>2021 features</span></td>
+<tr class="category"><td colspan="160"><span>2021 features</span></td>
 </tr>
 <tr significance="0.25"><td id="test-String.prototype.replaceAll"><span><a class="anchor" href="#test-String.prototype.replaceAll">&#xA7;</a><a href="https://github.com/tc39/proposal-string-replace-all">String.prototype.replaceAll</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &apos;) === &apos;q=query string parameters&apos;;
@@ -26079,6 +26236,7 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Promise.any"><span><a class="anchor" href="#test-Promise.any">&#xA7;</a><a href="https://github.com/tc39/proposal-promise-any">Promise.any</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/any" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/2</td>
@@ -26237,6 +26395,7 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">2/2</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">2/2</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">2/2</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/2</td>
 </tr>
 <tr class="subtest" data-parent="Promise.any" id="test-Promise.any_fulfillment"><td><span><a class="anchor" href="#test-Promise.any_fulfillment">&#xA7;</a>fulfillment</span><script data-source="
 Promise.any([
@@ -26404,6 +26563,7 @@ Promise.any([
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Promise.any" id="test-Promise.any_AggregateError"><td><span><a class="anchor" href="#test-Promise.any_AggregateError">&#xA7;</a>AggregateError</span><script data-source="
 Promise.any([
@@ -26571,6 +26731,7 @@ Promise.any([
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-WeakReferences"><span><a class="anchor" href="#test-WeakReferences">&#xA7;</a><a href="https://github.com/tc39/proposal-weakrefs">WeakReferences</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakRef" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/2</td>
@@ -26729,6 +26890,7 @@ Promise.any([
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">2/2</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">2/2</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">2/2</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/2</td>
 </tr>
 <tr class="subtest" data-parent="WeakReferences" id="test-WeakReferences_a_href=_https://github.com/tc39/proposal-weakrefs#weak-references_WeakRef_minimal_support_/a"><td><span><a class="anchor" href="#test-WeakReferences_a_href=_https://github.com/tc39/proposal-weakrefs#weak-references_WeakRef_minimal_support_/a">&#xA7;</a><a href="https://github.com/tc39/proposal-weakrefs#weak-references">WeakRef minimal support</a></span><script data-source="
 var O = {};
@@ -26892,6 +27054,7 @@ return weakref.deref() === O;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="WeakReferences" id="test-WeakReferences_a_href=_https://github.com/tc39/proposal-weakrefs#finalizers_FinalizationRegistry_minimal_support_/a"><td><span><a class="anchor" href="#test-WeakReferences_a_href=_https://github.com/tc39/proposal-weakrefs#finalizers_FinalizationRegistry_minimal_support_/a">&#xA7;</a><a href="https://github.com/tc39/proposal-weakrefs#finalizers">FinalizationRegistry minimal support</a></span><script data-source="
 var fr = new FinalizationRegistry(function() {});
@@ -27054,6 +27217,7 @@ return Object.getPrototypeOf(fr) === FinalizationRegistry.prototype;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Logical_Assignment"><span><a class="anchor" href="#test-Logical_Assignment">&#xA7;</a><a href="https://github.com/tc39/proposal-logical-assignment/">Logical Assignment</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/9</td>
@@ -27212,6 +27376,7 @@ return Object.getPrototypeOf(fr) === FinalizationRegistry.prototype;
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">9/9</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">9/9</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">9/9</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="1">9/9</td>
 </tr>
 <tr class="subtest" data-parent="Logical_Assignment" id="test-Logical_Assignment_||=_basic_support_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR_assignment_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Logical_Assignment_||=_basic_support_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR_assignment_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>||= basic support <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR_assignment" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 let a;
@@ -27379,6 +27544,7 @@ return a === 2 &amp;&amp; b === 2 &amp;&amp; c === 1;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Logical_Assignment" id="test-Logical_Assignment_||=_short-circuiting_behaviour"><td><span><a class="anchor" href="#test-Logical_Assignment_||=_short-circuiting_behaviour">&#xA7;</a>||= short-circuiting behaviour</span><script data-source="
 let a = 1;
@@ -27543,6 +27709,7 @@ return a === 1 &amp;&amp; i === 1;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Logical_Assignment" id="test-Logical_Assignment_||=_setter_not_unecessarily_invoked"><td><span><a class="anchor" href="#test-Logical_Assignment_||=_setter_not_unecessarily_invoked">&#xA7;</a>||= setter not unecessarily invoked</span><script data-source="
 let i = 1;
@@ -27707,6 +27874,7 @@ return i === 1;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Logical_Assignment" id="test-Logical_Assignment_=_basic_support_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_AND_assignment_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Logical_Assignment_=_basic_support_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_AND_assignment_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>&amp;&amp;= basic support <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_AND_assignment" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 let a;
@@ -27874,6 +28042,7 @@ return typeof a === &apos;undefined&apos; &amp;&amp; b === 0 &amp;&amp; c === 2;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Logical_Assignment" id="test-Logical_Assignment_=_short-circuiting_behaviour"><td><span><a class="anchor" href="#test-Logical_Assignment_=_short-circuiting_behaviour">&#xA7;</a>&amp;&amp;= short-circuiting behaviour</span><script data-source="
 let a;
@@ -28038,6 +28207,7 @@ return typeof a === &apos;undefined&apos; &amp;&amp; i === 1;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Logical_Assignment" id="test-Logical_Assignment_=_setter_not_unecessarily_invoked"><td><span><a class="anchor" href="#test-Logical_Assignment_=_setter_not_unecessarily_invoked">&#xA7;</a>&amp;&amp;= setter not unecessarily invoked</span><script data-source="
 let i = 1;
@@ -28202,6 +28372,7 @@ return i === 1;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Logical_Assignment" id="test-Logical_Assignment_??=_basic_support_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_nullish_assignment_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Logical_Assignment_??=_basic_support_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_nullish_assignment_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>??= basic support <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_nullish_assignment" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 let a;
@@ -28369,6 +28540,7 @@ return a === 2 &amp;&amp; b === 0 &amp;&amp; c === 1;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Logical_Assignment" id="test-Logical_Assignment_??=_short-circuiting_behaviour"><td><span><a class="anchor" href="#test-Logical_Assignment_??=_short-circuiting_behaviour">&#xA7;</a>??= short-circuiting behaviour</span><script data-source="
 let a = 1;
@@ -28533,6 +28705,7 @@ return a === 1 &amp;&amp; i === 1;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Logical_Assignment" id="test-Logical_Assignment_??=_setter_not_unecessarily_invoked"><td><span><a class="anchor" href="#test-Logical_Assignment_??=_setter_not_unecessarily_invoked">&#xA7;</a>??= setter not unecessarily invoked</span><script data-source="
 let i = 1;
@@ -28697,6 +28870,7 @@ return i === 1;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr significance="0.25"><td id="test-numeric_separators"><span><a class="anchor" href="#test-numeric_separators">&#xA7;</a><a href="https://github.com/tc39/proposal-numeric-separator">numeric separators</a></span><script data-source="
 return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
@@ -28859,8 +29033,9 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
-<tr class="category"><td colspan="159"><span>2022 features</span></td>
+<tr class="category"><td colspan="160"><span>2022 features</span></td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-instance_class_fields"><span><a class="anchor" href="#test-instance_class_fields">&#xA7;</a><a href="https://github.com/tc39/proposal-class-fields">instance class fields</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
@@ -29019,6 +29194,7 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">6/6</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">6/6</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">6/6</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="1">6/6</td>
 </tr>
 <tr class="subtest" data-parent="instance_class_fields" id="test-instance_class_fields_public_instance_class_fields_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Class_elements#Public_instance_fields_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-instance_class_fields_public_instance_class_fields_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Class_elements#Public_instance_fields_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>public instance class fields <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Class_elements#Public_instance_fields" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 class C {
@@ -29183,6 +29359,7 @@ return new C().x === &apos;x&apos;;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="instance_class_fields" id="test-instance_class_fields_private_instance_class_fields_basic_support_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Class_elements#Private_instance_fields_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-instance_class_fields_private_instance_class_fields_basic_support_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Class_elements#Private_instance_fields_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>private instance class fields basic support <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Class_elements#Private_instance_fields" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 class C {
@@ -29353,6 +29530,7 @@ return new C(42).x() === 42;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="instance_class_fields" id="test-instance_class_fields_private_instance_class_fields_initializers"><td><span><a class="anchor" href="#test-instance_class_fields_private_instance_class_fields_initializers">&#xA7;</a>private instance class fields initializers</span><script data-source="
 class C {
@@ -29520,6 +29698,7 @@ return new C().x() === 42;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="instance_class_fields" id="test-instance_class_fields_optional_private_instance_class_fields_access"><td><span><a class="anchor" href="#test-instance_class_fields_optional_private_instance_class_fields_access">&#xA7;</a>optional private instance class fields access</span><script data-source="
 class C {
@@ -29687,6 +29866,7 @@ return new C().x() === 42 &amp;&amp; new C().x(null) === void 0;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="instance_class_fields" id="test-instance_class_fields_optional_deep_private_instance_class_fields_access"><td><span><a class="anchor" href="#test-instance_class_fields_optional_deep_private_instance_class_fields_access">&#xA7;</a>optional deep private instance class fields access</span><script data-source="
 class C {
@@ -29854,6 +30034,7 @@ return new C().x() === 42 &amp;&amp; new C().x(null) === void 0;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="instance_class_fields" id="test-instance_class_fields_computed_instance_class_fields"><td><span><a class="anchor" href="#test-instance_class_fields_computed_instance_class_fields">&#xA7;</a>computed instance class fields</span><script data-source="
 class C {
@@ -30018,6 +30199,7 @@ return new C().x === 42;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-static_class_fields"><span><a class="anchor" href="#test-static_class_fields">&#xA7;</a><a href="https://github.com/tc39/proposal-static-class-features/">static class fields</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
@@ -30176,6 +30358,7 @@ return new C().x === 42;
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">4/4</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">4/4</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">4/4</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="1">4/4</td>
 </tr>
 <tr class="subtest" data-parent="static_class_fields" id="test-static_class_fields_public_static_class_fields_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Class_elements#Public_static_fields_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-static_class_fields_public_static_class_fields_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Class_elements#Public_static_fields_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>public static class fields <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Class_elements#Public_static_fields" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 class C {
@@ -30340,6 +30523,7 @@ return C.x === &apos;x&apos;;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="static_class_fields" id="test-static_class_fields_static_class_fields_use_[[Define]]"><td><span><a class="anchor" href="#test-static_class_fields_static_class_fields_use_[[Define]]">&#xA7;</a>static class fields use [[Define]]</span><script data-source="
 return (class X { static name = &quot;name&quot;; }).name === &apos;name&apos;;
@@ -30501,6 +30685,7 @@ return (class X { static name = &quot;name&quot;; }).name === &apos;name&apos;;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="static_class_fields" id="test-static_class_fields_private_static_class_fields_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Class_elements#Private_static_fields_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-static_class_fields_private_static_class_fields_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Class_elements#Private_static_fields_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>private static class fields <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Class_elements#Private_static_fields" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 class C {
@@ -30668,6 +30853,7 @@ return new C().x() === 42;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="static_class_fields" id="test-static_class_fields_computed_static_class_fields"><td><span><a class="anchor" href="#test-static_class_fields_computed_static_class_fields">&#xA7;</a>computed static class fields</span><script data-source="
 class C {
@@ -30832,6 +31018,7 @@ return C.x === 42;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-private_class_methods"><span><a class="anchor" href="#test-private_class_methods">&#xA7;</a><a href="https://github.com/tc39/proposal-private-methods">private class methods</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/4</td>
@@ -30990,6 +31177,7 @@ return C.x === 42;
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">4/4</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">4/4</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">4/4</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/4</td>
 </tr>
 <tr class="subtest" data-parent="private_class_methods" id="test-private_class_methods_private_instance_methods"><td><span><a class="anchor" href="#test-private_class_methods_private_instance_methods">&#xA7;</a>private instance methods</span><script data-source="
 class C {
@@ -31157,6 +31345,7 @@ return new C().x() === 42;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="private_class_methods" id="test-private_class_methods_private_static_methods"><td><span><a class="anchor" href="#test-private_class_methods_private_static_methods">&#xA7;</a>private static methods</span><script data-source="
 class C {
@@ -31324,6 +31513,7 @@ return new C().x() === 42;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="private_class_methods" id="test-private_class_methods_private_accessor_properties"><td><span><a class="anchor" href="#test-private_class_methods_private_accessor_properties">&#xA7;</a>private accessor properties</span><script data-source="
 var y = false;
@@ -31494,6 +31684,7 @@ return new C().x() === 42 &amp;&amp; y;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="private_class_methods" id="test-private_class_methods_private_static_accessor_properties"><td><span><a class="anchor" href="#test-private_class_methods_private_static_accessor_properties">&#xA7;</a>private static accessor properties</span><script data-source="
 var y = false;
@@ -31664,6 +31855,7 @@ return new C().x() === 42 &amp;&amp; y;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr significance="0.25"><td id="test-Ergonomic_brand_checks_for_private_fields"><span><a class="anchor" href="#test-Ergonomic_brand_checks_for_private_fields">&#xA7;</a><a href="https://github.com/tc39/proposal-private-fields-in-in">Ergonomic brand checks for private fields</a></span><script data-source="
 class A {
@@ -31831,6 +32023,7 @@ return A.check(new A) &amp;&amp; !A.check({});
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="supertest" significance="0.125"><td id="test-.at()_method_on_the_built-in_indexables"><span><a class="anchor" href="#test-.at()_method_on_the_built-in_indexables">&#xA7;</a><a href="https://github.com/tc39/proposal-relative-indexing-method/">.at() method on the built-in indexables</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/3</td>
@@ -31989,6 +32182,7 @@ return A.check(new A) &amp;&amp; !A.check({});
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">3/3</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">3/3</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">3/3</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/3</td>
 </tr>
 <tr class="subtest" data-parent=".at()_method_on_the_built-in_indexables" id="test-.at()_method_on_the_built-in_indexables_Array.prototype.at()"><td><span><a class="anchor" href="#test-.at()_method_on_the_built-in_indexables_Array.prototype.at()">&#xA7;</a>Array.prototype.at()</span><script data-source="
 var arr = [1, 2, 3];
@@ -32158,6 +32352,7 @@ return arr.at(0) === 1
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent=".at()_method_on_the_built-in_indexables" id="test-.at()_method_on_the_built-in_indexables_String.prototype.at()"><td><span><a class="anchor" href="#test-.at()_method_on_the_built-in_indexables_String.prototype.at()">&#xA7;</a>String.prototype.at()</span><script data-source="
 var str = &apos;abc&apos;;
@@ -32327,6 +32522,7 @@ return str.at(0) === &apos;a&apos;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent=".at()_method_on_the_built-in_indexables" id="test-.at()_method_on_the_built-in_indexables_%TypedArray%.prototype.at()"><td><span><a class="anchor" href="#test-.at()_method_on_the_built-in_indexables_%TypedArray%.prototype.at()">&#xA7;</a>%TypedArray%.prototype.at()</span><script data-source="
 return [
@@ -32512,6 +32708,7 @@ return [
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Object.hasOwn"><span><a class="anchor" href="#test-Object.hasOwn">&#xA7;</a><a href="https://github.com/tc39/proposal-accessible-object-hasownproperty">Object.hasOwn</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/2</td>
@@ -32670,6 +32867,7 @@ return [
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">2/2</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">2/2</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">2/2</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="1">2/2</td>
 </tr>
 <tr class="subtest" data-parent="Object.hasOwn" id="test-Object.hasOwn_Basic_functionality"><td><span><a class="anchor" href="#test-Object.hasOwn_Basic_functionality">&#xA7;</a>Basic functionality</span><script data-source="
 return Object.hasOwn({ x: 2 }, &quot;x&quot;) === true;
@@ -32831,6 +33029,7 @@ return Object.hasOwn({ x: 2 }, &quot;x&quot;) === true;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Object.hasOwn" id="test-Object.hasOwn_ToObject_called_before_ToPropertyKey"><td><span><a class="anchor" href="#test-Object.hasOwn_ToObject_called_before_ToPropertyKey">&#xA7;</a>ToObject called before ToPropertyKey</span><script data-source="
 var ok = !!Object.hasOwn;
@@ -32998,6 +33197,7 @@ try {
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr significance="0.25"><td id="test-Class_static_initialization_blocks"><span><a class="anchor" href="#test-Class_static_initialization_blocks">&#xA7;</a><a href="https://github.com/tc39/proposal-class-static-block">Class static initialization blocks</a></span><script data-source="
 let ok = false;
@@ -33163,6 +33363,7 @@ return ok;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Error.cause_property"><span><a class="anchor" href="#test-Error.cause_property">&#xA7;</a><a href="https://github.com/tc39/proposal-error-cause">Error.cause property</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/16</td>
@@ -33321,6 +33522,7 @@ return ok;
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">16/16</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">16/16</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">16/16</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0.875" style="background-color:hsl(105,47%,50%)">14/16</td>
 </tr>
 <tr class="subtest" data-parent="Error.cause_property" id="test-Error.cause_property_Error_has_cause"><td><span><a class="anchor" href="#test-Error.cause_property_Error_has_cause">&#xA7;</a>Error has cause</span><script data-source="
 var error = new Error(&apos;error&apos;, { cause: &apos;cause&apos; })
@@ -33483,6 +33685,7 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Error.cause_property" id="test-Error.cause_property_Error.prototype_lacks_cause"><td><span><a class="anchor" href="#test-Error.cause_property_Error.prototype_lacks_cause">&#xA7;</a>Error.prototype lacks cause</span><script data-source="
 return !(&apos;cause&apos; in Error.prototype);
@@ -33644,6 +33847,7 @@ return !(&apos;cause&apos; in Error.prototype);
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Error.cause_property" id="test-Error.cause_property_EvalError_has_cause"><td><span><a class="anchor" href="#test-Error.cause_property_EvalError_has_cause">&#xA7;</a>EvalError has cause</span><script data-source="
 var error = new EvalError(&apos;error&apos;, { cause: &apos;cause&apos; })
@@ -33806,6 +34010,7 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Error.cause_property" id="test-Error.cause_property_EvalError.prototype_lacks_cause"><td><span><a class="anchor" href="#test-Error.cause_property_EvalError.prototype_lacks_cause">&#xA7;</a>EvalError.prototype lacks cause</span><script data-source="
 return !(&apos;cause&apos; in EvalError.prototype);
@@ -33967,6 +34172,7 @@ return !(&apos;cause&apos; in EvalError.prototype);
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Error.cause_property" id="test-Error.cause_property_RangeError_has_cause"><td><span><a class="anchor" href="#test-Error.cause_property_RangeError_has_cause">&#xA7;</a>RangeError has cause</span><script data-source="
 var error = new RangeError(&apos;error&apos;, { cause: &apos;cause&apos; })
@@ -34129,6 +34335,7 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Error.cause_property" id="test-Error.cause_property_RangeError.prototype_lacks_cause"><td><span><a class="anchor" href="#test-Error.cause_property_RangeError.prototype_lacks_cause">&#xA7;</a>RangeError.prototype lacks cause</span><script data-source="
 return !(&apos;cause&apos; in RangeError.prototype);
@@ -34290,6 +34497,7 @@ return !(&apos;cause&apos; in RangeError.prototype);
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Error.cause_property" id="test-Error.cause_property_ReferenceError_has_cause"><td><span><a class="anchor" href="#test-Error.cause_property_ReferenceError_has_cause">&#xA7;</a>ReferenceError has cause</span><script data-source="
 var error = new ReferenceError(&apos;error&apos;, { cause: &apos;cause&apos; })
@@ -34452,6 +34660,7 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Error.cause_property" id="test-Error.cause_property_ReferenceError.prototype_lacks_cause"><td><span><a class="anchor" href="#test-Error.cause_property_ReferenceError.prototype_lacks_cause">&#xA7;</a>ReferenceError.prototype lacks cause</span><script data-source="
 return !(&apos;cause&apos; in ReferenceError.prototype);
@@ -34613,6 +34822,7 @@ return !(&apos;cause&apos; in ReferenceError.prototype);
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Error.cause_property" id="test-Error.cause_property_SyntaxError_has_cause"><td><span><a class="anchor" href="#test-Error.cause_property_SyntaxError_has_cause">&#xA7;</a>SyntaxError has cause</span><script data-source="
 var error = new SyntaxError(&apos;error&apos;, { cause: &apos;cause&apos; })
@@ -34775,6 +34985,7 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Error.cause_property" id="test-Error.cause_property_SyntaxError.prototype_lacks_cause"><td><span><a class="anchor" href="#test-Error.cause_property_SyntaxError.prototype_lacks_cause">&#xA7;</a>SyntaxError.prototype lacks cause</span><script data-source="
 return !(&apos;cause&apos; in SyntaxError.prototype);
@@ -34936,6 +35147,7 @@ return !(&apos;cause&apos; in SyntaxError.prototype);
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Error.cause_property" id="test-Error.cause_property_TypeError_has_cause"><td><span><a class="anchor" href="#test-Error.cause_property_TypeError_has_cause">&#xA7;</a>TypeError has cause</span><script data-source="
 var error = new TypeError(&apos;error&apos;, { cause: &apos;cause&apos; })
@@ -35098,6 +35310,7 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Error.cause_property" id="test-Error.cause_property_TypeError.prototype_lacks_cause"><td><span><a class="anchor" href="#test-Error.cause_property_TypeError.prototype_lacks_cause">&#xA7;</a>TypeError.prototype lacks cause</span><script data-source="
 return !(&apos;cause&apos; in TypeError.prototype);
@@ -35259,6 +35472,7 @@ return !(&apos;cause&apos; in TypeError.prototype);
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Error.cause_property" id="test-Error.cause_property_URIError_has_cause"><td><span><a class="anchor" href="#test-Error.cause_property_URIError_has_cause">&#xA7;</a>URIError has cause</span><script data-source="
 var error = new URIError(&apos;error&apos;, { cause: &apos;cause&apos; })
@@ -35421,6 +35635,7 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Error.cause_property" id="test-Error.cause_property_URIError.prototype_lacks_cause"><td><span><a class="anchor" href="#test-Error.cause_property_URIError.prototype_lacks_cause">&#xA7;</a>URIError.prototype lacks cause</span><script data-source="
 return !(&apos;cause&apos; in URIError.prototype);
@@ -35582,6 +35797,7 @@ return !(&apos;cause&apos; in URIError.prototype);
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Error.cause_property" id="test-Error.cause_property_AggregateError_has_cause"><td><span><a class="anchor" href="#test-Error.cause_property_AggregateError_has_cause">&#xA7;</a>AggregateError has cause</span><script data-source="
 var error = new AggregateError([], &apos;error&apos;, { cause: &apos;cause&apos; })
@@ -35744,6 +35960,7 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Error.cause_property" id="test-Error.cause_property_AggregateError.prototype_lacks_cause"><td><span><a class="anchor" href="#test-Error.cause_property_AggregateError.prototype_lacks_cause">&#xA7;</a>AggregateError.prototype lacks cause</span><script data-source="
 return !(&apos;cause&apos; in AggregateError.prototype);
@@ -35905,6 +36122,7 @@ return !(&apos;cause&apos; in AggregateError.prototype);
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-RegExp_Match_Indices_(`hasIndices`_/_`d`_flag)"><span><a class="anchor" href="#test-RegExp_Match_Indices_(`hasIndices`_/_`d`_flag)">&#xA7;</a><a href="https://github.com/tc39/proposal-regexp-match-indices">RegExp Match Indices (`hasIndices` / `d` flag)</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/2</td>
@@ -36063,6 +36281,7 @@ return !(&apos;cause&apos; in AggregateError.prototype);
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/2</td>
 </tr>
 <tr class="subtest" data-parent="RegExp_Match_Indices_(`hasIndices`_/_`d`_flag)" id="test-RegExp_Match_Indices_(`hasIndices`_/_`d`_flag)_constructor_supports_it"><td><span><a class="anchor" href="#test-RegExp_Match_Indices_(`hasIndices`_/_`d`_flag)_constructor_supports_it">&#xA7;</a>constructor supports it</span><script data-source="
 return new RegExp(&apos;a&apos;, &apos;d&apos;) instanceof RegExp;
@@ -36224,6 +36443,7 @@ return new RegExp(&apos;a&apos;, &apos;d&apos;) instanceof RegExp;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="RegExp_Match_Indices_(`hasIndices`_/_`d`_flag)" id="test-RegExp_Match_Indices_(`hasIndices`_/_`d`_flag)_shows_up_in_flags"><td><span><a class="anchor" href="#test-RegExp_Match_Indices_(`hasIndices`_/_`d`_flag)_shows_up_in_flags">&#xA7;</a>shows up in flags</span><script data-source="
 var expected = [&apos;hasIndices&apos;];
@@ -36400,8 +36620,9 @@ return true;
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
-<tr class="category"><td colspan="159"><span>2023 features</span></td>
+<tr class="category"><td colspan="160"><span>2023 features</span></td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Array_find_from_last"><span><a class="anchor" href="#test-Array_find_from_last">&#xA7;</a><a href="https://github.com/tc39/proposal-array-find-from-last">Array find from last</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/2</td>
@@ -36560,6 +36781,7 @@ return true;
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">2/2</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">2/2</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">2/2</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="1">2/2</td>
 </tr>
 <tr class="subtest" data-parent="Array_find_from_last" id="test-Array_find_from_last_Array.prototype.findLast"><td><span><a class="anchor" href="#test-Array_find_from_last_Array.prototype.findLast">&#xA7;</a>Array.prototype.findLast</span><script data-source="
 var arr = [{ x: 1 }, { x: 2 }, { x: 1 }, { x: 2 }];
@@ -36722,6 +36944,7 @@ return arr.findLast(function (o) { return o.x === 1; }) === arr[2];
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Array_find_from_last" id="test-Array_find_from_last_Array.prototype.findLastIndex"><td><span><a class="anchor" href="#test-Array_find_from_last_Array.prototype.findLastIndex">&#xA7;</a>Array.prototype.findLastIndex</span><script data-source="
 var arr = [{ x: 1 }, { x: 2 }, { x: 1 }, { x: 2 }];
@@ -36884,6 +37107,7 @@ return arr.findLastIndex(function (o) { return o.x === 1; }) === 2;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr significance="0.125"><td id="test-Hashbang_Grammar"><span><a class="anchor" href="#test-Hashbang_Grammar">&#xA7;</a><a href="https://github.com/tc39/proposal-hashbang/">Hashbang Grammar</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#Hashbang_comments" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 try {
@@ -37049,6 +37273,7 @@ try {
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 </tbody>
     </table>

--- a/es5/index.html
+++ b/es5/index.html
@@ -276,6 +276,7 @@
 <th class="platform opera_mobile69 mobile obsolete" data-browser="opera_mobile69"><a href="#opera_mobile69" class="browser-name"><abbr title="Opera Mobile for Android 69">Opera Mobile 69</abbr></a></th>
 <th class="platform opera_mobile70 mobile" data-browser="opera_mobile70"><a href="#opera_mobile70" class="browser-name"><abbr title="Opera Mobile for Android 70">Opera Mobile 70</abbr></a></th>
 <th class="platform opera_mobile71 mobile" data-browser="opera_mobile71"><a href="#opera_mobile71" class="browser-name"><abbr title="Opera Mobile for Android 71">Opera Mobile 71</abbr></a></th>
+<th class="platform reactnative0_70_3 mobile" data-browser="reactnative0_70_3"><a href="#reactnative0_70_3" class="browser-name"><abbr title="React Native 0.70.3 (Using bundled Hermes and metro-react-native babel preset)">React Native 0.70.3 (Hermes + Babel)</abbr></a></th>
 </tr>
 
       </thead>
@@ -432,6 +433,7 @@
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">5/5</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">5/5</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">5/5</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="1">5/5</td>
 </tr>
 <tr class="subtest" data-parent="Object/array_literal_extensions" id="test-Object/array_literal_extensions_Getter_accessors"><td><span><a class="anchor" href="#test-Object/array_literal_extensions_Getter_accessors">&#xA7;</a>Getter accessors</span><script data-source="
 return ({ get x(){ return 1 } }).x === 1;
@@ -587,6 +589,7 @@ return ({ get x(){ return 1 } }).x === 1;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Object/array_literal_extensions" id="test-Object/array_literal_extensions_Setter_accessors"><td><span><a class="anchor" href="#test-Object/array_literal_extensions_Setter_accessors">&#xA7;</a>Setter accessors</span><script data-source="
 var value = 0;
@@ -744,6 +747,7 @@ return value === 1;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Object/array_literal_extensions" id="test-Object/array_literal_extensions_Trailing_commas_in_object_literals"><td><span><a class="anchor" href="#test-Object/array_literal_extensions_Trailing_commas_in_object_literals">&#xA7;</a>Trailing commas in object literals</span><script data-source="
 return { a: true, }.a === true;
@@ -899,6 +903,7 @@ return { a: true, }.a === true;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Object/array_literal_extensions" id="test-Object/array_literal_extensions_Trailing_commas_in_array_literals"><td><span><a class="anchor" href="#test-Object/array_literal_extensions_Trailing_commas_in_array_literals">&#xA7;</a>Trailing commas in array literals</span><script data-source="
 return [1,].length === 1;
@@ -1054,6 +1059,7 @@ return [1,].length === 1;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Object/array_literal_extensions" id="test-Object/array_literal_extensions_Reserved_words_as_property_names"><td><span><a class="anchor" href="#test-Object/array_literal_extensions_Reserved_words_as_property_names">&#xA7;</a>Reserved words as property names</span><script data-source="
 return ({ if: 1 }).if === 1;
@@ -1209,8 +1215,9 @@ return ({ if: 1 }).if === 1;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
-<tr><th colspan="153" class="separator"></th>
+<tr><th colspan="154" class="separator"></th>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Object_static_methods"><span><a class="anchor" href="#test-Object_static_methods">&#xA7;</a>Object static methods</span></td>
 <td class="tally" data-browser="es5shim" data-tally="0.07692307692307693" style="background-color:hsl(9,82%,50%)">1/13</td>
@@ -1363,6 +1370,7 @@ return ({ if: 1 }).if === 1;
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">13/13</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">13/13</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">13/13</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="1">13/13</td>
 </tr>
 <tr class="subtest" data-parent="Object_static_methods" id="test-Object_static_methods_Object.create_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Object_static_methods_Object.create_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Object.create <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Object.create === &apos;function&apos;;
@@ -1520,6 +1528,7 @@ return typeof Object.create === 'function';
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Object_static_methods" id="test-Object_static_methods_Object.defineProperty_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Object_static_methods_Object.defineProperty_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Object.defineProperty <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Object.defineProperty === &apos;function&apos;;
@@ -1677,6 +1686,7 @@ return typeof Object.defineProperty === 'function';
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Object_static_methods" id="test-Object_static_methods_Object.defineProperties_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperties_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Object_static_methods_Object.defineProperties_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperties_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Object.defineProperties <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperties" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Object.defineProperties === &apos;function&apos;;
@@ -1834,6 +1844,7 @@ return typeof Object.defineProperties === 'function';
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Object_static_methods" id="test-Object_static_methods_Object.getPrototypeOf_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getPrototypeOf_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Object_static_methods_Object.getPrototypeOf_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getPrototypeOf_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Object.getPrototypeOf <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getPrototypeOf" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Object.getPrototypeOf === &apos;function&apos;;
@@ -1991,6 +2002,7 @@ return typeof Object.getPrototypeOf === 'function';
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Object_static_methods" id="test-Object_static_methods_Object.keys_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Object_static_methods_Object.keys_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Object.keys <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Object.keys === &apos;function&apos;;
@@ -2148,6 +2160,7 @@ return typeof Object.keys === 'function';
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Object_static_methods" id="test-Object_static_methods_Object.seal_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/seal_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Object_static_methods_Object.seal_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/seal_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Object.seal <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/seal" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Object.seal === &apos;function&apos;;
@@ -2305,6 +2318,7 @@ return typeof Object.seal === 'function';
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Object_static_methods" id="test-Object_static_methods_Object.freeze_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Object_static_methods_Object.freeze_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Object.freeze <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Object.freeze === &apos;function&apos;;
@@ -2462,6 +2476,7 @@ return typeof Object.freeze === 'function';
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Object_static_methods" id="test-Object_static_methods_Object.preventExtensions_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/preventExtensions_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Object_static_methods_Object.preventExtensions_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/preventExtensions_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Object.preventExtensions <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/preventExtensions" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Object.preventExtensions === &apos;function&apos;;
@@ -2619,6 +2634,7 @@ return typeof Object.preventExtensions === 'function';
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Object_static_methods" id="test-Object_static_methods_Object.isSealed_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/isSealed_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Object_static_methods_Object.isSealed_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/isSealed_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Object.isSealed <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/isSealed" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Object.isSealed === &apos;function&apos;;
@@ -2776,6 +2792,7 @@ return typeof Object.isSealed === 'function';
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Object_static_methods" id="test-Object_static_methods_Object.isFrozen_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/isFrozen_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Object_static_methods_Object.isFrozen_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/isFrozen_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Object.isFrozen <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/isFrozen" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Object.isFrozen === &apos;function&apos;;
@@ -2933,6 +2950,7 @@ return typeof Object.isFrozen === 'function';
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Object_static_methods" id="test-Object_static_methods_Object.isExtensible_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/isExtensible_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Object_static_methods_Object.isExtensible_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/isExtensible_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Object.isExtensible <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/isExtensible" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Object.isExtensible === &apos;function&apos;;
@@ -3090,6 +3108,7 @@ return typeof Object.isExtensible === 'function';
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Object_static_methods" id="test-Object_static_methods_Object.getOwnPropertyDescriptor_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptor_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Object_static_methods_Object.getOwnPropertyDescriptor_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptor_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Object.getOwnPropertyDescriptor <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptor" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Object.getOwnPropertyDescriptor === &apos;function&apos;;
@@ -3247,6 +3266,7 @@ return typeof Object.getOwnPropertyDescriptor === 'function';
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Object_static_methods" id="test-Object_static_methods_Object.getOwnPropertyNames_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyNames_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Object_static_methods_Object.getOwnPropertyNames_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyNames_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Object.getOwnPropertyNames <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyNames" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Object.getOwnPropertyNames === &apos;function&apos;;
@@ -3404,6 +3424,7 @@ return typeof Object.getOwnPropertyNames === 'function';
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Array_methods"><span><a class="anchor" href="#test-Array_methods">&#xA7;</a>Array methods</span></td>
 <td class="tally" data-browser="es5shim" data-tally="1">13/13</td>
@@ -3556,6 +3577,7 @@ return typeof Object.getOwnPropertyNames === 'function';
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">13/13</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">13/13</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">13/13</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="1">13/13</td>
 </tr>
 <tr class="subtest" data-parent="Array_methods" id="test-Array_methods_Array.isArray_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Array_methods_Array.isArray_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Array.isArray <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Array.isArray === &apos;function&apos;;
@@ -3713,6 +3735,7 @@ return typeof Array.isArray === 'function';
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Array_methods" id="test-Array_methods_Array.prototype.indexOf_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Array_methods_Array.prototype.indexOf_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Array.prototype.indexOf <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Array.prototype.indexOf === &apos;function&apos;;
@@ -3870,6 +3893,7 @@ return typeof Array.prototype.indexOf === 'function';
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Array_methods" id="test-Array_methods_Array.prototype.lastIndexOf_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/lastIndexOf_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Array_methods_Array.prototype.lastIndexOf_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/lastIndexOf_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Array.prototype.lastIndexOf <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/lastIndexOf" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Array.prototype.lastIndexOf === &apos;function&apos;;
@@ -4027,6 +4051,7 @@ return typeof Array.prototype.lastIndexOf === 'function';
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Array_methods" id="test-Array_methods_Array.prototype.every_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/every_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Array_methods_Array.prototype.every_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/every_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Array.prototype.every <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/every" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Array.prototype.every === &apos;function&apos;;
@@ -4184,6 +4209,7 @@ return typeof Array.prototype.every === 'function';
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Array_methods" id="test-Array_methods_Array.prototype.some_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Array_methods_Array.prototype.some_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Array.prototype.some <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Array.prototype.some === &apos;function&apos;;
@@ -4341,6 +4367,7 @@ return typeof Array.prototype.some === 'function';
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Array_methods" id="test-Array_methods_Array.prototype.forEach_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Array_methods_Array.prototype.forEach_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Array.prototype.forEach <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Array.prototype.forEach === &apos;function&apos;;
@@ -4498,6 +4525,7 @@ return typeof Array.prototype.forEach === 'function';
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Array_methods" id="test-Array_methods_Array.prototype.map_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Array_methods_Array.prototype.map_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Array.prototype.map <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Array.prototype.map === &apos;function&apos;;
@@ -4655,6 +4683,7 @@ return typeof Array.prototype.map === 'function';
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Array_methods" id="test-Array_methods_Array.prototype.filter_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Array_methods_Array.prototype.filter_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Array.prototype.filter <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Array.prototype.filter === &apos;function&apos;;
@@ -4812,6 +4841,7 @@ return typeof Array.prototype.filter === 'function';
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Array_methods" id="test-Array_methods_Array.prototype.reduce_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Array_methods_Array.prototype.reduce_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Array.prototype.reduce <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Array.prototype.reduce === &apos;function&apos;;
@@ -4969,6 +4999,7 @@ return typeof Array.prototype.reduce === 'function';
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Array_methods" id="test-Array_methods_Array.prototype.reduceRight_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduceRight_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Array_methods_Array.prototype.reduceRight_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduceRight_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Array.prototype.reduceRight <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduceRight" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Array.prototype.reduceRight === &apos;function&apos;;
@@ -5126,6 +5157,7 @@ return typeof Array.prototype.reduceRight === 'function';
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Array_methods" id="test-Array_methods_Array.prototype.sort:_compareFn_must_be_function_or_undefined"><td><span><a class="anchor" href="#test-Array_methods_Array.prototype.sort:_compareFn_must_be_function_or_undefined">&#xA7;</a>Array.prototype.sort: compareFn must be function or undefined</span><script data-source="function () {
 try {
@@ -5323,6 +5355,7 @@ return true;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Array_methods" id="test-Array_methods_Array.prototype.sort:_compareFn_may_be_explicit_undefined"><td><span><a class="anchor" href="#test-Array_methods_Array.prototype.sort:_compareFn_may_be_explicit_undefined">&#xA7;</a>Array.prototype.sort: compareFn may be explicit undefined</span><script data-source="function () {
 try {
@@ -5490,6 +5523,7 @@ try {
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Array_methods" id="test-Array_methods_Array.prototype.unshift:_[].unshift(0)_returns_the_unshifted_count"><td><span><a class="anchor" href="#test-Array_methods_Array.prototype.unshift:_[].unshift(0)_returns_the_unshifted_count">&#xA7;</a>Array.prototype.unshift: [].unshift(0) returns the unshifted count</span><script data-source="function () {
 return [].unshift(0) === 1;
@@ -5647,6 +5681,7 @@ return [].unshift(0) === 1;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-String_properties_and_methods"><span><a class="anchor" href="#test-String_properties_and_methods">&#xA7;</a>String properties and methods</span></td>
 <td class="tally" data-browser="es5shim" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
@@ -5799,6 +5834,7 @@ return [].unshift(0) === 1;
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">4/4</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">4/4</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">4/4</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="1">4/4</td>
 </tr>
 <tr class="subtest" data-parent="String_properties_and_methods" id="test-String_properties_and_methods_Property_access_on_strings_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#Character_access_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-String_properties_and_methods_Property_access_on_strings_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#Character_access_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Property access on strings <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#Character_access" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return &quot;foobar&quot;[3] === &quot;b&quot;;
@@ -5956,6 +5992,7 @@ return "foobar"[3] === "b";
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="String_properties_and_methods" id="test-String_properties_and_methods_String.prototype.split_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-String_properties_and_methods_String.prototype.split_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>String.prototype.split <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 // all of these tests reflect bugs that es5-shim patches
@@ -6137,6 +6174,7 @@ return typeof String.prototype.split === 'function'
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="String_properties_and_methods" id="test-String_properties_and_methods_String.prototype.substr_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-String_properties_and_methods_String.prototype.substr_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>String.prototype.substr <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return &apos;0b&apos;.substr(-1) === &apos;b&apos;;
@@ -6294,6 +6332,7 @@ return '0b'.substr(-1) === 'b';
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="String_properties_and_methods" id="test-String_properties_and_methods_String.prototype.trim_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/Trim_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-String_properties_and_methods_String.prototype.trim_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/Trim_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>String.prototype.trim <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/Trim" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof String.prototype.trim === &apos;function&apos;;
@@ -6451,6 +6490,7 @@ return typeof String.prototype.trim === 'function';
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Date_methods"><span><a class="anchor" href="#test-Date_methods">&#xA7;</a>Date methods</span></td>
 <td class="tally" data-browser="es5shim" data-tally="1">3/3</td>
@@ -6603,6 +6643,7 @@ return typeof String.prototype.trim === 'function';
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">3/3</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">3/3</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">3/3</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="1">3/3</td>
 </tr>
 <tr class="subtest" data-parent="Date_methods" id="test-Date_methods_Date.prototype.toISOString_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Date_methods_Date.prototype.toISOString_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Date.prototype.toISOString <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Date.prototype.toISOString === &apos;function&apos;;
@@ -6760,6 +6801,7 @@ return typeof Date.prototype.toISOString === 'function';
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Date_methods" id="test-Date_methods_Date.now_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/now_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Date_methods_Date.now_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/now_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Date.now <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/now" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Date.now === &apos;function&apos;;
@@ -6917,6 +6959,7 @@ return typeof Date.now === 'function';
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Date_methods" id="test-Date_methods_Date.prototype.toJSON_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toJSON_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Date_methods_Date.prototype.toJSON_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toJSON_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Date.prototype.toJSON <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toJSON" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 try {
@@ -7082,6 +7125,7 @@ try {
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr significance="0.5"><td id="test-Function.prototype.bind"><span><a class="anchor" href="#test-Function.prototype.bind">&#xA7;</a>Function.prototype.bind <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Function.prototype.bind === &apos;function&apos;;
@@ -7239,6 +7283,7 @@ return typeof Function.prototype.bind === 'function';
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr significance="0.5"><td id="test-JSON"><span><a class="anchor" href="#test-JSON">&#xA7;</a>JSON <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof JSON === &apos;object&apos;;
@@ -7396,8 +7441,9 @@ return typeof JSON === 'object';
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
-<tr><th colspan="153" class="separator"></th>
+<tr><th colspan="154" class="separator"></th>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Immutable_globals"><span><a class="anchor" href="#test-Immutable_globals">&#xA7;</a>Immutable globals</span></td>
 <td class="tally" data-browser="es5shim" data-tally="0">0/3</td>
@@ -7550,6 +7596,7 @@ return typeof JSON === 'object';
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">3/3</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">3/3</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">3/3</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="1">3/3</td>
 </tr>
 <tr class="subtest" data-parent="Immutable_globals" id="test-Immutable_globals_undefined"><td><span><a class="anchor" href="#test-Immutable_globals_undefined">&#xA7;</a>undefined</span><script data-source="
 undefined = 12345;
@@ -7708,6 +7755,7 @@ return result;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Immutable_globals" id="test-Immutable_globals_NaN"><td><span><a class="anchor" href="#test-Immutable_globals_NaN">&#xA7;</a>NaN</span><script data-source="
 NaN = false;
@@ -7866,6 +7914,7 @@ return result;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Immutable_globals" id="test-Immutable_globals_Infinity"><td><span><a class="anchor" href="#test-Immutable_globals_Infinity">&#xA7;</a>Infinity</span><script data-source="
 Infinity = false;
@@ -8024,6 +8073,7 @@ return result;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Number_methods"><span><a class="anchor" href="#test-Number_methods">&#xA7;</a>Number methods</span></td>
 <td class="tally" data-browser="es5shim" data-tally="0">0/3</td>
@@ -8176,6 +8226,7 @@ return result;
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">3/3</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">3/3</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">3/3</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="1">3/3</td>
 </tr>
 <tr class="subtest" data-parent="Number_methods" id="test-Number_methods_Number.prototype.toExponential_rounds_properly"><td><span><a class="anchor" href="#test-Number_methods_Number.prototype.toExponential_rounds_properly">&#xA7;</a>Number.prototype.toExponential rounds properly</span><script data-source="function () {
 return (-6.9e-11).toExponential(4) === &apos;-6.9000e-11&apos; // Edge &lt;= 17
@@ -8337,6 +8388,7 @@ return (-6.9e-11).toExponential(4) === '-6.9000e-11' // Edge <= 17
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Number_methods" id="test-Number_methods_Number.prototype.toExponential_throws_on_&#xB1;Infinity_fractionDigits"><td><span><a class="anchor" href="#test-Number_methods_Number.prototype.toExponential_throws_on_&#xB1;Infinity_fractionDigits">&#xA7;</a>Number.prototype.toExponential throws on &#xB1;Infinity fractionDigits</span><script data-source="function () {
 try {
@@ -8506,6 +8558,7 @@ try {
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Number_methods" id="test-Number_methods_Number.prototype.toExponential_does_not_throw_on_edge_cases"><td><span><a class="anchor" href="#test-Number_methods_Number.prototype.toExponential_does_not_throw_on_edge_cases">&#xA7;</a>Number.prototype.toExponential does not throw on edge cases</span><script data-source="function () {
 try {
@@ -8675,6 +8728,7 @@ try {
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-Miscellaneous"><span><a class="anchor" href="#test-Miscellaneous">&#xA7;</a>Miscellaneous</span></td>
 <td class="tally" data-browser="es5shim" data-tally="0.125" style="background-color:hsl(15,80%,50%)">1/8</td>
@@ -8827,6 +8881,7 @@ try {
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">8/8</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">8/8</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">8/8</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 </tr>
 <tr class="subtest" data-parent="Miscellaneous" id="test-Miscellaneous_Function.prototype.apply_permits_array-likes"><td><span><a class="anchor" href="#test-Miscellaneous_Function.prototype.apply_permits_array-likes">&#xA7;</a>Function.prototype.apply permits array-likes</span><script data-source="function () {
 try {
@@ -8992,6 +9047,7 @@ try {
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Miscellaneous" id="test-Miscellaneous_parseInt_ignores_leading_zeros"><td><span><a class="anchor" href="#test-Miscellaneous_parseInt_ignores_leading_zeros">&#xA7;</a>parseInt ignores leading zeros</span><script data-source="function () {
 return parseInt(&apos;010&apos;) === 10;
@@ -9149,6 +9205,7 @@ return parseInt('010') === 10;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Miscellaneous" id="test-Miscellaneous_Function_prototype_property_is_non-enumerable"><td><span><a class="anchor" href="#test-Miscellaneous_Function_prototype_property_is_non-enumerable">&#xA7;</a>Function &quot;prototype&quot; property is non-enumerable</span><script data-source="
 return !Function().propertyIsEnumerable(&apos;prototype&apos;);
@@ -9304,6 +9361,7 @@ return !Function().propertyIsEnumerable(&apos;prototype&apos;);
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Miscellaneous" id="test-Miscellaneous_Arguments_toStringTag_is_Arguments"><td><span><a class="anchor" href="#test-Miscellaneous_Arguments_toStringTag_is_Arguments">&#xA7;</a>Arguments toStringTag is &quot;Arguments&quot;</span><script data-source="
 return (function(){ return Object.prototype.toString.call(arguments) === &apos;[object Arguments]&apos;; }());
@@ -9459,6 +9517,7 @@ return (function(){ return Object.prototype.toString.call(arguments) === &apos;[
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Miscellaneous" id="test-Miscellaneous_Zero-width_chars_in_identifiers"><td><span><a class="anchor" href="#test-Miscellaneous_Zero-width_chars_in_identifiers">&#xA7;</a>Zero-width chars in identifiers</span><script data-source="
 var _\u200c\u200d = true;
@@ -9615,6 +9674,7 @@ return _\u200c\u200d;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Miscellaneous" id="test-Miscellaneous_Unreserved_words"><td><span><a class="anchor" href="#test-Miscellaneous_Unreserved_words">&#xA7;</a>Unreserved words</span><script data-source="
 var abstract, boolean, byte, char, double, final, float, goto, int, long,
@@ -9772,6 +9832,7 @@ return true;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Miscellaneous" id="test-Miscellaneous_Enumerable_properties_can_be_shadowed_by_non-enumerables"><td><span><a class="anchor" href="#test-Miscellaneous_Enumerable_properties_can_be_shadowed_by_non-enumerables">&#xA7;</a>Enumerable properties can be shadowed by non-enumerables</span><script data-source="
 var result = true;
@@ -9935,6 +9996,7 @@ return result;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Miscellaneous" id="test-Miscellaneous_Thrown_functions_have_proper_this_values"><td><span><a class="anchor" href="#test-Miscellaneous_Thrown_functions_have_proper_this_values">&#xA7;</a>Thrown functions have proper &quot;this&quot; values</span><script data-source="
 try {
@@ -10096,6 +10158,7 @@ catch(e) {
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Strict_mode"><span><a class="anchor" href="#test-Strict_mode">&#xA7;</a>Strict mode <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally" data-browser="es5shim" data-tally="0">0/19</td>
@@ -10248,6 +10311,7 @@ catch(e) {
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">19/19</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">19/19</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">19/19</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0.5789473684210527" style="background-color:hsl(69,60%,50%)">11/19</td>
 </tr>
 <tr class="subtest" data-parent="Strict_mode" id="test-Strict_mode_reserved_words"><td><span><a class="anchor" href="#test-Strict_mode_reserved_words">&#xA7;</a>reserved words</span><script data-source="
 &apos;use strict&apos;;
@@ -10408,6 +10472,7 @@ return true;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Strict_mode" id="test-Strict_mode_this_is_undefined_in_functions"><td><span><a class="anchor" href="#test-Strict_mode_this_is_undefined_in_functions">&#xA7;</a>&quot;this&quot; is undefined in functions</span><script data-source="
 &apos;use strict&apos;;
@@ -10564,6 +10629,7 @@ return this === void undefined &amp;&amp; (function(){ return this === void unde
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Strict_mode" id="test-Strict_mode_this_is_not_coerced_to_object_in_primitive_methods"><td><span><a class="anchor" href="#test-Strict_mode_this_is_not_coerced_to_object_in_primitive_methods">&#xA7;</a>&quot;this&quot; is not coerced to object in primitive methods</span><script data-source="
 &apos;use strict&apos;;
@@ -10722,6 +10788,7 @@ return (function(){ return typeof this === &apos;string&apos; }).call(&apos;&apo
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Strict_mode" id="test-Strict_mode_this_is_not_coerced_to_object_in_primitive_accessors"><td><span><a class="anchor" href="#test-Strict_mode_this_is_not_coerced_to_object_in_primitive_accessors">&#xA7;</a>&quot;this&quot; is not coerced to object in primitive accessors</span><script data-source="
 &apos;use strict&apos;;
@@ -10894,6 +10961,7 @@ return test(String, &apos;&apos;)
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Strict_mode" id="test-Strict_mode_legacy_octal_is_a_SyntaxError"><td><span><a class="anchor" href="#test-Strict_mode_legacy_octal_is_a_SyntaxError">&#xA7;</a>legacy octal is a SyntaxError</span><script data-source="
 &apos;use strict&apos;;
@@ -11052,6 +11120,7 @@ return true;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Strict_mode" id="test-Strict_mode_assignment_to_unresolvable_identifiers_is_a_ReferenceError"><td><span><a class="anchor" href="#test-Strict_mode_assignment_to_unresolvable_identifiers_is_a_ReferenceError">&#xA7;</a>assignment to unresolvable identifiers is a ReferenceError</span><script data-source="
 &apos;use strict&apos;;
@@ -11208,6 +11277,7 @@ try { eval(&apos;__i_dont_exist = 1&apos;); } catch (err) { return err instanceo
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Strict_mode" id="test-Strict_mode_assignment_to_eval_or_arguments_is_a_SyntaxError"><td><span><a class="anchor" href="#test-Strict_mode_assignment_to_eval_or_arguments_is_a_SyntaxError">&#xA7;</a>assignment to eval or arguments is a SyntaxError</span><script data-source="
 &apos;use strict&apos;;
@@ -11368,6 +11438,7 @@ return true;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Strict_mode" id="test-Strict_mode_assignment_to_non-writable_properties_is_a_TypeError"><td><span><a class="anchor" href="#test-Strict_mode_assignment_to_non-writable_properties_is_a_TypeError">&#xA7;</a>assignment to non-writable properties is a TypeError</span><script data-source="
 &apos;use strict&apos;;
@@ -11528,6 +11599,7 @@ return true;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Strict_mode" id="test-Strict_mode_eval_or_arguments_bindings_is_a_SyntaxError"><td><span><a class="anchor" href="#test-Strict_mode_eval_or_arguments_bindings_is_a_SyntaxError">&#xA7;</a>eval or arguments bindings is a SyntaxError</span><script data-source="
 &apos;use strict&apos;;
@@ -11690,6 +11762,7 @@ return true;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Strict_mode" id="test-Strict_mode_arguments.caller_removed_or_is_a_TypeError"><td><span><a class="anchor" href="#test-Strict_mode_arguments.caller_removed_or_is_a_TypeError">&#xA7;</a>arguments.caller removed or is a TypeError</span><script data-source="
 &apos;use strict&apos;;
@@ -11849,6 +11922,7 @@ return true;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Strict_mode" id="test-Strict_mode_arguments.callee_is_a_TypeError"><td><span><a class="anchor" href="#test-Strict_mode_arguments.callee_is_a_TypeError">&#xA7;</a>arguments.callee is a TypeError</span><script data-source="
 &apos;use strict&apos;;
@@ -12006,6 +12080,7 @@ return true;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Strict_mode" id="test-Strict_mode_(function(){}).caller_and_(function(){}).arguments_is_a_TypeError"><td><span><a class="anchor" href="#test-Strict_mode_(function(){}).caller_and_(function(){}).arguments_is_a_TypeError">&#xA7;</a>(function(){}).caller and (function(){}).arguments is a TypeError</span><script data-source="
 &apos;use strict&apos;;
@@ -12164,6 +12239,7 @@ return true;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Strict_mode" id="test-Strict_mode_arguments_is_unmapped"><td><span><a class="anchor" href="#test-Strict_mode_arguments_is_unmapped">&#xA7;</a>arguments is unmapped</span><script data-source="
 &apos;use strict&apos;;
@@ -12326,6 +12402,7 @@ return (function(x){
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Strict_mode" id="test-Strict_mode_eval()_can&apos;t_create_bindings"><td><span><a class="anchor" href="#test-Strict_mode_eval()_can&apos;t_create_bindings">&#xA7;</a>eval() can&apos;t create bindings</span><script data-source="
 &apos;use strict&apos;;
@@ -12482,6 +12559,7 @@ try { eval(&apos;var __some_unique_variable;&apos;); __some_unique_variable; } c
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Strict_mode" id="test-Strict_mode_deleting_bindings_is_a_SyntaxError"><td><span><a class="anchor" href="#test-Strict_mode_deleting_bindings_is_a_SyntaxError">&#xA7;</a>deleting bindings is a SyntaxError</span><script data-source="
 &apos;use strict&apos;;
@@ -12638,6 +12716,7 @@ try { eval(&apos;var x; delete x;&apos;); } catch (err) { return err instanceof 
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Strict_mode" id="test-Strict_mode_deleting_non-configurable_properties_is_a_TypeError"><td><span><a class="anchor" href="#test-Strict_mode_deleting_non-configurable_properties_is_a_TypeError">&#xA7;</a>deleting non-configurable properties is a TypeError</span><script data-source="
 &apos;use strict&apos;;
@@ -12794,6 +12873,7 @@ try { delete Object.prototype; } catch (err) { return err instanceof TypeError; 
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Strict_mode" id="test-Strict_mode_with_is_a_SyntaxError"><td><span><a class="anchor" href="#test-Strict_mode_with_is_a_SyntaxError">&#xA7;</a>&quot;with&quot; is a SyntaxError</span><script data-source="
 &apos;use strict&apos;;
@@ -12950,6 +13030,7 @@ try { eval(&apos;with({}){}&apos;); } catch (err) { return err instanceof Syntax
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Strict_mode" id="test-Strict_mode_repeated_parameter_names_is_a_SyntaxError"><td><span><a class="anchor" href="#test-Strict_mode_repeated_parameter_names_is_a_SyntaxError">&#xA7;</a>repeated parameter names is a SyntaxError</span><script data-source="
 &apos;use strict&apos;;
@@ -13106,6 +13187,7 @@ try { eval(&apos;function f(x, x) { }&apos;); } catch (err) { return err instanc
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Strict_mode" id="test-Strict_mode_function_expressions_with_matching_name_and_argument_are_valid"><td><span><a class="anchor" href="#test-Strict_mode_function_expressions_with_matching_name_and_argument_are_valid">&#xA7;</a>function expressions with matching name and argument are valid</span><script data-source="
 var foo = function bar(bar) {&apos;use strict&apos;};
@@ -13262,6 +13344,7 @@ return typeof foo === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 </tbody>
     </table>

--- a/esintl/index.html
+++ b/esintl/index.html
@@ -268,6 +268,7 @@
 <th class="platform opera_mobile69 mobile obsolete" data-browser="opera_mobile69"><a href="#opera_mobile69" class="browser-name"><abbr title="Opera Mobile for Android 69">Opera Mobile 69</abbr></a></th>
 <th class="platform opera_mobile70 mobile" data-browser="opera_mobile70"><a href="#opera_mobile70" class="browser-name"><abbr title="Opera Mobile for Android 70">Opera Mobile 70</abbr></a></th>
 <th class="platform opera_mobile71 mobile" data-browser="opera_mobile71"><a href="#opera_mobile71" class="browser-name"><abbr title="Opera Mobile for Android 71">Opera Mobile 71</abbr></a></th>
+<th class="platform reactnative0_70_3 mobile" data-browser="reactnative0_70_3"><a href="#reactnative0_70_3" class="browser-name"><abbr title="React Native 0.70.3 (Using bundled Hermes and metro-react-native babel preset)">React Native 0.70.3 (Hermes + Babel)</abbr></a></th>
 </tr>
 
       </thead>
@@ -409,6 +410,7 @@
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">2/2</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">2/2</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">2/2</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="1">2/2</td>
 </tr>
 <tr class="subtest" data-parent="Intl_object" id="test-Intl_object_exists_on_global"><td><span><a class="anchor" href="#test-Intl_object_exists_on_global">&#xA7;</a>exists on global</span><script data-source="
 return typeof Intl === &apos;object&apos;;
@@ -549,6 +551,7 @@ return typeof Intl === &apos;object&apos;;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Intl_object" id="test-Intl_object_has_prototype_of_Object"><td><span><a class="anchor" href="#test-Intl_object_has_prototype_of_Object">&#xA7;</a>has prototype of Object</span><script data-source="
 return Intl.constructor === Object;
@@ -689,6 +692,7 @@ return Intl.constructor === Object;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Intl.Collator"><span><a class="anchor" href="#test-Intl.Collator">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-10">Intl.Collator</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Collator" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="ie8" data-tally="0">0/5</td>
@@ -826,6 +830,7 @@ return Intl.constructor === Object;
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">5/5</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">5/5</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">5/5</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="1">5/5</td>
 </tr>
 <tr class="subtest" data-parent="Intl.Collator" id="test-Intl.Collator_exists_on_intl_object"><td><span><a class="anchor" href="#test-Intl.Collator_exists_on_intl_object">&#xA7;</a>exists on intl object</span><script data-source="
 return typeof Intl.Collator === &apos;function&apos;;
@@ -966,6 +971,7 @@ return typeof Intl.Collator === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Intl.Collator" id="test-Intl.Collator_a_href=_http://www.ecma-international.org/ecma-402/1.0/#sec-10.1.3.1_creates_new_Collator_instances_/a"><td><span><a class="anchor" href="#test-Intl.Collator_a_href=_http://www.ecma-international.org/ecma-402/1.0/#sec-10.1.3.1_creates_new_Collator_instances_/a">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-10.1.3.1">creates new Collator instances</a></span><script data-source="
 return new Intl.Collator() instanceof Intl.Collator;
@@ -1106,6 +1112,7 @@ return new Intl.Collator() instanceof Intl.Collator;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Intl.Collator" id="test-Intl.Collator_a_href=_http://www.ecma-international.org/ecma-402/1.0/#sec-10.1.2.1_constructor_called_without_new_creates_instances_/a"><td><span><a class="anchor" href="#test-Intl.Collator_a_href=_http://www.ecma-international.org/ecma-402/1.0/#sec-10.1.2.1_constructor_called_without_new_creates_instances_/a">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-10.1.2.1">constructor called without new creates instances</a></span><script data-source="
 return Intl.Collator() instanceof Intl.Collator;
@@ -1246,6 +1253,7 @@ return Intl.Collator() instanceof Intl.Collator;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Intl.Collator" id="test-Intl.Collator_accepts_valid_language_tags"><td><span><a class="anchor" href="#test-Intl.Collator_accepts_valid_language_tags">&#xA7;</a>accepts valid language tags</span><script data-source="
 try {
@@ -1408,6 +1416,7 @@ try {
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Intl.Collator" id="test-Intl.Collator_a_href=_https://github.com/tc39/ecma402/pull/289_rejects_invalid_language_tags_/a"><td><span><a class="anchor" href="#test-Intl.Collator_a_href=_https://github.com/tc39/ecma402/pull/289_rejects_invalid_language_tags_/a">&#xA7;</a><a href="https://github.com/tc39/ecma402/pull/289">rejects invalid language tags</a></span><script data-source="
 if (typeof Intl.Collator !== &apos;function&apos;) return false;
@@ -1565,6 +1574,7 @@ try {
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Intl.Collator.prototype.compare"><span><a class="anchor" href="#test-Intl.Collator.prototype.compare">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-10.3.2">Intl.Collator.prototype.compare</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Collator/compare" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="ie8" data-tally="0">0/1</td>
@@ -1702,6 +1712,7 @@ try {
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">1/1</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">1/1</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">1/1</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="1">1/1</td>
 </tr>
 <tr class="subtest" data-parent="Intl.Collator.prototype.compare" id="test-Intl.Collator.prototype.compare_exists_on_Collator_prototype"><td><span><a class="anchor" href="#test-Intl.Collator.prototype.compare_exists_on_Collator_prototype">&#xA7;</a>exists on Collator prototype</span><script data-source="
 return typeof Intl.Collator().compare === &apos;function&apos;;
@@ -1842,6 +1853,7 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Intl.Collator.prototype.resolvedOptions"><span><a class="anchor" href="#test-Intl.Collator.prototype.resolvedOptions">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-10.3.3">Intl.Collator.prototype.resolvedOptions</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Collator/resolvedOptions" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="ie8" data-tally="0">0/1</td>
@@ -1979,6 +1991,7 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">1/1</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">1/1</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">1/1</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="1">1/1</td>
 </tr>
 <tr class="subtest" data-parent="Intl.Collator.prototype.resolvedOptions" id="test-Intl.Collator.prototype.resolvedOptions_exists_on_Collator_prototype"><td><span><a class="anchor" href="#test-Intl.Collator.prototype.resolvedOptions_exists_on_Collator_prototype">&#xA7;</a>exists on Collator prototype</span><script data-source="
 return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
@@ -2119,6 +2132,7 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-NumberFormat"><span><a class="anchor" href="#test-NumberFormat">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-11">NumberFormat</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="ie8" data-tally="0">0/6</td>
@@ -2256,6 +2270,7 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">6/6</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">6/6</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">6/6</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="1">6/6</td>
 </tr>
 <tr class="subtest" data-parent="NumberFormat" id="test-NumberFormat_exists_on_intl_object"><td><span><a class="anchor" href="#test-NumberFormat_exists_on_intl_object">&#xA7;</a>exists on intl object</span><script data-source="
 return typeof Intl.NumberFormat === &apos;function&apos;;
@@ -2396,6 +2411,7 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="NumberFormat" id="test-NumberFormat_exists_on_intl_object"><td><span><a class="anchor" href="#test-NumberFormat_exists_on_intl_object">&#xA7;</a>exists on intl object</span><script data-source="
 return typeof Intl.NumberFormat === &apos;function&apos;;
@@ -2536,6 +2552,7 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="NumberFormat" id="test-NumberFormat_a_href=_http://www.ecma-international.org/ecma-402/1.0/#sec-10.1.3.1_creates_new_NumberFormat_instances_/a"><td><span><a class="anchor" href="#test-NumberFormat_a_href=_http://www.ecma-international.org/ecma-402/1.0/#sec-10.1.3.1_creates_new_NumberFormat_instances_/a">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-10.1.3.1">creates new NumberFormat instances</a></span><script data-source="
 return new Intl.NumberFormat() instanceof Intl.NumberFormat;
@@ -2676,6 +2693,7 @@ return new Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="NumberFormat" id="test-NumberFormat_a_href=_http://www.ecma-international.org/ecma-402/1.0/#sec-10.1.2.1_constructor_called_without_new_creates_instances_/a"><td><span><a class="anchor" href="#test-NumberFormat_a_href=_http://www.ecma-international.org/ecma-402/1.0/#sec-10.1.2.1_constructor_called_without_new_creates_instances_/a">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-10.1.2.1">constructor called without new creates instances</a></span><script data-source="
 return Intl.NumberFormat() instanceof Intl.NumberFormat;
@@ -2816,6 +2834,7 @@ return Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="NumberFormat" id="test-NumberFormat_accepts_valid_language_tags"><td><span><a class="anchor" href="#test-NumberFormat_accepts_valid_language_tags">&#xA7;</a>accepts valid language tags</span><script data-source="
 try {
@@ -2978,6 +2997,7 @@ try {
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="NumberFormat" id="test-NumberFormat_a_href=_https://github.com/tc39/ecma402/pull/289_rejects_invalid_language_tags_/a"><td><span><a class="anchor" href="#test-NumberFormat_a_href=_https://github.com/tc39/ecma402/pull/289_rejects_invalid_language_tags_/a">&#xA7;</a><a href="https://github.com/tc39/ecma402/pull/289">rejects invalid language tags</a></span><script data-source="
 if (typeof Intl.NumberFormat !== &apos;function&apos;) return false;
@@ -3135,6 +3155,7 @@ try {
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-DateTimeFormat"><span><a class="anchor" href="#test-DateTimeFormat">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-12">DateTimeFormat</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="ie8" data-tally="0">0/7</td>
@@ -3272,6 +3293,7 @@ try {
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">7/7</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">7/7</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">7/7</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="1">7/7</td>
 </tr>
 <tr class="subtest" data-parent="DateTimeFormat" id="test-DateTimeFormat_exists_on_intl_object"><td><span><a class="anchor" href="#test-DateTimeFormat_exists_on_intl_object">&#xA7;</a>exists on intl object</span><script data-source="
 return typeof Intl.DateTimeFormat === &apos;function&apos;;
@@ -3412,6 +3434,7 @@ return typeof Intl.DateTimeFormat === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="DateTimeFormat" id="test-DateTimeFormat_a_href=_http://www.ecma-international.org/ecma-402/1.0/#sec-10.1.3.1_creates_new_DateTimeFormat_instances_/a"><td><span><a class="anchor" href="#test-DateTimeFormat_a_href=_http://www.ecma-international.org/ecma-402/1.0/#sec-10.1.3.1_creates_new_DateTimeFormat_instances_/a">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-10.1.3.1">creates new DateTimeFormat instances</a></span><script data-source="
 return new Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
@@ -3552,6 +3575,7 @@ return new Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="DateTimeFormat" id="test-DateTimeFormat_a_href=_http://www.ecma-international.org/ecma-402/1.0/#sec-10.1.2.1_constructor_called_without_new_creates_instances_/a"><td><span><a class="anchor" href="#test-DateTimeFormat_a_href=_http://www.ecma-international.org/ecma-402/1.0/#sec-10.1.2.1_constructor_called_without_new_creates_instances_/a">&#xA7;</a><a href="http://www.ecma-international.org/ecma-402/1.0/#sec-10.1.2.1">constructor called without new creates instances</a></span><script data-source="
 return Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
@@ -3692,6 +3716,7 @@ return Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="DateTimeFormat" id="test-DateTimeFormat_accepts_valid_language_tags"><td><span><a class="anchor" href="#test-DateTimeFormat_accepts_valid_language_tags">&#xA7;</a>accepts valid language tags</span><script data-source="
 try {
@@ -3854,6 +3879,7 @@ try {
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="DateTimeFormat" id="test-DateTimeFormat_a_href=_https://github.com/tc39/ecma402/pull/289_rejects_invalid_language_tags_/a"><td><span><a class="anchor" href="#test-DateTimeFormat_a_href=_https://github.com/tc39/ecma402/pull/289_rejects_invalid_language_tags_/a">&#xA7;</a><a href="https://github.com/tc39/ecma402/pull/289">rejects invalid language tags</a></span><script data-source="
 if (typeof Intl.DateTimeFormat !== &apos;function&apos;) return false;
@@ -4011,6 +4037,7 @@ try {
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="DateTimeFormat" id="test-DateTimeFormat_resolvedOptions().timeZone_defaults_to_the_host_environment"><td><span><a class="anchor" href="#test-DateTimeFormat_resolvedOptions().timeZone_defaults_to_the_host_environment">&#xA7;</a>resolvedOptions().timeZone defaults to the host environment</span><script data-source="
 var tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
@@ -4152,6 +4179,7 @@ return tz !== void undefined &amp;&amp; tz.length &gt; 0;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="DateTimeFormat" id="test-DateTimeFormat_accepts_IANA_timezone_names"><td><span><a class="anchor" href="#test-DateTimeFormat_accepts_IANA_timezone_names">&#xA7;</a>accepts IANA timezone names</span><script data-source="
 try {
@@ -4300,6 +4328,7 @@ try {
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-String.prototype.localeCompare"><span><a class="anchor" href="#test-String.prototype.localeCompare">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-string.prototype.localecompare">String.prototype.localeCompare</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="ie8" data-tally="0">0/1</td>
@@ -4437,6 +4466,7 @@ try {
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">1/1</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">1/1</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">1/1</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="1">1/1</td>
 </tr>
 <tr class="subtest" data-parent="String.prototype.localeCompare" id="test-String.prototype.localeCompare_exists_on_String_prototype"><td><span><a class="anchor" href="#test-String.prototype.localeCompare_exists_on_String_prototype">&#xA7;</a>exists on String prototype</span><script data-source="
 return typeof String.prototype.localeCompare === &apos;function&apos;;
@@ -4577,6 +4607,7 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Number.prototype.toLocaleString"><span><a class="anchor" href="#test-Number.prototype.toLocaleString">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-number.prototype.tolocalestring">Number.prototype.toLocaleString</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="ie8" data-tally="0">0/1</td>
@@ -4714,6 +4745,7 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">1/1</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">1/1</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">1/1</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="1">1/1</td>
 </tr>
 <tr class="subtest" data-parent="Number.prototype.toLocaleString" id="test-Number.prototype.toLocaleString_exists_on_Number_prototype"><td><span><a class="anchor" href="#test-Number.prototype.toLocaleString_exists_on_Number_prototype">&#xA7;</a>exists on Number prototype</span><script data-source="
 return typeof Number.prototype.toLocaleString === &apos;function&apos;;
@@ -4854,6 +4886,7 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Array.prototype.toLocaleString"><span><a class="anchor" href="#test-Array.prototype.toLocaleString">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-array.prototype.tolocalestring">Array.prototype.toLocaleString</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toLocaleString" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="ie8" data-tally="0">0/1</td>
@@ -4991,6 +5024,7 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">1/1</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">1/1</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">1/1</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="1">1/1</td>
 </tr>
 <tr class="subtest" data-parent="Array.prototype.toLocaleString" id="test-Array.prototype.toLocaleString_exists_on_Array_prototype"><td><span><a class="anchor" href="#test-Array.prototype.toLocaleString_exists_on_Array_prototype">&#xA7;</a>exists on Array prototype</span><script data-source="
 return typeof Array.prototype.toLocaleString === &apos;function&apos;;
@@ -5131,6 +5165,7 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Object.prototype.toLocaleString"><span><a class="anchor" href="#test-Object.prototype.toLocaleString">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object.prototype.tolocalestring">Object.prototype.toLocaleString</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toLocaleString" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="ie8" data-tally="0">0/1</td>
@@ -5268,6 +5303,7 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">1/1</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">1/1</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">1/1</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="1">1/1</td>
 </tr>
 <tr class="subtest" data-parent="Object.prototype.toLocaleString" id="test-Object.prototype.toLocaleString_exists_on_Object_prototype"><td><span><a class="anchor" href="#test-Object.prototype.toLocaleString_exists_on_Object_prototype">&#xA7;</a>exists on Object prototype</span><script data-source="
 return typeof Object.prototype.toLocaleString === &apos;function&apos;;
@@ -5408,6 +5444,7 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Date.prototype.toLocaleString"><span><a class="anchor" href="#test-Date.prototype.toLocaleString">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-date.prototype.tolocalestring">Date.prototype.toLocaleString</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleString" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="ie8" data-tally="0">0/1</td>
@@ -5545,6 +5582,7 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">1/1</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">1/1</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">1/1</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="1">1/1</td>
 </tr>
 <tr class="subtest" data-parent="Date.prototype.toLocaleString" id="test-Date.prototype.toLocaleString_exists_on_Date_prototype"><td><span><a class="anchor" href="#test-Date.prototype.toLocaleString_exists_on_Date_prototype">&#xA7;</a>exists on Date prototype</span><script data-source="
 return typeof Date.prototype.toLocaleString === &apos;function&apos;;
@@ -5685,6 +5723,7 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Date.prototype.toLocaleDateString"><span><a class="anchor" href="#test-Date.prototype.toLocaleDateString">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-date.prototype.tolocaledatestring">Date.prototype.toLocaleDateString</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="ie8" data-tally="0">0/1</td>
@@ -5822,6 +5861,7 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">1/1</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">1/1</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">1/1</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="1">1/1</td>
 </tr>
 <tr class="subtest" data-parent="Date.prototype.toLocaleDateString" id="test-Date.prototype.toLocaleDateString_exists_on_Date_prototype"><td><span><a class="anchor" href="#test-Date.prototype.toLocaleDateString_exists_on_Date_prototype">&#xA7;</a>exists on Date prototype</span><script data-source="
 return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
@@ -5962,6 +6002,7 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Date.prototype.toLocaleTimeString"><span><a class="anchor" href="#test-Date.prototype.toLocaleTimeString">&#xA7;</a><a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-date.prototype.tolocaletimestring">Date.prototype.toLocaleTimeString</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="ie8" data-tally="0">0/1</td>
@@ -6099,6 +6140,7 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">1/1</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">1/1</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">1/1</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="1">1/1</td>
 </tr>
 <tr class="subtest" data-parent="Date.prototype.toLocaleTimeString" id="test-Date.prototype.toLocaleTimeString_exists_on_Date_prototype"><td><span><a class="anchor" href="#test-Date.prototype.toLocaleTimeString_exists_on_Date_prototype">&#xA7;</a>exists on Date prototype</span><script data-source="
 return typeof Date.prototype.toLocaleTimeString === &apos;function&apos;;
@@ -6239,6 +6281,7 @@ return typeof Date.prototype.toLocaleTimeString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 </tbody>
     </table>

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -281,12 +281,13 @@
 <th class="platform opera_mobile69 mobile obsolete" data-browser="opera_mobile69"><a href="#opera_mobile69" class="browser-name"><abbr title="Opera Mobile for Android 69">Opera Mobile 69</abbr></a></th>
 <th class="platform opera_mobile70 mobile" data-browser="opera_mobile70"><a href="#opera_mobile70" class="browser-name"><abbr title="Opera Mobile for Android 70">Opera Mobile 70</abbr></a></th>
 <th class="platform opera_mobile71 mobile" data-browser="opera_mobile71"><a href="#opera_mobile71" class="browser-name"><abbr title="Opera Mobile for Android 71">Opera Mobile 71</abbr></a></th>
+<th class="platform reactnative0_70_3 mobile" data-browser="reactnative0_70_3"><a href="#reactnative0_70_3" class="browser-name"><abbr title="React Native 0.70.3 (Using bundled Hermes and metro-react-native babel preset)">React Native 0.70.3 (Hermes + Babel)</abbr></a></th>
 </tr>
 
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr class="category"><td colspan="154"><span>Stage 3</span></td>
+      <tr class="category"><td colspan="155"><span>Stage 3</span></td>
 </tr>
 <tr significance="1"><td id="test-ShadowRealm"><span><a class="anchor" href="#test-ShadowRealm">&#xA7;</a><a href="https://github.com/tc39/proposal-shadowrealm">ShadowRealm</a></span><script data-source="
 return typeof ShadowRealm === &quot;function&quot;
@@ -446,6 +447,7 @@ return typeof ShadowRealm === &quot;function&quot;
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Legacy_RegExp_features_in_JavaScript"><span><a class="anchor" href="#test-Legacy_RegExp_features_in_JavaScript">&#xA7;</a><a href="https://github.com/tc39/proposal-regexp-legacy-features">Legacy RegExp features in JavaScript</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/2</td>
@@ -599,6 +601,7 @@ return typeof ShadowRealm === &quot;function&quot;
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="1">2/2</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="1">2/2</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="1">2/2</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="1">2/2</td>
 </tr>
 <tr class="subtest" data-parent="Legacy_RegExp_features_in_JavaScript" id="test-Legacy_RegExp_features_in_JavaScript_RegExp_lastMatch_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastMatch_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Legacy_RegExp_features_in_JavaScript_RegExp_lastMatch_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastMatch_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>RegExp &quot;lastMatch&quot; <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastMatch" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 var re = /\w/;
@@ -761,6 +764,7 @@ return RegExp.lastMatch === 'x';
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Legacy_RegExp_features_in_JavaScript" id="test-Legacy_RegExp_features_in_JavaScript_RegExp.$1-$9_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/n_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Legacy_RegExp_features_in_JavaScript_RegExp.$1-$9_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/n_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>RegExp.$1-$9 <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/n" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 for (var i = 1; i &lt; 10; i++) {
@@ -925,8 +929,9 @@ return true;
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
-<tr class="category"><td colspan="154"><span>Stage 2</span></td>
+<tr class="category"><td colspan="155"><span>Stage 2</span></td>
 </tr>
 <tr significance="0.25"><td id="test-Generator_function.sent_Meta_Property"><span><a class="anchor" href="#test-Generator_function.sent_Meta_Property">&#xA7;</a><a href="https://github.com/tc39/proposal-function.sent">Generator function.sent Meta Property</a></span><script data-source="
 var result;
@@ -1089,6 +1094,7 @@ return result === &apos;tromple&apos;;
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-Class_and_Property_Decorators"><span><a class="anchor" href="#test-Class_and_Property_Decorators">&#xA7;</a><a href="https://github.com/tc39/proposal-decorators">Class and Property Decorators</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/1</td>
@@ -1242,6 +1248,7 @@ return result === &apos;tromple&apos;;
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="0">0/1</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="0">0/1</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="0">0/1</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/1</td>
 </tr>
 <tr class="subtest" data-parent="Class_and_Property_Decorators" id="test-Class_and_Property_Decorators_a_href=_https://github.com/wycats/javascript-decorators_class_decorators_/a"><td><span><a class="anchor" href="#test-Class_and_Property_Decorators_a_href=_https://github.com/wycats/javascript-decorators_class_decorators_/a">&#xA7;</a><a href="https://github.com/wycats/javascript-decorators">class decorators</a></span><script data-source="
 class A {
@@ -1406,6 +1413,7 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-throw_expressions"><span><a class="anchor" href="#test-throw_expressions">&#xA7;</a><a href="https://github.com/tc39/proposal-throw-expressions">throw expressions</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/4</td>
@@ -1559,6 +1567,7 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="0">0/4</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="0">0/4</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="0">0/4</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/4</td>
 </tr>
 <tr class="subtest" data-parent="throw_expressions" id="test-throw_expressions_logical"><td><span><a class="anchor" href="#test-throw_expressions_logical">&#xA7;</a>logical</span><script data-source="
 var a, b;
@@ -1721,6 +1730,7 @@ try {
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="throw_expressions" id="test-throw_expressions_parameter_initializers"><td><span><a class="anchor" href="#test-throw_expressions_parameter_initializers">&#xA7;</a>parameter initializers</span><script data-source="
 function fn (arg = throw 42) {
@@ -1887,6 +1897,7 @@ try {
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="throw_expressions" id="test-throw_expressions_arrow_function_bodies"><td><span><a class="anchor" href="#test-throw_expressions_arrow_function_bodies">&#xA7;</a>arrow function bodies</span><script data-source="
 var fn = () =&gt; throw 42;
@@ -2048,6 +2059,7 @@ try {
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="throw_expressions" id="test-throw_expressions_conditionals"><td><span><a class="anchor" href="#test-throw_expressions_conditionals">&#xA7;</a>conditionals</span><script data-source="
 true ? 42 : throw 21;
@@ -2209,6 +2221,7 @@ try {
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-Set_methods"><span><a class="anchor" href="#test-Set_methods">&#xA7;</a><a href="https://github.com/tc39/proposal-set-methods">Set methods</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/7</td>
@@ -2362,6 +2375,7 @@ try {
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="0">0/7</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="0">0/7</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="0">0/7</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/7</td>
 </tr>
 <tr class="subtest" data-parent="Set_methods" id="test-Set_methods_Set.prototype.intersection"><td><span><a class="anchor" href="#test-Set_methods_Set.prototype.intersection">&#xA7;</a>Set.prototype.intersection</span><script data-source="
 var set = new Set([1, 2, 3]).intersection(new Set([2, 3, 4]));
@@ -2521,6 +2535,7 @@ return set.size === 2
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Set_methods" id="test-Set_methods_Set.prototype.union"><td><span><a class="anchor" href="#test-Set_methods_Set.prototype.union">&#xA7;</a>Set.prototype.union</span><script data-source="
 var set = new Set([1, 2]).union(new Set([2, 3]));
@@ -2681,6 +2696,7 @@ return set.size === 3
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Set_methods" id="test-Set_methods_Set.prototype.difference"><td><span><a class="anchor" href="#test-Set_methods_Set.prototype.difference">&#xA7;</a>Set.prototype.difference</span><script data-source="
 var set = new Set([1, 2, 3]).difference(new Set([3, 4]));
@@ -2840,6 +2856,7 @@ return set.size === 2
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Set_methods" id="test-Set_methods_Set.prototype.symmetricDifference"><td><span><a class="anchor" href="#test-Set_methods_Set.prototype.symmetricDifference">&#xA7;</a>Set.prototype.symmetricDifference</span><script data-source="
 var set = new Set([1, 2]).symmetricDifference(new Set([2, 3]));
@@ -2999,6 +3016,7 @@ return set.size === 2
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Set_methods" id="test-Set_methods_Set.prototype.isDisjointFrom"><td><span><a class="anchor" href="#test-Set_methods_Set.prototype.isDisjointFrom">&#xA7;</a>Set.prototype.isDisjointFrom</span><script data-source="
 return new Set([1, 2, 3]).isDisjointFrom([4, 5, 6]);
@@ -3155,6 +3173,7 @@ return new Set([1, 2, 3]).isDisjointFrom([4, 5, 6]);
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Set_methods" id="test-Set_methods_Set.prototype.isSubsetOf"><td><span><a class="anchor" href="#test-Set_methods_Set.prototype.isSubsetOf">&#xA7;</a>Set.prototype.isSubsetOf</span><script data-source="
 return new Set([1, 2, 3]).isSubsetOf([5, 4, 3, 2, 1]);
@@ -3311,6 +3330,7 @@ return new Set([1, 2, 3]).isSubsetOf([5, 4, 3, 2, 1]);
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Set_methods" id="test-Set_methods_Set.prototype.isSupersetOf"><td><span><a class="anchor" href="#test-Set_methods_Set.prototype.isSupersetOf">&#xA7;</a>Set.prototype.isSupersetOf</span><script data-source="
 return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
@@ -3467,6 +3487,7 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-ArrayBuffer.prototype.transfer"><span><a class="anchor" href="#test-ArrayBuffer.prototype.transfer">&#xA7;</a><a href="https://github.com/domenic/proposal-arraybuffer-transfer/">ArrayBuffer.prototype.transfer</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/2</td>
@@ -3620,6 +3641,7 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="0">0/2</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="0">0/2</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="0">0/2</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/2</td>
 </tr>
 <tr class="subtest" data-parent="ArrayBuffer.prototype.transfer" id="test-ArrayBuffer.prototype.transfer_ArrayBuffer.prototype.transfer()"><td><span><a class="anchor" href="#test-ArrayBuffer.prototype.transfer_ArrayBuffer.prototype.transfer()">&#xA7;</a>ArrayBuffer.prototype.transfer()</span><script data-source="
 const buffer1 = new Uint8Array([1, 2]).buffer;
@@ -3779,6 +3801,7 @@ return buffer1.byteLength === 0
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="ArrayBuffer.prototype.transfer" id="test-ArrayBuffer.prototype.transfer_ArrayBuffer.prototype.realloc()"><td><span><a class="anchor" href="#test-ArrayBuffer.prototype.transfer_ArrayBuffer.prototype.realloc()">&#xA7;</a>ArrayBuffer.prototype.realloc()</span><script data-source="
 const buffer1 = new ArrayBuffer(1024);
@@ -3938,6 +3961,7 @@ return buffer1.byteLength === 0
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Map.prototype.upsert"><span><a class="anchor" href="#test-Map.prototype.upsert">&#xA7;</a><a href="https://github.com/tc39/proposal-upsert">Map.prototype.upsert</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/2</td>
@@ -4091,6 +4115,7 @@ return buffer1.byteLength === 0
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="0">0/2</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="0">0/2</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="0">0/2</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/2</td>
 </tr>
 <tr class="subtest" data-parent="Map.prototype.upsert" id="test-Map.prototype.upsert_Map.prototype.upsert"><td><span><a class="anchor" href="#test-Map.prototype.upsert_Map.prototype.upsert">&#xA7;</a>Map.prototype.upsert</span><script data-source="
 const map = new Map([[&apos;a&apos;, 1]]);
@@ -4250,6 +4275,7 @@ return Array.from(map).join() === &apos;a,2,b,3&apos;;
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Map.prototype.upsert" id="test-Map.prototype.upsert_WeakMap.prototype.upsert"><td><span><a class="anchor" href="#test-Map.prototype.upsert_WeakMap.prototype.upsert">&#xA7;</a>WeakMap.prototype.upsert</span><script data-source="
 const a = {}, b = {};
@@ -4410,6 +4436,7 @@ return map.get(a) === 2 &amp;&amp; map.get(b) === 3;
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr significance="0.25"><td id="test-Array.isTemplateObject"><span><a class="anchor" href="#test-Array.isTemplateObject">&#xA7;</a><a href="https://github.com/tc39/proposal-array-is-template-object">Array.isTemplateObject</a></span><script data-source="
 return !Array.isTemplateObject([])
@@ -4567,6 +4594,7 @@ return !Array.isTemplateObject([])
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Iterator_Helpers"><span><a class="anchor" href="#test-Iterator_Helpers">&#xA7;</a><a href="https://github.com/tc39/proposal-iterator-helpers">Iterator Helpers</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/35</td>
@@ -4720,6 +4748,7 @@ return !Array.isTemplateObject([])
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="0">0/35</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="0">0/35</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="0">0/35</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/35</td>
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_instanceof_Iterator"><td><span><a class="anchor" href="#test-Iterator_Helpers_instanceof_Iterator">&#xA7;</a>instanceof Iterator</span><script data-source="
 return [1, 2, 3].values() instanceof Iterator;
@@ -4876,6 +4905,7 @@ return [1, 2, 3].values() instanceof Iterator;
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_extends_Iterator"><td><span><a class="anchor" href="#test-Iterator_Helpers_extends_Iterator">&#xA7;</a>extends Iterator</span><script data-source="
 class Class extends Iterator { }
@@ -5034,6 +5064,7 @@ return instance[Symbol.iterator]() === instance;
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_Iterator.from,_iterable"><td><span><a class="anchor" href="#test-Iterator_Helpers_Iterator.from,_iterable">&#xA7;</a>Iterator.from, iterable</span><script data-source="
 const iterator = Iterator.from([1, 2, 3]);
@@ -5193,6 +5224,7 @@ return &apos;next&apos; in iterator
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_Iterator.from,_iterator"><td><span><a class="anchor" href="#test-Iterator_Helpers_Iterator.from,_iterator">&#xA7;</a>Iterator.from, iterator</span><script data-source="
 const iterator = Iterator.from({
@@ -5357,6 +5389,7 @@ return &apos;next&apos; in iterator
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_Iterator.prototype.asIndexedPairs"><td><span><a class="anchor" href="#test-Iterator_Helpers_Iterator.prototype.asIndexedPairs">&#xA7;</a>Iterator.prototype.asIndexedPairs</span><script data-source="
 return Array.from([1, 2, 3].values().asIndexedPairs()).join() === &apos;0,1,1,2,2,3&apos;;
@@ -5513,6 +5546,7 @@ return Array.from([1, 2, 3].values().asIndexedPairs()).join() === &apos;0,1,1,2,
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_Iterator.prototype.drop"><td><span><a class="anchor" href="#test-Iterator_Helpers_Iterator.prototype.drop">&#xA7;</a>Iterator.prototype.drop</span><script data-source="
 return Array.from([1, 2, 3].values().drop(1)).join() === &apos;2,3&apos;;
@@ -5669,6 +5703,7 @@ return Array.from([1, 2, 3].values().drop(1)).join() === &apos;2,3&apos;;
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_Iterator.prototype.every"><td><span><a class="anchor" href="#test-Iterator_Helpers_Iterator.prototype.every">&#xA7;</a>Iterator.prototype.every</span><script data-source="
 return [1, 2, 3].values().every(it =&gt; typeof it === &apos;number&apos;);
@@ -5825,6 +5860,7 @@ return [1, 2, 3].values().every(it =&gt; typeof it === &apos;number&apos;);
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_Iterator.prototype.filter"><td><span><a class="anchor" href="#test-Iterator_Helpers_Iterator.prototype.filter">&#xA7;</a>Iterator.prototype.filter</span><script data-source="
 return Array.from([1, 2, 3].values().filter(it =&gt; it % 2)).join() === &apos;1,3&apos;;
@@ -5981,6 +6017,7 @@ return Array.from([1, 2, 3].values().filter(it =&gt; it % 2)).join() === &apos;1
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_Iterator.prototype.find"><td><span><a class="anchor" href="#test-Iterator_Helpers_Iterator.prototype.find">&#xA7;</a>Iterator.prototype.find</span><script data-source="
 return [1, 2, 3].values().find(it =&gt; it % 2) === 1;
@@ -6137,6 +6174,7 @@ return [1, 2, 3].values().find(it =&gt; it % 2) === 1;
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_Iterator.prototype.flatMap"><td><span><a class="anchor" href="#test-Iterator_Helpers_Iterator.prototype.flatMap">&#xA7;</a>Iterator.prototype.flatMap</span><script data-source="
 return Array.from([1, 2, 3].values().flatMap(it =&gt; [it, 0])).join() === &apos;1,0,2,0,3,0&apos;;
@@ -6293,6 +6331,7 @@ return Array.from([1, 2, 3].values().flatMap(it =&gt; [it, 0])).join() === &apos
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_Iterator.prototype.forEach"><td><span><a class="anchor" href="#test-Iterator_Helpers_Iterator.prototype.forEach">&#xA7;</a>Iterator.prototype.forEach</span><script data-source="
 let result = &apos;&apos;;
@@ -6451,6 +6490,7 @@ return result === &apos;123&apos;;
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_Iterator.prototype.map"><td><span><a class="anchor" href="#test-Iterator_Helpers_Iterator.prototype.map">&#xA7;</a>Iterator.prototype.map</span><script data-source="
 return Array.from([1, 2, 3].values().map(it =&gt; it * it)).join() === &apos;1,4,9&apos;;
@@ -6607,6 +6647,7 @@ return Array.from([1, 2, 3].values().map(it =&gt; it * it)).join() === &apos;1,4
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_Iterator.prototype.reduce"><td><span><a class="anchor" href="#test-Iterator_Helpers_Iterator.prototype.reduce">&#xA7;</a>Iterator.prototype.reduce</span><script data-source="
 return [1, 2, 3].values().reduce((a, b) =&gt; a + b) === 6;
@@ -6763,6 +6804,7 @@ return [1, 2, 3].values().reduce((a, b) =&gt; a + b) === 6;
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_Iterator.prototype.some"><td><span><a class="anchor" href="#test-Iterator_Helpers_Iterator.prototype.some">&#xA7;</a>Iterator.prototype.some</span><script data-source="
 return [1, 2, 3].values().some(it =&gt; typeof it === &apos;number&apos;);
@@ -6919,6 +6961,7 @@ return [1, 2, 3].values().some(it =&gt; typeof it === &apos;number&apos;);
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_Iterator.prototype.take"><td><span><a class="anchor" href="#test-Iterator_Helpers_Iterator.prototype.take">&#xA7;</a>Iterator.prototype.take</span><script data-source="
 return Array.from([1, 2, 3].values().take(2)).join() === &apos;1,2&apos;;
@@ -7075,6 +7118,7 @@ return Array.from([1, 2, 3].values().take(2)).join() === &apos;1,2&apos;;
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_Iterator.prototype.toArray"><td><span><a class="anchor" href="#test-Iterator_Helpers_Iterator.prototype.toArray">&#xA7;</a>Iterator.prototype.toArray</span><script data-source="
 const array = [1, 2, 3].values().toArray();
@@ -7232,6 +7276,7 @@ return Array.isArray(array) &amp;&amp; array.join() === &apos;1,2,3&apos;;
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_Iterator.prototype[@@toStringTag]"><td><span><a class="anchor" href="#test-Iterator_Helpers_Iterator.prototype[@@toStringTag]">&#xA7;</a>Iterator.prototype[@@toStringTag]</span><script data-source="
 return Iterator.prototype[Symbol.toStringTag] === &apos;Iterator&apos;;
@@ -7388,6 +7433,7 @@ return Iterator.prototype[Symbol.toStringTag] === &apos;Iterator&apos;;
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_instanceof_AsyncIterator"><td><span><a class="anchor" href="#test-Iterator_Helpers_instanceof_AsyncIterator">&#xA7;</a>instanceof AsyncIterator</span><script data-source="
 return (async function*() {})() instanceof AsyncIterator;
@@ -7544,6 +7590,7 @@ return (async function*() {})() instanceof AsyncIterator;
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_extends_AsyncIterator"><td><span><a class="anchor" href="#test-Iterator_Helpers_extends_AsyncIterator">&#xA7;</a>extends AsyncIterator</span><script data-source="
 class Class extends AsyncIterator { }
@@ -7702,6 +7749,7 @@ return instance[Symbol.asyncIterator]() === instance;
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_AsyncIterator.from,_async_iterable"><td><span><a class="anchor" href="#test-Iterator_Helpers_AsyncIterator.from,_async_iterable">&#xA7;</a>AsyncIterator.from, async iterable</span><script data-source="
 async function toArray(iterator) {
@@ -7870,6 +7918,7 @@ toArray(iterator).then(it =&gt; {
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_AsyncIterator.from,_iterable"><td><span><a class="anchor" href="#test-Iterator_Helpers_AsyncIterator.from,_iterable">&#xA7;</a>AsyncIterator.from, iterable</span><script data-source="
 async function toArray(iterator) {
@@ -8038,6 +8087,7 @@ toArray(iterator).then(it =&gt; {
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_AsyncIterator.from,_iterator"><td><span><a class="anchor" href="#test-Iterator_Helpers_AsyncIterator.from,_iterator">&#xA7;</a>AsyncIterator.from, iterator</span><script data-source="
 async function toArray(iterator) {
@@ -8206,6 +8256,7 @@ toArray(iterator).then(it =&gt; {
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_AsyncIterator.prototype.asIndexedPairs"><td><span><a class="anchor" href="#test-Iterator_Helpers_AsyncIterator.prototype.asIndexedPairs">&#xA7;</a>AsyncIterator.prototype.asIndexedPairs</span><script data-source="
 async function toArray(iterator) {
@@ -8370,6 +8421,7 @@ toArray((async function*() { yield * [1, 2, 3] })().asIndexedPairs()).then(it =&
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_AsyncIterator.prototype.drop"><td><span><a class="anchor" href="#test-Iterator_Helpers_AsyncIterator.prototype.drop">&#xA7;</a>AsyncIterator.prototype.drop</span><script data-source="
 async function toArray(iterator) {
@@ -8534,6 +8586,7 @@ toArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it =&gt; {
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_AsyncIterator.prototype.every"><td><span><a class="anchor" href="#test-Iterator_Helpers_AsyncIterator.prototype.every">&#xA7;</a>AsyncIterator.prototype.every</span><script data-source="
 (async function*() { yield * [1, 2, 3] })().every(it =&gt; typeof it === &apos;number&apos;).then(it =&gt; {
@@ -8692,6 +8745,7 @@ toArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it =&gt; {
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_AsyncIterator.prototype.filter"><td><span><a class="anchor" href="#test-Iterator_Helpers_AsyncIterator.prototype.filter">&#xA7;</a>AsyncIterator.prototype.filter</span><script data-source="
 async function toArray(iterator) {
@@ -8856,6 +8910,7 @@ toArray(async function*() { yield * [1, 2, 3] }().filter(it =&gt; it % 2)).then(
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_AsyncIterator.prototype.find"><td><span><a class="anchor" href="#test-Iterator_Helpers_AsyncIterator.prototype.find">&#xA7;</a>AsyncIterator.prototype.find</span><script data-source="
 (async function*() { yield * [1, 2, 3] })().find(it =&gt; it % 2).then(it =&gt; {
@@ -9014,6 +9069,7 @@ toArray(async function*() { yield * [1, 2, 3] }().filter(it =&gt; it % 2)).then(
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_AsyncIterator.prototype.flatMap"><td><span><a class="anchor" href="#test-Iterator_Helpers_AsyncIterator.prototype.flatMap">&#xA7;</a>AsyncIterator.prototype.flatMap</span><script data-source="
 async function toArray(iterator) {
@@ -9178,6 +9234,7 @@ toArray(async function*() { yield * [1, 2, 3] }().flatMap(it =&gt; [it, 0])).the
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_AsyncIterator.prototype.forEach"><td><span><a class="anchor" href="#test-Iterator_Helpers_AsyncIterator.prototype.forEach">&#xA7;</a>AsyncIterator.prototype.forEach</span><script data-source="
 let result = &apos;&apos;;
@@ -9337,6 +9394,7 @@ let result = &apos;&apos;;
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_AsyncIterator.prototype.map"><td><span><a class="anchor" href="#test-Iterator_Helpers_AsyncIterator.prototype.map">&#xA7;</a>AsyncIterator.prototype.map</span><script data-source="
 async function toArray(iterator) {
@@ -9501,6 +9559,7 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_AsyncIterator.prototype.reduce"><td><span><a class="anchor" href="#test-Iterator_Helpers_AsyncIterator.prototype.reduce">&#xA7;</a>AsyncIterator.prototype.reduce</span><script data-source="
 (async function*() { yield * [1, 2, 3] })().reduce((a, b) =&gt; a + b).then(it =&gt; {
@@ -9659,6 +9718,7 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_AsyncIterator.prototype.some"><td><span><a class="anchor" href="#test-Iterator_Helpers_AsyncIterator.prototype.some">&#xA7;</a>AsyncIterator.prototype.some</span><script data-source="
 (async function*() { yield * [1, 2, 3] })().some(it =&gt; typeof it === &apos;number&apos;).then(it =&gt; {
@@ -9817,6 +9877,7 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_AsyncIterator.prototype.take"><td><span><a class="anchor" href="#test-Iterator_Helpers_AsyncIterator.prototype.take">&#xA7;</a>AsyncIterator.prototype.take</span><script data-source="
 async function toArray(iterator) {
@@ -9981,6 +10042,7 @@ toArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it =&gt; {
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_AsyncIterator.prototype.toArray"><td><span><a class="anchor" href="#test-Iterator_Helpers_AsyncIterator.prototype.toArray">&#xA7;</a>AsyncIterator.prototype.toArray</span><script data-source="
 (async function*() { yield * [1, 2, 3] })().toArray().then(it =&gt; {
@@ -10139,6 +10201,7 @@ toArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it =&gt; {
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_AsyncIterator.prototype[@@toStringTag]"><td><span><a class="anchor" href="#test-Iterator_Helpers_AsyncIterator.prototype[@@toStringTag]">&#xA7;</a>AsyncIterator.prototype[@@toStringTag]</span><script data-source="
 return AsyncIterator.prototype[Symbol.toStringTag] === &apos;AsyncIterator&apos;;
@@ -10295,6 +10358,7 @@ return AsyncIterator.prototype[Symbol.toStringTag] === &apos;AsyncIterator&apos;
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 </tbody>
     </table>

--- a/hermes.js
+++ b/hermes.js
@@ -22,7 +22,7 @@ var argv = require('yargs/yargs')(process.argv.slice(2))
     .option('suite', {
         alias: 's',
         type: 'string',
-        choices: ['all', 'es5', 'es6', 'es2016plus'],
+        choices: ['all', 'es5', 'es6', 'es2016plus', 'esintl', 'esnext', 'non-standard'],
         default: 'all'
     })
     .option('test-name', {

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -254,6 +254,7 @@
 <th class="platform opera_mobile69 mobile obsolete" data-browser="opera_mobile69"><a href="#opera_mobile69" class="browser-name"><abbr title="Opera Mobile for Android 69">Opera Mobile 69</abbr></a></th>
 <th class="platform opera_mobile70 mobile" data-browser="opera_mobile70"><a href="#opera_mobile70" class="browser-name"><abbr title="Opera Mobile for Android 70">Opera Mobile 70</abbr></a></th>
 <th class="platform opera_mobile71 mobile" data-browser="opera_mobile71"><a href="#opera_mobile71" class="browser-name"><abbr title="Opera Mobile for Android 71">Opera Mobile 71</abbr></a></th>
+<th class="platform reactnative0_70_3 mobile" data-browser="reactnative0_70_3"><a href="#reactnative0_70_3" class="browser-name"><abbr title="React Native 0.70.3 (Using bundled Hermes and metro-react-native babel preset)">React Native 0.70.3 (Hermes + Babel)</abbr></a></th>
 </tr>
 
         </thead>
@@ -398,6 +399,7 @@
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="0">0/57</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="0">0/57</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="0">0/57</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/57</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_basic_support_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_basic_support_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>basic support <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 simdFloatTypes=[&apos;Float32x4&apos;];
@@ -549,6 +551,7 @@ return typeof SIMD !== &apos;undefined&apos;;
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#float32x4_Float32x4_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float32x4_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#float32x4_Float32x4_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float32x4_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/#float32x4">Float32x4</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float32x4" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Float32x4 === &apos;function&apos;;
@@ -692,6 +695,7 @@ return typeof SIMD.Float32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#int32x4_Int32x4_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int32x4_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#int32x4_Int32x4_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int32x4_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/#int32x4">Int32x4</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int32x4" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Int32x4 === &apos;function&apos;;
@@ -835,6 +839,7 @@ return typeof SIMD.Int32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#int16x8_Int16x8_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int16x8_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#int16x8_Int16x8_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int16x8_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/#int16x8">Int16x8</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int16x8" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Int16x8 === &apos;function&apos;;
@@ -978,6 +983,7 @@ return typeof SIMD.Int16x8 === &apos;function&apos;;
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#int8x16_Int8x16_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int8x16_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#int8x16_Int8x16_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int8x16_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/#int8x16">Int8x16</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int8x16" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Int8x16 === &apos;function&apos;;
@@ -1121,6 +1127,7 @@ return typeof SIMD.Int8x16 === &apos;function&apos;;
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#uint32x4_Uint32x4_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint32x4_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#uint32x4_Uint32x4_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint32x4_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/#uint32x4">Uint32x4</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint32x4" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Uint32x4 === &apos;function&apos;;
@@ -1264,6 +1271,7 @@ return typeof SIMD.Uint32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#uint16x8_Uint16x8_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint16x8_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#uint16x8_Uint16x8_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint16x8_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/#uint16x8">Uint16x8</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint16x8" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Uint16x8 === &apos;function&apos;;
@@ -1407,6 +1415,7 @@ return typeof SIMD.Uint16x8 === &apos;function&apos;;
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#uint8x16_Uint8x16_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8x16_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#uint8x16_Uint8x16_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8x16_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/#uint8x16">Uint8x16</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8x16" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Uint8x16 === &apos;function&apos;;
@@ -1550,6 +1559,7 @@ return typeof SIMD.Uint8x16 === &apos;function&apos;;
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#bool32x4_Bool32x4_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Bool32x4_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#bool32x4_Bool32x4_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Bool32x4_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/#bool32x4">Bool32x4</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Bool32x4" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Bool32x4 === &apos;function&apos;;
@@ -1693,6 +1703,7 @@ return typeof SIMD.Bool32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#bool16x8_Bool16x8_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Bool16x8_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#bool16x8_Bool16x8_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Bool16x8_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/#bool16x8">Bool16x8</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Bool16x8" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Bool16x8 === &apos;function&apos;;
@@ -1836,6 +1847,7 @@ return typeof SIMD.Bool16x8 === &apos;function&apos;;
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#bool8x16_Bool8x16_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Bool8x16_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#bool8x16_Bool8x16_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Bool8x16_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/#bool8x16">Bool8x16</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Bool8x16" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Bool8x16 === &apos;function&apos;;
@@ -1979,6 +1991,7 @@ return typeof SIMD.Bool8x16 === &apos;function&apos;;
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-abs_SIMD.%floatType%.abs_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/abs_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-abs_SIMD.%floatType%.abs_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/abs_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/#simd-abs">SIMD.%floatType%.abs</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/abs" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return simdFloatTypes.every(function(type){
@@ -2124,6 +2137,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-add_SIMD.%type%.add_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/add_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-add_SIMD.%type%.add_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/add_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/#simd-add">SIMD.%type%.add</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/add" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return simdFloatIntTypes.every(function(type){
@@ -2269,6 +2283,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-add-saturate_SIMD.%integerType%.addSaturate_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/addSaturate_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-add-saturate_SIMD.%integerType%.addSaturate_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/addSaturate_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/#simd-add-saturate">SIMD.%integerType%.addSaturate</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/addSaturate" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return simdSmallIntTypes.every(function(type){
@@ -2414,6 +2429,7 @@ return simdSmallIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-and_SIMD.%type%.and_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/and_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-and_SIMD.%type%.and_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/and_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/#simd-and">SIMD.%type%.and</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/and" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return simdBoolIntTypes.every(function(type){
@@ -2559,6 +2575,7 @@ return simdBoolIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-any-true_SIMD.%booleanType%.anyTrue_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/anyTrue_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-any-true_SIMD.%booleanType%.anyTrue_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/anyTrue_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/#simd-any-true">SIMD.%booleanType%.anyTrue</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/anyTrue" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return simdBoolTypes.every(function(type){
@@ -2704,6 +2721,7 @@ return simdBoolTypes.every(function(type){
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-all-true_SIMD.%booleanType%.allTrue_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/allTrue_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-all-true_SIMD.%booleanType%.allTrue_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/allTrue_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/#simd-all-true">SIMD.%booleanType%.allTrue</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/allTrue" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return simdBoolTypes.every(function(type){
@@ -2849,6 +2867,7 @@ return simdBoolTypes.every(function(type){
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-check_SIMD.%type%.check_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/check_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-check_SIMD.%type%.check_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/check_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/#simd-check">SIMD.%type%.check</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/check" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return simdAllTypes.every(function(type){
@@ -2994,6 +3013,7 @@ return simdAllTypes.every(function(type){
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-equal_SIMD.%type%.equal_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/equal_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-equal_SIMD.%type%.equal_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/equal_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/#simd-equal">SIMD.%type%.equal</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/equal" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return simdFloatIntTypes.every(function(type){
@@ -3139,6 +3159,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-extract-lane_SIMD.%type%.extractLane_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/extractLane_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-extract-lane_SIMD.%type%.extractLane_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/extractLane_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/#simd-extract-lane">SIMD.%type%.extractLane</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/extractLane" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return simdAllTypes.every(function(type){
@@ -3284,6 +3305,7 @@ return simdAllTypes.every(function(type){
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-greater-than_SIMD.%type%.greaterThan_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/greaterThan_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-greater-than_SIMD.%type%.greaterThan_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/greaterThan_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/#simd-greater-than">SIMD.%type%.greaterThan</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/greaterThan" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return simdFloatIntTypes.every(function(type){
@@ -3429,6 +3451,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-greater-than-or-equal_SIMD.%type%.greaterThanOrEqual_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/greaterThanOrEqual_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-greater-than-or-equal_SIMD.%type%.greaterThanOrEqual_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/greaterThanOrEqual_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/#simd-greater-than-or-equal">SIMD.%type%.greaterThanOrEqual</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/greaterThanOrEqual" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return simdFloatIntTypes.every(function(type){
@@ -3574,6 +3597,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-less-than_SIMD.%type%.lessThan_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/lessThan_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-less-than_SIMD.%type%.lessThan_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/lessThan_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/#simd-less-than">SIMD.%type%.lessThan</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/lessThan" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return simdFloatIntTypes.every(function(type){
@@ -3719,6 +3743,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-less-than-or-equal_SIMD.%type%.lessThanOrEqual_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/lessThanOrEqual_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-less-than-or-equal_SIMD.%type%.lessThanOrEqual_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/lessThanOrEqual_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/#simd-less-than-or-equal">SIMD.%type%.lessThanOrEqual</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/lessThanOrEqual" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return simdFloatIntTypes.every(function(type){
@@ -3864,6 +3889,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-mul_SIMD.%type%.mul_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/mul_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-mul_SIMD.%type%.mul_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/mul_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/#simd-mul">SIMD.%type%.mul</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/mul" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return simdFloatIntTypes.every(function(type){
@@ -4009,6 +4035,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-div_SIMD.%floatType%.div_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/div_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-div_SIMD.%floatType%.div_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/div_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/#simd-div">SIMD.%floatType%.div</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/div" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return simdFloatTypes.every(function(type){
@@ -4154,6 +4181,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-load-function_SIMD.%type%.load_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/load_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-load-function_SIMD.%type%.load_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/load_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/#simd-load-function">SIMD.%type%.load</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/load" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return simdFloatIntTypes.every(function(type){
@@ -4299,6 +4327,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.load1_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/load_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.load1_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/load_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SIMD.%type%.load1 <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/load" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return simd32bitFloatIntTypes.every(function(type){
@@ -4444,6 +4473,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.load2_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/load_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.load2_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/load_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SIMD.%type%.load2 <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/load" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return simd32bitFloatIntTypes.every(function(type){
@@ -4589,6 +4619,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.load3_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/load_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.load3_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/load_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SIMD.%type%.load3 <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/load" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return simd32bitFloatIntTypes.every(function(type){
@@ -4734,6 +4765,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-max_SIMD.%floatType%.max_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/max_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-max_SIMD.%floatType%.max_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/max_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/#simd-max">SIMD.%floatType%.max</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/max" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return simdFloatTypes.every(function(type){
@@ -4879,6 +4911,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-max-num_SIMD.%floatType%.maxNum_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/maxNum_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-max-num_SIMD.%floatType%.maxNum_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/maxNum_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/#simd-max-num">SIMD.%floatType%.maxNum</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/maxNum" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return simdFloatTypes.every(function(type){
@@ -5024,6 +5057,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-min_SIMD.%floatType%.min_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/min_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-min_SIMD.%floatType%.min_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/min_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/#simd-min">SIMD.%floatType%.min</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/min" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return simdFloatTypes.every(function(type){
@@ -5169,6 +5203,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-min-num_SIMD.%floatType%.minNum_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/minNum_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-min-num_SIMD.%floatType%.minNum_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/minNum_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/#simd-min-num">SIMD.%floatType%.minNum</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/minNum" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return simdFloatTypes.every(function(type){
@@ -5314,6 +5349,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-neg_SIMD.%type%.neg_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/neg_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-neg_SIMD.%type%.neg_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/neg_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/#simd-neg">SIMD.%type%.neg</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/neg" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return simdFloatIntTypes.every(function(type){
@@ -5459,6 +5495,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-not_SIMD.%type%.not_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/not_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-not_SIMD.%type%.not_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/not_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/#simd-not">SIMD.%type%.not</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/not" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return simdBoolTypes.every(function(type){
@@ -5604,6 +5641,7 @@ return simdBoolTypes.every(function(type){
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-not-equal_SIMD.%type%.notEqual_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/notEqual_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-not-equal_SIMD.%type%.notEqual_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/notEqual_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/#simd-not-equal">SIMD.%type%.notEqual</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/notEqual" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return simdFloatIntTypes.every(function(type){
@@ -5749,6 +5787,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-or_SIMD.%type%.or_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/or_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-or_SIMD.%type%.or_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/or_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/#simd-or">SIMD.%type%.or</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/or" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return simdBoolIntTypes.every(function(type){
@@ -5894,6 +5933,7 @@ return simdBoolIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-reciprocal-approximation_SIMD.%floatType%.reciprocalApproximation_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/reciprocalApproximation_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-reciprocal-approximation_SIMD.%floatType%.reciprocalApproximation_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/reciprocalApproximation_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/#simd-reciprocal-approximation">SIMD.%floatType%.reciprocalApproximation</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/reciprocalApproximation" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return simdFloatTypes.every(function(type){
@@ -6039,6 +6079,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-reciprocal-sqrt-approximation_SIMD.%floatType%.reciprocalSqrtApproximation_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/reciprocalSqrtApproximation_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-reciprocal-sqrt-approximation_SIMD.%floatType%.reciprocalSqrtApproximation_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/reciprocalSqrtApproximation_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/#simd-reciprocal-sqrt-approximation">SIMD.%floatType%.reciprocalSqrtApproximation</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/reciprocalSqrtApproximation" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return simdFloatTypes.every(function(type){
@@ -6184,6 +6225,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-replace-lane_SIMD.%type%.replaceLane_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/replaceLane_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-replace-lane_SIMD.%type%.replaceLane_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/replaceLane_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/#simd-replace-lane">SIMD.%type%.replaceLane</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/replaceLane" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return simdAllTypes.every(function(type){
@@ -6329,6 +6371,7 @@ return simdAllTypes.every(function(type){
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-select_SIMD.%type%.select_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/select_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-select_SIMD.%type%.select_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/select_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/#simd-select">SIMD.%type%.select</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/select" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return simdFloatIntTypes.every(function(type){
@@ -6474,6 +6517,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-shift-left-by-scalar_SIMD.%integerType%.shiftLeftByScalar_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/shiftLeftByScalar_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-shift-left-by-scalar_SIMD.%integerType%.shiftLeftByScalar_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/shiftLeftByScalar_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/#simd-shift-left-by-scalar">SIMD.%integerType%.shiftLeftByScalar</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/shiftLeftByScalar" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return simdIntTypes.every(function(type){
@@ -6619,6 +6663,7 @@ return simdIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-shift-right-by-scalar_SIMD.%integerType%.shiftRightByScalar_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/shiftRightByScalar_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-shift-right-by-scalar_SIMD.%integerType%.shiftRightByScalar_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/shiftRightByScalar_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/#simd-shift-right-by-scalar">SIMD.%integerType%.shiftRightByScalar</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/shiftRightByScalar" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return simdIntTypes.every(function(type){
@@ -6764,6 +6809,7 @@ return simdIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#shuffle_SIMD.%type%.shuffle_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/shuffle_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#shuffle_SIMD.%type%.shuffle_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/shuffle_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/#shuffle">SIMD.%type%.shuffle</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/shuffle" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return simdFloatIntTypes.every(function(type){
@@ -6909,6 +6955,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-splat_SIMD.%type%.splat_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/splat_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-splat_SIMD.%type%.splat_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/splat_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/#simd-splat">SIMD.%type%.splat</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/splat" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return simdFloatIntTypes.every(function(type){
@@ -7054,6 +7101,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-sqrt_SIMD.%floatType%.sqrt_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/sqrt_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-sqrt_SIMD.%floatType%.sqrt_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/sqrt_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/#simd-sqrt">SIMD.%floatType%.sqrt</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/sqrt" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return simdFloatTypes.every(function(type){
@@ -7199,6 +7247,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-store-function_SIMD.%type%.store_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/store_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-store-function_SIMD.%type%.store_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/store_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/#simd-store-function">SIMD.%type%.store</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/store" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return simdFloatIntTypes.every(function(type){
@@ -7344,6 +7393,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.store1_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/store_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.store1_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/store_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SIMD.%type%.store1 <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/store" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return simd32bitFloatIntTypes.every(function(type){
@@ -7489,6 +7539,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.store2_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/store_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.store2_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/store_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SIMD.%type%.store2 <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/store" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return simd32bitFloatIntTypes.every(function(type){
@@ -7634,6 +7685,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.store3_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/store_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_SIMD.%type%.store3_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/store_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>SIMD.%type%.store3 <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/store" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return simd32bitFloatIntTypes.every(function(type){
@@ -7779,6 +7831,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-sub_SIMD.%type%.sub_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/sub_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-sub_SIMD.%type%.sub_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/sub_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/#simd-sub">SIMD.%type%.sub</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/sub" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return simdFloatIntTypes.every(function(type){
@@ -7924,6 +7977,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-sub-saturate_SIMD.%integerType%.subSaturate_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/subSaturate_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-sub-saturate_SIMD.%integerType%.subSaturate_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/subSaturate_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/#simd-sub-saturate">SIMD.%integerType%.subSaturate</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/subSaturate" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return simdSmallIntTypes.every(function(type){
@@ -8069,6 +8123,7 @@ return simdSmallIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#swizzle_SIMD.%type%.swizzle_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/swizzle_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#swizzle_SIMD.%type%.swizzle_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/swizzle_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/#swizzle">SIMD.%type%.swizzle</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/swizzle" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return simdFloatIntTypes.every(function(type){
@@ -8214,6 +8269,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-xor_SIMD.%type%.xor_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/xor_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-xor_SIMD.%type%.xor_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/xor_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/#simd-xor">SIMD.%type%.xor</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/xor" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return simdBoolIntTypes.every(function(type){
@@ -8359,6 +8415,7 @@ return simdBoolIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-to-timd_SIMD.%type%.fromTIMDBits_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/fromFloat32x4Bits_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-to-timd_SIMD.%type%.fromTIMDBits_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/fromFloat32x4Bits_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/#simd-to-timd">SIMD.%type%.fromTIMDBits</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/fromFloat32x4Bits" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return [&apos;Float32x4&apos;,&apos;Int32x4&apos;,&apos;Int8x16&apos;,&apos;Uint32x4&apos;,&apos;Uint16x8&apos;,&apos;Uint8x16&apos;].every(function(type){
@@ -8504,6 +8561,7 @@ return [&apos;Float32x4&apos;,&apos;Int32x4&apos;,&apos;Int8x16&apos;,&apos;Uint
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="SIMD_(Single_Instruction,_Multiple_Data)" id="test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-to-timd-logical_SIMD.%type%.fromTIMD_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/fromFloat32x4_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-SIMD_(Single_Instruction,_Multiple_Data)_a_href=_https://tc39.github.io/ecmascript_simd/#simd-to-timd-logical_SIMD.%type%.fromTIMD_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/fromFloat32x4_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecmascript_simd/#simd-to-timd-logical">SIMD.%type%.fromTIMD</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SIMD/fromFloat32x4" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typeof SIMD.Float32x4.fromUint32x4 === &apos;function&apos; &amp;&amp; typeof SIMD.Int32x4.fromFloat32x4 === &apos;function&apos; &amp;&amp; typeof SIMD.Uint32x4.fromFloat32x4 === &apos;function&apos;;
@@ -8647,8 +8705,9 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
-<tr><th colspan="141" class="separator"></th>
+<tr><th colspan="142" class="separator"></th>
 </tr>
 <tr class="supertest" significance="1"><td id="test-decompilation"><span><a class="anchor" href="#test-decompilation">&#xA7;</a>decompilation</span></td>
 <td class="tally obsolete" data-browser="konq4_13" data-tally="0">0/4</td>
@@ -8789,6 +8848,7 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="0">0/4</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="0">0/4</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="0">0/4</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/4</td>
 </tr>
 <tr class="subtest" data-parent="decompilation" id="test-decompilation_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/uneval_uneval,_existence_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/uneval_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-decompilation_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/uneval_uneval,_existence_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/uneval_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/uneval">uneval, existence</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/uneval" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof uneval === &apos;function&apos;;
@@ -8932,6 +8992,7 @@ return typeof uneval === &apos;function&apos;;
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="decompilation" id="test-decompilation_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toSource_built-in_toSource_methods_/a_a_href=_https://developer.mozilla.org/en-US/search?q=tosource_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-decompilation_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toSource_built-in_toSource_methods_/a_a_href=_https://developer.mozilla.org/en-US/search?q=tosource_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toSource">built-in &quot;toSource&quot; methods</a> <a href="https://developer.mozilla.org/en-US/search?q=tosource" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return &apos;toSource&apos; in Object.prototype
@@ -9083,6 +9144,7 @@ return &apos;toSource&apos; in Object.prototype
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="decompilation" id="test-decompilation_toSource_method_as_hook_for_uneval"><td><span><a class="anchor" href="#test-decompilation_toSource_method_as_hook_for_uneval">&#xA7;</a>&quot;toSource&quot; method as hook for uneval</span><script data-source="
 return uneval({ toSource: function() { return &quot;pwnd!&quot; } }) === &quot;pwnd!&quot;;
@@ -9226,6 +9288,7 @@ return uneval({ toSource: function() { return &quot;pwnd!&quot; } }) === &quot;p
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="decompilation" id="test-decompilation_eval(uneval(value))_is_functionally_equivalent_to_value"><td><span><a class="anchor" href="#test-decompilation_eval(uneval(value))_is_functionally_equivalent_to_value">&#xA7;</a>eval(uneval(value)) is functionally equivalent to value</span><script data-source="
 
@@ -9455,6 +9518,7 @@ return true;
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr significance="1"><td id="test-optional_scope_argument_of_eval"><span><a class="anchor" href="#test-optional_scope_argument_of_eval">&#xA7;</a>optional &quot;scope&quot; argument of &quot;eval&quot;</span><script data-source="
 var x = 1;
@@ -9599,8 +9663,9 @@ return eval(&quot;x&quot;, { x: 2 }) === 2;
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
-<tr><th colspan="141" class="separator"></th>
+<tr><th colspan="142" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-function_caller_property"><span><a class="anchor" href="#test-function_caller_property">&#xA7;</a>function &quot;caller&quot; property <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/caller" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return &apos;caller&apos; in function(){};
@@ -9746,6 +9811,7 @@ return 'caller' in function(){};
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr significance="1"><td id="test-function_arity_property"><span><a class="anchor" href="#test-function_arity_property">&#xA7;</a>function &quot;arity&quot; property <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/arity" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return (function () {}).arity === 0 &amp;&amp;
@@ -9895,6 +9961,7 @@ return (function () {}).arity === 0 &&
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr significance="1"><td id="test-function_arguments_property"><span><a class="anchor" href="#test-function_arguments_property">&#xA7;</a>function &quot;arguments&quot; property <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/arguments" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 function f(a, b) {
@@ -10046,6 +10113,7 @@ return f(1, 'boo');
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr significance="1"><td id="test-Function.prototype.isGenerator"><span><a class="anchor" href="#test-Function.prototype.isGenerator">&#xA7;</a><a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Function/isGenerator">Function.prototype.isGenerator</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/isGenerator" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof Function.prototype.isGenerator === &apos;function&apos;;
@@ -10191,8 +10259,9 @@ return typeof Function.prototype.isGenerator === 'function';
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
-<tr><th colspan="141" class="separator"></th>
+<tr><th colspan="142" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-class_extends_null"><span><a class="anchor" href="#test-class_extends_null">&#xA7;</a><a href="https://github.com/tc39/ecma262/issues/543">class extends null</a></span><script data-source="
 class C extends null {}
@@ -10337,6 +10406,7 @@ return new C instanceof C;
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr significance="1"><td id="test-__count__"><span><a class="anchor" href="#test-__count__">&#xA7;</a><a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/prototype">__count__</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/count" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof ({}).__count__ === &apos;number&apos; &amp;&amp;
@@ -10484,6 +10554,7 @@ return typeof ({}).__count__ === 'number' &&
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr significance="1"><td id="test-__parent__"><span><a class="anchor" href="#test-__parent__">&#xA7;</a><a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/Parent">__parent__</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/Parent" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return typeof ({}).__parent__ !== &apos;undefined&apos;;
@@ -10629,6 +10700,7 @@ return typeof ({}).__parent__ !== 'undefined';
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr significance="1"><td id="test-__noSuchMethod__"><span><a class="anchor" href="#test-__noSuchMethod__">&#xA7;</a><a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/noSuchMethod">__noSuchMethod__</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/noSuchMethod" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 var o = { }, executed = false;
@@ -10784,6 +10856,7 @@ return executed;
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr significance="1"><td id="test-Array_generics"><span><a class="anchor" href="#test-Array_generics">&#xA7;</a>Array generics</span><script data-source="function () {
 return typeof Array.slice === &apos;function&apos; &amp;&amp; Array.slice(&apos;abc&apos;).length === 3;
@@ -10929,6 +11002,7 @@ return typeof Array.slice === 'function' && Array.slice('abc').length === 3;
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr significance="1"><td id="test-String_generics"><span><a class="anchor" href="#test-String_generics">&#xA7;</a>String generics</span><script data-source="function () {
 return typeof String.slice === &apos;function&apos; &amp;&amp; String.slice(123, 1) === &quot;23&quot;;
@@ -11074,8 +11148,9 @@ return typeof String.slice === 'function' && String.slice(123, 1) === "23";
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
-<tr><th colspan="141" class="separator"></th>
+<tr><th colspan="142" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Array_comprehensions_(JS_1.8_style)"><span><a class="anchor" href="#test-Array_comprehensions_(JS_1.8_style)">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Predefined_Core_Objects#Array_comprehensions">Array comprehensions (JS 1.8 style)</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Array_comprehensions#Differences_to_the_older_JS1.7JS1.8_comprehensions" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var obj = { 2: true, &quot;foo&quot;: true, 4: true };
@@ -11221,6 +11296,7 @@ return a instanceof Array &amp;&amp; a[0] === 4 &amp;&amp; a[1] === 8;
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr significance="0.5"><td id="test-Array_comprehensions_(ES_draft_style)"><span><a class="anchor" href="#test-Array_comprehensions_(ES_draft_style)">&#xA7;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:array_comprehensions">Array comprehensions (ES draft style)</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Array_comprehensions" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return [for (a of [1, 2, 3]) a * a] + &apos;&apos; === &apos;1,4,9&apos;;
@@ -11364,6 +11440,7 @@ return [for (a of [1, 2, 3]) a * a] + &apos;&apos; === &apos;1,4,9&apos;;
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr significance="1"><td id="test-Expression_closures"><span><a class="anchor" href="#test-Expression_closures">&#xA7;</a>Expression closures <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Expression_closures" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return (function(x)x)(1) === 1;
@@ -11507,6 +11584,7 @@ return (function(x)x)(1) === 1;
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr significance="1"><td id="test-ECMAScript_for_XML_(E4X)"><span><a class="anchor" href="#test-ECMAScript_for_XML_(E4X)">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Archive/Web/E4X">ECMAScript for XML (E4X)</a> <a href="https://developer.mozilla.org/en-US/docs/Archive/Web/E4X" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof &lt;foo/&gt; === &quot;xml&quot;;
@@ -11650,6 +11728,7 @@ return typeof &lt;foo/&gt; === &quot;xml&quot;;
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr significance="1"><td id="test-for_each..in_loops"><span><a class="anchor" href="#test-for_each..in_loops">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for_each...in">&quot;for each..in&quot; loops</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for_each...in" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var str = &apos;&apos;;
@@ -11797,6 +11876,7 @@ return str === &quot;foobarbaz&quot;;
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr significance="1"><td id="test-Sharp_variables"><span><a class="anchor" href="#test-Sharp_variables">&#xA7;</a><a href="https://developer.mozilla.org/en/Sharp_variables_in_JavaScript">Sharp variables</a> <a href="https://developer.mozilla.org/en-US/docs/Archive/Web/Sharp_variables_in_JavaScript" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var arr = #1=[1, #1#, 3];
@@ -11941,8 +12021,9 @@ return arr[1] === arr;
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
-<tr><th colspan="141" class="separator"></th>
+<tr><th colspan="142" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Iterator"><span><a class="anchor" href="#test-Iterator">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators">Iterator</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 /* global Iterator */
@@ -12118,6 +12199,7 @@ catch(e) {
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr significance="1"><td id="test-__iterator__"><span><a class="anchor" href="#test-__iterator__">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators">__iterator__</a></span><script data-source="function () {
 try {
@@ -12301,6 +12383,7 @@ catch(e) {
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr significance="1"><td id="test-Generators_(JS_1.8)"><span><a class="anchor" href="#test-Generators_(JS_1.8)">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators#Generators">Generators (JS 1.8)</a></span><script type="application/javascript;version=1.8" data-source="global.test((function () {
 try {
@@ -12483,6 +12566,7 @@ global.test((function () {
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr significance="1"><td id="test-Generator_comprehensions_(JS_1.8_style)"><span><a class="anchor" href="#test-Generator_comprehensions_(JS_1.8_style)">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators#Generator_expressions">Generator comprehensions (JS 1.8 style)</a></span><script data-source="
 var obj = { 2: true, &quot;foo&quot;: true, 4: true };
@@ -12628,6 +12712,7 @@ return g.next() === 4 &amp;&amp; g.next() === 8;
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr significance="0.5"><td id="test-Generator_comprehensions_(ES_draft_style)"><span><a class="anchor" href="#test-Generator_comprehensions_(ES_draft_style)">&#xA7;</a><a href="http://wiki.ecmascript.org/doku.php?id=harmony:array_comprehensions">Generator comprehensions (ES draft style)</a></span><script data-source="
 var iterator = (for (a of [1,2]) a + 4);
@@ -12778,8 +12863,9 @@ return passed;
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
-<tr><th colspan="141" class="separator"></th>
+<tr><th colspan="142" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-RegExp_x_flag"><span><a class="anchor" href="#test-RegExp_x_flag">&#xA7;</a>RegExp &quot;x&quot; flag</span><script data-source="function () {
 try {
@@ -12939,6 +13025,7 @@ try {
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr significance="1"><td id="test-Callable_RegExp"><span><a class="anchor" href="#test-Callable_RegExp">&#xA7;</a>Callable RegExp</span><script data-source="
 return /\\w/(&quot;x&quot;)[0] === &quot;x&quot;;
@@ -13082,6 +13169,7 @@ return /\\w/(&quot;x&quot;)[0] === &quot;x&quot;;
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr significance="1"><td id="test-RegExp_named_groups"><span><a class="anchor" href="#test-RegExp_named_groups">&#xA7;</a>RegExp named groups</span><script data-source="
 return /(?P&lt;name&gt;a)(?P=name)/.test(&quot;aa&quot;) &amp;&amp;
@@ -13226,8 +13314,9 @@ return /(?P&lt;name&gt;a)(?P=name)/.test(&quot;aa&quot;) &amp;&amp;
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
-<tr><th colspan="141" class="separator"></th>
+<tr><th colspan="142" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-String.prototype.quote"><span><a class="anchor" href="#test-String.prototype.quote">&#xA7;</a>String.prototype.quote <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/quote" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () { return typeof String.prototype.quote === &apos;function&apos; }">test(
 function () { return typeof String.prototype.quote === 'function' }())</script></td>
@@ -13369,6 +13458,7 @@ function () { return typeof String.prototype.quote === 'function' }())</script><
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr significance="1"><td id="test-String.prototype.replace_flags"><span><a class="anchor" href="#test-String.prototype.replace_flags">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace">String.prototype.replace flags</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Firefox-specific_notes" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () { return &apos;foofoo&apos;.replace(&apos;foo&apos;, &apos;bar&apos;, &apos;g&apos;) === &apos;barbar&apos; }">test(
 function () { return 'foofoo'.replace('foo', 'bar', 'g') === 'barbar' }())</script></td>
@@ -13510,8 +13600,9 @@ function () { return 'foofoo'.replace('foo', 'bar', 'g') === 'barbar' }())</scri
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
-<tr><th colspan="141" class="separator"></th>
+<tr><th colspan="142" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Date.prototype.toLocaleFormat"><span><a class="anchor" href="#test-Date.prototype.toLocaleFormat">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleFormat">Date.prototype.toLocaleFormat</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleFormat" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () { return typeof Date.prototype.toLocaleFormat === &apos;function&apos; }">test(
 function () { return typeof Date.prototype.toLocaleFormat === 'function' }())</script></td>
@@ -13653,6 +13744,7 @@ function () { return typeof Date.prototype.toLocaleFormat === 'function' }())</s
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr significance="1"><td id="test-Date.parse_produces_NaN_for_invalid_dates"><span><a class="anchor" href="#test-Date.parse_produces_NaN_for_invalid_dates">&#xA7;</a>Date.parse produces NaN for invalid dates</span><script data-source="function () {
 var brokenOnFirefox = !isNaN(Date.parse(&apos;2012-04-04T24:00:00.500Z&apos;));
@@ -13804,8 +13896,9 @@ return !brokenOnFirefox && !brokenOnIE10 && !brokenOnChrome;
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
-<tr><th colspan="141" class="separator"></th>
+<tr><th colspan="142" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Object.prototype.watch"><span><a class="anchor" href="#test-Object.prototype.watch">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/watch">Object.prototype.watch</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/watch" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () { return typeof Object.prototype.watch === &apos;function&apos; }">test(
 function () { return typeof Object.prototype.watch === 'function' }())</script></td>
@@ -13947,6 +14040,7 @@ function () { return typeof Object.prototype.watch === 'function' }())</script><
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr significance="1"><td id="test-Object.prototype.unwatch"><span><a class="anchor" href="#test-Object.prototype.unwatch">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/unwatch">Object.prototype.unwatch</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/unwatch" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () { return typeof Object.prototype.unwatch === &apos;function&apos; }">test(
 function () { return typeof Object.prototype.unwatch === 'function' }())</script></td>
@@ -14088,6 +14182,7 @@ function () { return typeof Object.prototype.unwatch === 'function' }())</script
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr significance="1"><td id="test-Object.prototype.eval"><span><a class="anchor" href="#test-Object.prototype.eval">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/eval">Object.prototype.eval</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/eval" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () { return typeof Object.prototype.eval === &apos;function&apos; }">test(
 function () { return typeof Object.prototype.eval === 'function' }())</script></td>
@@ -14229,6 +14324,7 @@ function () { return typeof Object.prototype.eval === 'function' }())</script></
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr significance="1"><td id="test-Object.observe"><span><a class="anchor" href="#test-Object.observe">&#xA7;</a><a href="https://arv.github.io/ecmascript-object-observe/">Object.observe</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/observe" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return typeof Object.observe === &apos;function&apos;;
@@ -14372,8 +14468,9 @@ return typeof Object.observe === &apos;function&apos;;
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
-<tr><th colspan="141" class="separator"></th>
+<tr><th colspan="142" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-error_stack"><span><a class="anchor" href="#test-error_stack">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack">error &quot;stack&quot;</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 try {
@@ -14527,6 +14624,7 @@ try {
 <td class="yes obsolete" data-browser="opera_mobile69">Yes</td>
 <td class="yes" data-browser="opera_mobile70">Yes</td>
 <td class="yes" data-browser="opera_mobile71">Yes</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr significance="1"><td id="test-error_lineNumber"><span><a class="anchor" href="#test-error_lineNumber">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/lineNumber">error &quot;lineNumber&quot;</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/lineNumber" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return &apos;lineNumber&apos; in new Error();
@@ -14672,6 +14770,7 @@ return 'lineNumber' in new Error();
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr significance="1"><td id="test-error_columnNumber"><span><a class="anchor" href="#test-error_columnNumber">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/columnNumber">error &quot;columnNumber&quot;</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/columnNumber" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return &apos;columnNumber&apos; in new Error();
@@ -14817,6 +14916,7 @@ return 'columnNumber' in new Error();
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr significance="1"><td id="test-error_fileName"><span><a class="anchor" href="#test-error_fileName">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/fileName">error &quot;fileName&quot;</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/fileName" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return &apos;fileName&apos; in new Error();
@@ -14962,6 +15062,7 @@ return 'fileName' in new Error();
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr significance="1"><td id="test-error_description"><span><a class="anchor" href="#test-error_description">&#xA7;</a><a href="http://msdn.microsoft.com/en-us/library/ie/dww52sbt(v=vs.94).aspx">error &quot;description&quot;</a></span><script data-source="function () {
 return &apos;description&apos; in new Error();
@@ -15107,8 +15208,9 @@ return 'description' in new Error();
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
-<tr><th colspan="141" class="separator"></th>
+<tr><th colspan="142" class="separator"></th>
 </tr>
 <tr class="supertest" significance="1"><td id="test-global"><span><a class="anchor" href="#test-global">&#xA7;</a>global</span></td>
 <td class="tally obsolete" data-browser="konq4_13" data-tally="0">0/2</td>
@@ -15249,6 +15351,7 @@ return 'description' in new Error();
 <td class="tally obsolete" data-browser="opera_mobile69" data-tally="0">0/2</td>
 <td class="tally" data-browser="opera_mobile70" data-tally="0">0/2</td>
 <td class="tally" data-browser="opera_mobile71" data-tally="0">0/2</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0.5">1/2</td>
 </tr>
 <tr class="subtest" data-parent="global" id="test-global_global_global_property_is_global_object"><td><span><a class="anchor" href="#test-global_global_global_property_is_global_object">&#xA7;</a>&quot;global&quot; global property is global object</span><script data-source="
 var actualGlobal = Function(&apos;return this&apos;)();
@@ -15394,6 +15497,7 @@ return typeof global === &apos;object&apos; &amp;&amp; global &amp;&amp; global 
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="global" id="test-global_global_global_property_has_correct_property_descriptor"><td><span><a class="anchor" href="#test-global_global_global_property_has_correct_property_descriptor">&#xA7;</a>&quot;global&quot; global property has correct property descriptor</span><script data-source="
 var actualGlobal = Function(&apos;return this&apos;)();
@@ -15544,6 +15648,7 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr significance="1"><td id="test-Proxy_ownKeys_handler,_duplicate_keys_for_non-extensible_targets_(ES_2017_semantics)"><span><a class="anchor" href="#test-Proxy_ownKeys_handler,_duplicate_keys_for_non-extensible_targets_(ES_2017_semantics)">&#xA7;</a><a href="https://github.com/tc39/ecma262/pull/594">Proxy &quot;ownKeys&quot; handler, duplicate keys for non-extensible targets (ES 2017 semantics)</a><a href="#proxy-duplictate-ownkeys-updated-note"><sup>[11]</sup></a></span><script data-source="
 var P = new Proxy(Object.preventExtensions(Object.defineProperty({a:1}, &quot;b&quot;, {value:1})), {
@@ -15692,6 +15797,7 @@ return Object.getOwnPropertyNames(P) + &apos;&apos; === &quot;a,a,b,b&quot;;
 <td class="no obsolete" data-browser="opera_mobile69">No</td>
 <td class="no" data-browser="opera_mobile70">No</td>
 <td class="no" data-browser="opera_mobile71">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 </tbody>
       </table>


### PR DESCRIPTION
# Summary

Hermes is a JavaScript engine optimised for React Native which is used as default JS engine for react native now.  Also there is a bundled Hermes version along with each react native release and can find under assets.

https://github.com/facebook/react-native/releases/tag/v0.70.3

React native uses Hermes and [metro](https://facebook.github.io/metro/) transpliles the code using [metro-react-native-babel-preset](https://www.npmjs.com/package/metro-react-native-babel-preset), so ECMAScript support in react native is not same as Hermes version.

As @ljharb pointed out previously https://github.com/kangax/compat-table/pull/1836#issuecomment-1297179893
> plenty of people still run RN with v8, as there’s lots of tradeoffs to using one engine or the other. Wouldn’t calling Hermes “React Native” imply the wrong thing?

Calling just React native is confusing as RN can be used with JSC, V8 also. So making it clear by calling it `React Native 0.70.3 (Hermes + Babel)`

This PR,

1. Adding support to run react native bundler in hermes.js. I created a metro proxy script for this use case and is available here - [rn-bundle-proxy](https://github.com/jacdebug/rn-bundle-proxy). Run tests by `node hermes.js --hermes-bin ./hermes-runtime-darwin-v0.70.3/destroot/bin/hermes  -r "http://localhost:3006?dev=true&platform=ios"`
3. Leave existing Hermes config as it is.
4. Add new environments for react native.
5. Update data
6. Run build

Ref:
- https://reactnative.dev/blog/2022/07/08/hermes-as-the-default
- https://github.com/facebook/react-native/releases


## Test

Ran `npx http-server` after build and loaded in browser.

<img width="1506" alt="image" src="https://user-images.githubusercontent.com/430289/199776552-f536ef32-a2bc-4f50-8e0b-3217462e6835.png">

## What is bundled Hermes and how we can identify versions
React Native uses Hermes as default JS engine now so as with each release of react-native there is a Hermes release, `bundled Hermes` refers to that. Hermes uses different version strings to identify that like below.

Bundled Hermes version string: `Hermes release version: for RN 0.70.3`
![image](https://user-images.githubusercontent.com/430289/200047538-4c383c31-5edb-466e-971f-701f32a2410a.png)

Previous standalone Hermes version string - `Hermes release version: 0.12.0`
![image](https://user-images.githubusercontent.com/430289/200051181-78a394a1-4cbb-4074-bd80-8d624475d52f.png)


## Other options considered

Extending Hermes to react native but had multiple issues with it.  https://github.com/kangax/compat-table/pull/1836
- Hermes itself has not all data points like esnext, es2016.
- Hermes is showing under server runtime but RN needs to be under mobile.


