### PR TITLE
Update data for hermes 0.7.0  and 0_12_0

### DIFF
--- a/data-es2016plus.js
+++ b/data-es2016plus.js
@@ -4806,6 +4806,8 @@ exports.tests = [
           safaritp: true,
           duktape2_0: false,
           graalvm21_3_3: true,
+          hermes0_7_0: false,
+          hermes0_12_0: true,
           reactnative0_70_3: true,
           rhino1_7_13: false
         }
@@ -5423,6 +5425,7 @@ exports.tests = [
           duktape2_0: false,
           graalvm19: false,
           graalvm20: true,
+          hermes0_7_0: false,
           reactnative0_70_3: true,
           rhino1_7_13: false
         }
@@ -5457,6 +5460,7 @@ exports.tests = [
           duktape2_0: false,
           graalvm19: false,
           graalvm20: true,
+          hermes0_7_0: false,
           reactnative0_70_3: true,
           rhino1_7_13: false
         }
@@ -5487,6 +5491,7 @@ exports.tests = [
           duktape2_0: false,
           graalvm19: false,
           graalvm20: true,
+          hermes0_7_0: false,
           reactnative0_70_3: true,
           rhino1_7_13: false
         }
@@ -5521,6 +5526,7 @@ exports.tests = [
           graalvm20: false,
           graalvm20_3: true,
           typescript3_8corejs3: false,
+          hermes0_7_0: false,
           reactnative0_70_3: true,
           rhino1_7_13: false
         }
@@ -5556,6 +5562,7 @@ exports.tests = [
           graalvm20: false,
           graalvm20_3: true,
           typescript3_8corejs3: false,
+          hermes0_7_0: false,
           reactnative0_70_3: true,
           rhino1_7_13: false
         }
@@ -5582,6 +5589,7 @@ exports.tests = [
           duktape2_0: false,
           graalvm19: false,
           graalvm20: true,
+          hermes0_7_0: false,
           reactnative0_70_3: true,
           rhino1_7_13: false
         }
@@ -5619,6 +5627,7 @@ exports.tests = [
           duktape2_0: false,
           graalvm19: false,
           graalvm20: true,
+          hermes0_7_0: false,
           reactnative0_70_3: true,
           rhino1_7_13: false
         }
@@ -5655,6 +5664,7 @@ exports.tests = [
           duktape2_0: false,
           graalvm21_3_3: false,
           graalvm22_2: true,
+          hermes0_7_0: false,
           reactnative0_70_3: true
         }
       },
@@ -5683,6 +5693,7 @@ exports.tests = [
           duktape2_0: false,
           graalvm19: false,
           graalvm20: true,
+          hermes0_7_0: false,
           reactnative0_70_3: true,
           rhino1_7_13: false
         }
@@ -5708,6 +5719,7 @@ exports.tests = [
           duktape2_0: false,
           graalvm19: false,
           graalvm20: true,
+          hermes0_7_0: false,
           reactnative0_70_3: true,
           rhino1_7_13: false
         }
@@ -5752,6 +5764,7 @@ exports.tests = [
           safaritp: true,
           graalvm20: false,
           graalvm20_1: true,
+          hermes0_7_0: false,
           reactnative0_70_3: false,
           rhino1_7_13: false
         }
@@ -5787,6 +5800,7 @@ exports.tests = [
           safaritp: true,
           graalvm20: false,
           graalvm20_1: true,
+          hermes0_7_0: false,
           reactnative0_70_3: false,
           rhino1_7_13: false
         }
@@ -5825,6 +5839,7 @@ exports.tests = [
           safaritp: true,
           graalvm20: false,
           graalvm20_1: true,
+          hermes0_7_0: false,
           reactnative0_70_3: false,
           rhino1_7_13: false
         }
@@ -5863,6 +5878,7 @@ exports.tests = [
           safaritp: true,
           graalvm20: false,
           graalvm20_1: true,
+          hermes0_7_0: false,
           reactnative0_70_3: false,
           rhino1_7_13: false
         }
@@ -5899,6 +5915,7 @@ exports.tests = [
       duktape2_0: false,
       graalvm21_3_3: graalvm.esStagingFlag,
       graalvm22_2: true,
+      hermes0_7_0: false,
       reactnative0_70_3: true,
       rhino1_7_13: false
     }
@@ -5949,6 +5966,7 @@ exports.tests = [
           graalvm21: graalvm.es2022flag,
           graalvm21_3_3: graalvm.esStagingFlag,
           graalvm22_2: true,
+          hermes0_7_0: false,
           reactnative0_70_3: false,
           rhino1_7_13: false
         }
@@ -5991,6 +6009,7 @@ exports.tests = [
           graalvm21: graalvm.es2022flag,
           graalvm21_3_3: graalvm.esStagingFlag,
           graalvm22_2: true,
+          hermes0_7_0: false,
           reactnative0_70_3: false,
           rhino1_7_13: false
         }
@@ -6049,6 +6068,7 @@ exports.tests = [
           graalvm21: graalvm.es2022flag,
           graalvm21_3_3: graalvm.esStagingFlag,
           graalvm22_2: true,
+          hermes0_7_0: false,
           reactnative0_70_3: false,
           rhino1_7_13: false
         }
@@ -6087,6 +6107,8 @@ exports.tests = [
           duktape2_0: false,
           graalvm21_3_3: graalvm.esStagingFlag,
           graalvm22_2: true,
+          hermes0_7_0: false,
+          hermes0_12_0: true,
           reactnative0_70_3: true,
           rhino1_7_13: false
         }
@@ -6122,6 +6144,8 @@ exports.tests = [
           duktape2_0: false,
           graalvm21_3_3: graalvm.esStagingFlag,
           graalvm22_2: true,
+          hermes0_7_0: false,
+          hermes0_12_0: true,
           reactnative0_70_3: true,
           rhino1_7_13: false
         }
@@ -6167,6 +6191,7 @@ exports.tests = [
       duktape2_0: false,
       graalvm21_3_3: graalvm.esStagingFlag,
       graalvm22_2: true,
+      hermes0_7_0: false,
       reactnative0_70_3: false,
       rhino1_7_13: false
     },
@@ -6197,6 +6222,8 @@ exports.tests = [
           duktape2_0: false,
           graalvm21_3_3: false,
           graalvm22_2: true,
+          hermes0_7_0: false,
+          hermes0_12_0: true,
           reactnative0_70_3: true,
           rhino1_7_14: false,
         }
@@ -6220,6 +6247,7 @@ exports.tests = [
           safari15: true,
           duktape2_0: true,
           graalvm21_3_3: true,
+          hermes0_7_0: true,
           reactnative0_70_3: true,
           rhino1_7_14: true,
         }
@@ -6244,6 +6272,8 @@ exports.tests = [
           duktape2_0: false,
           graalvm21_3_3: false,
           graalvm22_2: true,
+          hermes0_7_0: false,
+          hermes0_12_0: true,
           reactnative0_70_3: true,
           rhino1_7_14: false,
         }
@@ -6267,6 +6297,7 @@ exports.tests = [
           safari15: true,
           duktape2_0: true,
           graalvm21_3_3: true,
+          hermes0_7_0: true,
           reactnative0_70_3: true,
           rhino1_7_14: true,
         }
@@ -6291,6 +6322,8 @@ exports.tests = [
           duktape2_0: false,
           graalvm21_3_3: false,
           graalvm22_2: true,
+          hermes0_7_0: false,
+          hermes0_12_0: true,
           reactnative0_70_3: true,
           rhino1_7_14: false,
         }
@@ -6314,6 +6347,7 @@ exports.tests = [
           safari15: true,
           duktape2_0: true,
           graalvm21_3_3: true,
+          hermes0_7_0: true,
           reactnative0_70_3: true,
           rhino1_7_14: true,
         }
@@ -6338,6 +6372,8 @@ exports.tests = [
           duktape2_0: false,
           graalvm21_3_3: false,
           graalvm22_2: true,
+          hermes0_7_0: false,
+          hermes0_12_0: true,
           reactnative0_70_3: true,
           rhino1_7_14: false,
         }
@@ -6361,6 +6397,7 @@ exports.tests = [
           safari15: true,
           duktape2_0: true,
           graalvm21_3_3: true,
+          hermes0_7_0: true,
           reactnative0_70_3: true,
           rhino1_7_14: true,
         }
@@ -6385,6 +6422,8 @@ exports.tests = [
           duktape2_0: false,
           graalvm21_3_3: false,
           graalvm22_2: true,
+          hermes0_7_0: false,
+          hermes0_12_0: true,
           reactnative0_70_3: true,
           rhino1_7_14: false,
         }
@@ -6408,6 +6447,7 @@ exports.tests = [
           safari15: true,
           duktape2_0: true,
           graalvm21_3_3: true,
+          hermes0_7_0: true,
           reactnative0_70_3: true,
           rhino1_7_14: true,
         }
@@ -6432,6 +6472,8 @@ exports.tests = [
           duktape2_0: false,
           graalvm21_3_3: false,
           graalvm22_2: true,
+          hermes0_7_0: false,
+          hermes0_12_0: true,
           reactnative0_70_3: true,
           rhino1_7_14: false,
         }
@@ -6455,6 +6497,7 @@ exports.tests = [
           safari15: true,
           duktape2_0: true,
           graalvm21_3_3: true,
+          hermes0_7_0: true,
           reactnative0_70_3: true,
           rhino1_7_14: true,
         }
@@ -6479,6 +6522,8 @@ exports.tests = [
           duktape2_0: false,
           graalvm21_3_3: false,
           graalvm22_2: true,
+          hermes0_7_0: false,
+          hermes0_12_0: true,
           reactnative0_70_3: true,
           rhino1_7_14: false,
         }
@@ -6502,6 +6547,7 @@ exports.tests = [
           safari15: true,
           duktape2_0: true,
           graalvm21_3_3: true,
+          hermes0_7_0: true,
           reactnative0_70_3: true,
           rhino1_7_14: true,
         }
@@ -6526,6 +6572,7 @@ exports.tests = [
           duktape2_0: false,
           graalvm21_3_3: false,
           graalvm22_2: true,
+          hermes0_7_0: false,
           reactnative0_70_3: false,
           rhino1_7_14: false,
         }
@@ -6549,6 +6596,7 @@ exports.tests = [
           safari15: true,
           duktape2_0: false,
           graalvm21_3_3: true,
+          hermes0_7_0: false,
           reactnative0_70_3: false,
           rhino1_7_14: false,
         }
@@ -6574,6 +6622,7 @@ exports.tests = [
           chrome90: true,
           graalvm21_3_3: graalvm.esStagingFlag,
           graalvm22_2: true,
+          hermes0_7_0: false,
           reactnative0_70_3: false
         }
       },
@@ -6606,6 +6655,7 @@ exports.tests = [
           chrome90: false,
           graalvm21_3_3: graalvm.esStagingFlag,
           graalvm22_2: true,
+          hermes0_7_0: false,
           reactnative0_70_3: false
         }
       }
@@ -6648,6 +6698,8 @@ exports.tests = [
           duktape2_0: false,
           graalvm21_3_3: false,
           graalvm22_2: graalvm.esStagingFlag,
+          hermes0_7_0: false,
+          hermes0_12_0: true,
           reactnative0_70_3: true,
           rhino1_7_13: false
         }
@@ -6679,6 +6731,8 @@ exports.tests = [
           duktape2_0: false,
           graalvm21_3_3: false,
           graalvm22_2: graalvm.esStagingFlag,
+          hermes0_7_0: false,
+          hermes0_12_0: true,
           reactnative0_70_3: true,
           rhino1_7_13: false
         }
@@ -6715,6 +6769,7 @@ exports.tests = [
       babel7corejs3: false,
       typescript3_2corejs3: false,
       closure: false,
+      hermes0_7_0: true,
       reactnative0_70_3: true,
       rhino1_7_13: false
     }

--- a/data-es5.js
+++ b/data-es5.js
@@ -974,6 +974,7 @@ exports.tests = [
         safari4: true,
         safari15: true,
         graalvm21_3_3: true,
+        hermes0_7_0: true,
         reactnative0_70_3: true
       }
     }
@@ -1079,6 +1080,7 @@ exports.tests = [
       firefox3: true,
       opera11: true,
       graalvm21_3_3: true,
+      hermes0_7_0: true,
       reactnative0_70_3: true
     }
   },
@@ -1427,6 +1429,7 @@ exports.tests = [
       edge80: true,
       duktape2_0: true,
       graalvm21_3_3: true,
+      hermes0_7_0: true,
       reactnative0_70_3: true,
       rhino1_7_14: true,
     }
@@ -1459,6 +1462,7 @@ exports.tests = [
       edge80: true,
       duktape2_0: true,
       graalvm21_3_3: true,
+      hermes0_7_0: true,
       reactnative0_70_3: true,
       rhino1_7_14: true,
     }
@@ -1486,6 +1490,7 @@ exports.tests = [
       safari11: true,
       duktape2_0: true,
       graalvm21_3_3: true,
+      hermes0_7_0: true,
       reactnative0_70_3: true,
       rhino1_7_14: true,
     }

--- a/data-es6.js
+++ b/data-es6.js
@@ -19759,6 +19759,7 @@ exports.tests = [
         firefox70: true,
         firefox99: true,
         graalvm21_3_3: true,
+        hermes0_7_0: true,
         reactnative0_70_3: true
       }
     },
@@ -21783,6 +21784,7 @@ exports.tests = [
         safari5_1: true,
         safari15: true,
         graalvm21_3_3: true,
+        hermes0_7_0: true,
         reactnative0_70_3: true
       }
     },
@@ -23013,7 +23015,7 @@ exports.tests = [
         graalvm19: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
-        hermes0_7_0: hermes.class,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }

--- a/data-esintl.js
+++ b/data-esintl.js
@@ -29,6 +29,7 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
+        hermes0_7_0: false,
         reactnative0_70_3: true,
         rhino1_7_13: false
       }
@@ -50,6 +51,7 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
+        hermes0_7_0: false,
         reactnative0_70_3: true,
         rhino1_7_13: false
       }
@@ -78,6 +80,7 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
+        hermes0_7_0: false,
         reactnative0_70_3: true,
         rhino1_7_13: false
       }
@@ -100,6 +103,7 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
+        hermes0_7_0: false,
         reactnative0_70_3: true,
         rhino1_7_13: false
       }
@@ -122,6 +126,7 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
+        hermes0_7_0: false,
         reactnative0_70_3: true,
         rhino1_7_13: false
       }
@@ -186,6 +191,7 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
+        hermes0_7_0: false,
         reactnative0_70_3: true,
         rhino1_7_13: false
       }
@@ -221,6 +227,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: false,
         graalvm20_1: true,
+        hermes0_7_0: false,
         reactnative0_70_3: true,
         rhino1_7_13: true
       }
@@ -249,6 +256,7 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
+        hermes0_7_0: false,
         reactnative0_70_3: true,
         rhino1_7_13: false
       }
@@ -277,6 +285,7 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
+        hermes0_7_0: false,
         reactnative0_70_3: true,
         rhino1_7_13: false
       }
@@ -305,6 +314,7 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
+        hermes0_7_0: false,
         reactnative0_70_3: true,
         rhino1_7_13: false
       }
@@ -326,6 +336,7 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
+        hermes0_7_0: false,
         reactnative0_70_3: true,
         rhino1_7_13: false
       }
@@ -348,6 +359,7 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
+        hermes0_7_0: false,
         reactnative0_70_3: true,
         rhino1_7_13: false
       }
@@ -370,6 +382,7 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
+        hermes0_7_0: false,
         reactnative0_70_3: true,
         rhino1_7_13: false
       }
@@ -434,6 +447,7 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
+        hermes0_7_0: false,
         reactnative0_70_3: true,
         rhino1_7_13: false
       }
@@ -468,6 +482,7 @@ exports.tests = [
         safari14: true,
         duktape2_0: false,
         graalvm19: true,
+        hermes0_7_0: false,
         reactnative0_70_3: true,
         rhino1_7_13: true
       }
@@ -496,6 +511,7 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
+        hermes0_7_0: false,
         reactnative0_70_3: true,
         rhino1_7_13: false
       }
@@ -518,6 +534,7 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
+        hermes0_7_0: false,
         reactnative0_70_3: true,
         rhino1_7_13: false
       }
@@ -540,6 +557,7 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
+        hermes0_7_0: false,
         reactnative0_70_3: true,
         rhino1_7_13: false
       }
@@ -604,6 +622,7 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
+        hermes0_7_0: false,
         reactnative0_70_3: true,
         rhino1_7_13: false
       }
@@ -638,6 +657,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: false,
         graalvm20_1: true,
+        hermes0_7_0: false,
         reactnative0_70_3: true,
         rhino1_7_13: true
       }
@@ -667,6 +687,7 @@ exports.tests = [
         ios7: false,
         duktape2_0: false,
         graalvm19: true,
+        hermes0_7_0: false,
         reactnative0_70_3: true,
         rhino1_7_13: false
       }
@@ -696,6 +717,7 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
+        hermes0_7_0: false,
         reactnative0_70_3: true,
         rhino1_7_13: false
       }
@@ -728,6 +750,7 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
+        hermes0_7_0: true,
         reactnative0_70_3: true,
         rhino1_7_13: true
       }
@@ -760,6 +783,7 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
+        hermes0_7_0: true,
         reactnative0_70_3: true,
         rhino1_7_13: true
       }
@@ -792,6 +816,7 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
+        hermes0_7_0: true,
         reactnative0_70_3: true,
         rhino1_7_13: true
       }
@@ -824,6 +849,7 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
+        hermes0_7_0: true,
         reactnative0_70_3: true,
         rhino1_7_13: true
       }
@@ -856,6 +882,7 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
+        hermes0_7_0: true,
         reactnative0_70_3: true,
         rhino1_7_13: true
       }
@@ -888,6 +915,7 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
+        hermes0_7_0: true,
         reactnative0_70_3: true,
         rhino1_7_13: true
       }
@@ -920,6 +948,7 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
+        hermes0_7_0: true,
         reactnative0_70_3: true,
         rhino1_7_13: true
       }

--- a/data-esnext.js
+++ b/data-esnext.js
@@ -35,6 +35,7 @@ exports.tests = [
     chrome77: false,
     duktape2_0: false,
     graalvm19: false,
+    hermes0_7_0: false,
     reactnative0_70_3: false,
     rhino1_7_13: false
   }
@@ -68,6 +69,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm19: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -93,6 +95,7 @@ exports.tests = [
     chrome77: false,
     duktape2_0: false,
     graalvm19: false,
+    hermes0_7_0: false,
     reactnative0_70_3: false,
     rhino1_7_13: false
   }
@@ -123,6 +126,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm19: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -151,6 +155,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm19: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -174,6 +179,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm19: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -197,6 +203,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm19: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -228,6 +235,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: false,
         graalvm21_3_3: graalvm.newSetMethodsFlag,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -252,6 +260,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: false,
         graalvm21_3_3: graalvm.newSetMethodsFlag,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -275,6 +284,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: false,
         graalvm21_3_3: graalvm.newSetMethodsFlag,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -298,6 +308,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: false,
         graalvm21_3_3: graalvm.newSetMethodsFlag,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -319,6 +330,7 @@ exports.tests = [
         graalvm19: false,
         graalvm20_1: graalvm.es2021flag,
         graalvm21_3_3: graalvm.newSetMethodsFlag,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -339,6 +351,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: false,
         graalvm21_3_3: graalvm.newSetMethodsFlag,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -359,6 +372,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: false,
         graalvm21_3_3: graalvm.newSetMethodsFlag,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -387,6 +401,7 @@ exports.tests = [
         safari12: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -407,6 +422,7 @@ exports.tests = [
         safari12: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -445,6 +461,7 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
+        hermes0_7_0: true,
         reactnative0_70_3: true
       }
     },
@@ -475,6 +492,7 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
+        hermes0_7_0: true,
         reactnative0_70_3: true
       }
     }
@@ -505,6 +523,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -529,6 +548,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -555,6 +575,7 @@ exports.tests = [
     chrome77: false,
     duktape2_0: false,
     graalvm21_3_3: false,
+    hermes0_7_0: false,
     reactnative0_70_3: false,
     rhino1_7_13: false
   }
@@ -581,6 +602,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -603,6 +625,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -626,6 +649,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -654,6 +678,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -674,6 +699,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -694,6 +720,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -714,6 +741,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -734,6 +762,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -754,6 +783,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -774,6 +804,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -796,6 +827,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -816,6 +848,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -836,6 +869,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -856,6 +890,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -876,6 +911,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -897,6 +933,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -917,6 +954,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -937,6 +975,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -959,6 +998,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -991,6 +1031,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -1023,6 +1064,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -1055,6 +1097,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -1083,6 +1126,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -1111,6 +1155,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -1133,6 +1178,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -1161,6 +1207,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -1183,6 +1230,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -1211,6 +1259,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -1234,6 +1283,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -1262,6 +1312,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -1284,6 +1335,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -1306,6 +1358,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -1334,6 +1387,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -1356,6 +1410,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -1376,6 +1431,7 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }

--- a/data-non-standard.js
+++ b/data-non-standard.js
@@ -42,6 +42,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs", note_html: "The feature has to be enabled via <code>--experimental-options --js.simdjs</code> flag"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -66,6 +67,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -90,6 +92,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -114,6 +117,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -138,6 +142,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -162,6 +167,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -186,6 +192,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -210,6 +217,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -234,6 +242,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -258,6 +267,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -282,6 +292,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -308,6 +319,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -334,6 +346,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -360,6 +373,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -386,6 +400,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -412,6 +427,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -438,6 +454,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -464,6 +481,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -490,6 +508,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -516,6 +535,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -542,6 +562,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -568,6 +589,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -594,6 +616,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -620,6 +643,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -646,6 +670,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -672,6 +697,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -698,6 +724,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -723,6 +750,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -748,6 +776,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -773,6 +802,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -799,6 +829,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -826,6 +857,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -852,6 +884,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -879,6 +912,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -905,6 +939,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -931,6 +966,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -957,6 +993,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -983,6 +1020,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -1009,6 +1047,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -1035,6 +1074,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -1061,6 +1101,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -1087,6 +1128,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -1113,6 +1155,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -1139,6 +1182,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -1165,6 +1209,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -1191,6 +1236,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -1217,6 +1263,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -1243,6 +1290,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -1268,6 +1316,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -1293,6 +1342,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -1318,6 +1368,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -1344,6 +1395,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -1370,6 +1422,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -1396,6 +1449,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -1422,6 +1476,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -1448,6 +1503,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -1472,6 +1528,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -1495,6 +1552,7 @@ exports.tests = [
         firefox74: false,
         opera10_50: false,
         chrome77: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: true,
         duktape2_0: false,
@@ -1523,6 +1581,7 @@ exports.tests = [
         opera10_50: false,
         chrome77: false,
         besen: true,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: true,
         duktape2_0: false,
@@ -1540,6 +1599,7 @@ exports.tests = [
         firefox74: false,
         opera10_50: false,
         chrome77: false,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: true,
         duktape2_0: false,
@@ -1644,6 +1704,7 @@ exports.tests = [
         opera10_50: false,
         chrome77: false,
         besen: null,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false,
         duktape2_0: false,
@@ -1667,6 +1728,7 @@ exports.tests = [
     firefox4: false,
     opera10_50: false,
     chrome77: false,
+    hermes0_7_0: false,
     reactnative0_70_3: false,
     rhino1_7_13: false,
     duktape2_0: false,
@@ -1690,6 +1752,7 @@ exports.tests = [
     safari3_1: true,
     konq4_4: true,
     besen: false,
+    hermes0_7_0: false,
     reactnative0_70_3: false,
     rhino1_7_13: false,
     phantom1_9: true,
@@ -1717,6 +1780,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
+    hermes0_7_0: false,
     reactnative0_70_3: false,
     rhino1_7_13: true,
     phantom1_9: false,
@@ -1743,6 +1807,7 @@ exports.tests = [
     safari3_1: true,
     konq4_4: true,
     besen: false,
+    hermes0_7_0: false,
     reactnative0_70_3: false,
     rhino1_7_13: true,
     phantom1_9: true,
@@ -1772,6 +1837,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
+    hermes0_7_0: false,
     reactnative0_70_3: false,
     rhino1_7_13: false,
     phantom1_9: false,
@@ -1798,6 +1864,7 @@ exports.tests = [
     chrome77: false,
     duktape2_0: false,
     graalvm19: false,
+    hermes0_7_0: false,
     reactnative0_70_3: false,
     rhino1_7_13: false
   },
@@ -1821,6 +1888,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
+    hermes0_7_0: false,
     reactnative0_70_3: false,
     rhino1_7_13: false,
     phantom1_9: false,
@@ -1846,6 +1914,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
+    hermes0_7_0: false,
     reactnative0_70_3: false,
     rhino1_7_13: true,
     phantom1_9: false,
@@ -1876,6 +1945,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
+    hermes0_7_0: false,
     reactnative0_70_3: false,
     rhino1_7_13: true,
     phantom1_9: false,
@@ -1908,6 +1978,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
+    hermes0_7_0: false,
     reactnative0_70_3: false,
     rhino1_7_13: true,
     phantom1_9: false,
@@ -1932,6 +2003,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
+    hermes0_7_0: false,
     reactnative0_70_3: false,
     rhino1_7_13: true,
     phantom1_9: false,
@@ -1961,6 +2033,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
+    hermes0_7_0: false,
     reactnative0_70_3: false,
     rhino1_7_13: true,
     phantom1_9: false,
@@ -1987,6 +2060,7 @@ exports.tests = [
     chrome77: false,
     duktape2_0: false,
     graalvm19: false,
+    hermes0_7_0: false,
     reactnative0_70_3: false,
     rhino1_7_13: false
   }
@@ -2009,6 +2083,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: true,
+    hermes0_7_0: false,
     reactnative0_70_3: false,
     rhino1_7_13: true,
     phantom1_9: false,
@@ -2038,6 +2113,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
+    hermes0_7_0: false,
     reactnative0_70_3: false,
     rhino1_7_13: true,
     phantom1_9: false,
@@ -2067,6 +2143,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
+    hermes0_7_0: false,
     reactnative0_70_3: false,
     rhino1_7_13: true,
     phantom1_9: false,
@@ -2097,6 +2174,7 @@ exports.tests = [
     konq4_4: null,
     konq4_9: false,
     besen: null,
+    hermes0_7_0: false,
     reactnative0_70_3: false,
     rhino1_7_13: false,
     phantom1_9: false,
@@ -2138,6 +2216,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
+    hermes0_7_0: false,
     reactnative0_70_3: false,
     rhino1_7_13: true,
     phantom1_9: false,
@@ -2181,6 +2260,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
+    hermes0_7_0: false,
     reactnative0_70_3: false,
     rhino1_7_13: true,
     phantom1_9: false,
@@ -2234,6 +2314,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
+    hermes0_7_0: false,
     reactnative0_70_3: false,
     rhino1_7_13: true,
     phantom1_9: false,
@@ -2261,6 +2342,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
+    hermes0_7_0: false,
     reactnative0_70_3: false,
     rhino1_7_13: false,
     phantom1_9: false,
@@ -2293,6 +2375,7 @@ exports.tests = [
     chrome77: false,
     duktape2_0: false,
     graalvm19: false,
+    hermes0_7_0: false,
     reactnative0_70_3: false,
     rhino1_7_13: false
   },
@@ -2321,6 +2404,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
+    hermes0_7_0: false,
     reactnative0_70_3: false,
     rhino1_7_13: false,
     phantom1_9: false,
@@ -2343,6 +2427,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
+    hermes0_7_0: false,
     reactnative0_70_3: false,
     rhino1_7_13: false,
     phantom1_9: false,
@@ -2367,6 +2452,7 @@ exports.tests = [
     konq4_4: null,
     konq4_9: true,
     besen: null,
+    hermes0_7_0: false,
     reactnative0_70_3: false,
     rhino1_7_13: false,
     phantom1_9: false,
@@ -2390,6 +2476,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: null,
+    hermes0_7_0: false,
     reactnative0_70_3: false,
     rhino1_7_13: false,
     phantom1_9: false,
@@ -2409,6 +2496,7 @@ exports.tests = [
     opera7_5: false,
     opera10_50: false,
     chrome77: false,
+    hermes0_7_0: false,
     reactnative0_70_3: false,
     rhino1_7_13: false,
     phantom1_9: false,
@@ -2433,6 +2521,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
+    hermes0_7_0: false,
     reactnative0_70_3: false,
     rhino1_7_13: false,
     phantom1_9: false,
@@ -2460,6 +2549,7 @@ exports.tests = [
     chrome77: false,
     konq4_3: true,
     besen: true,
+    hermes0_7_0: false,
     reactnative0_70_3: false,
     rhino1_7_13: true,
     ejs: true,
@@ -2485,6 +2575,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
+    hermes0_7_0: false,
     reactnative0_70_3: false,
     rhino1_7_13: false,
     phantom1_9: false,
@@ -2508,6 +2599,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
+    hermes0_7_0: false,
     reactnative0_70_3: false,
     rhino1_7_13: false,
     phantom1_9: false,
@@ -2530,6 +2622,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: true,
+    hermes0_7_0: false,
     reactnative0_70_3: false,
     rhino1_7_13: false,
     phantom1_9: false,
@@ -2555,6 +2648,7 @@ exports.tests = [
     android5_0: true,
     duktape2_0: false,
     graalvm19: false,
+    hermes0_7_0: false,
     reactnative0_70_3: false,
     rhino1_7_13: false
   },
@@ -2583,6 +2677,7 @@ exports.tests = [
     safari7_1: true,
     konq4_4: false,
     besen: false,
+    hermes0_7_0: true,
     reactnative0_70_3: true,
     rhino1_7_13: false,
     rhino1_7_14: true,
@@ -2612,6 +2707,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
+    hermes0_7_0: false,
     reactnative0_70_3: false,
     rhino1_7_13: true,
     phantom1_9: false,
@@ -2641,6 +2737,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
+    hermes0_7_0: false,
     reactnative0_70_3: false,
     rhino1_7_13: false,
     phantom1_9: false,
@@ -2669,6 +2766,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
+    hermes0_7_0: false,
     reactnative0_70_3: false,
     rhino1_7_13: true,
     phantom1_9: false,
@@ -2695,6 +2793,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
+    hermes0_7_0: false,
     reactnative0_70_3: false,
     rhino1_7_13: false,
     phantom1_9: false,
@@ -2736,6 +2835,7 @@ exports.tests = [
         duktape2_5: false,
         graalvm19: true,
         graalvm21_3_3: graalvm.globalPropertyFlag,
+        hermes0_7_0: false,
         reactnative0_70_3: true,
         rhino1_7_13: false
       }
@@ -2775,6 +2875,7 @@ exports.tests = [
         duktape2_5: false,
         graalvm19: false,
         graalvm21_3_3: graalvm.globalPropertyFlag,
+        hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
       }
@@ -2813,6 +2914,7 @@ exports.tests = [
     duktape2_0: true,
     graalvm19: true,
     graalvm20: false,
+    hermes0_7_0: false,
     reactnative0_70_3: false,
     rhino1_7_13: false
   },

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -25052,7 +25052,7 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">5/5</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="hermes0_7_0" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally" data-browser="hermes0_12_0" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">5/5</td>
@@ -25875,8 +25875,8 @@ return fn?.(...[], 1) === void undefined &amp;&amp; fn?.(...[], ...[]) === void 
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no obsolete" data-browser="hermes0_7_0">No</td>
+<td class="yes" data-browser="hermes0_12_0">Yes</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -29329,8 +29329,8 @@ return new C().x === &apos;x&apos;;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no obsolete" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -29500,8 +29500,8 @@ return new C(42).x() === 42;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no obsolete" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -29668,8 +29668,8 @@ return new C().x() === 42;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no obsolete" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -29836,8 +29836,8 @@ return new C().x() === 42 &amp;&amp; new C().x(null) === void 0;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no obsolete" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -30004,8 +30004,8 @@ return new C().x() === 42 &amp;&amp; new C().x(null) === void 0;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no obsolete" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -30169,8 +30169,8 @@ return new C().x === 42;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no obsolete" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -30493,8 +30493,8 @@ return C.x === &apos;x&apos;;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no obsolete" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -30655,8 +30655,8 @@ return (class X { static name = &quot;name&quot;; }).name === &apos;name&apos;;
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no obsolete" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -30823,8 +30823,8 @@ return new C().x() === 42;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no obsolete" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -30988,8 +30988,8 @@ return C.x === 42;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no obsolete" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -31315,8 +31315,8 @@ return new C().x() === 42;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no obsolete" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -31483,8 +31483,8 @@ return new C().x() === 42;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no obsolete" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -31654,8 +31654,8 @@ return new C().x() === 42 &amp;&amp; y;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no obsolete" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -31825,8 +31825,8 @@ return new C().x() === 42 &amp;&amp; y;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no obsolete" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -31993,8 +31993,8 @@ return A.check(new A) &amp;&amp; !A.check({});
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-js-ecmascript-version-staging-note"><sup>[31]</sup></a></td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no obsolete" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -32322,8 +32322,8 @@ return arr.at(0) === 1
 <td class="no flagged obsolete" data-browser="graalvm21">Flag<a href="#graalvm-js-ecmascript-version-2022-note"><sup>[34]</sup></a></td>
 <td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-js-ecmascript-version-staging-note"><sup>[31]</sup></a></td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no obsolete" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -32492,8 +32492,8 @@ return str.at(0) === &apos;a&apos;
 <td class="no flagged obsolete" data-browser="graalvm21">Flag<a href="#graalvm-js-ecmascript-version-2022-note"><sup>[34]</sup></a></td>
 <td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-js-ecmascript-version-staging-note"><sup>[31]</sup></a></td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no obsolete" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -32678,8 +32678,8 @@ return [
 <td class="no flagged obsolete" data-browser="graalvm21">Flag<a href="#graalvm-js-ecmascript-version-2022-note"><sup>[34]</sup></a></td>
 <td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-js-ecmascript-version-staging-note"><sup>[31]</sup></a></td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no obsolete" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -32838,7 +32838,7 @@ return [
 <td class="tally" data-browser="graalvm21_3_3" data-tally="0" data-flagged-tally="1">0/2</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="hermes0_7_0" data-tally="0">0/2</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/2</td>
+<td class="tally" data-browser="hermes0_12_0" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">2/2</td>
@@ -32999,8 +32999,8 @@ return Object.hasOwn({ x: 2 }, &quot;x&quot;) === true;
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-js-ecmascript-version-staging-note"><sup>[31]</sup></a></td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no obsolete" data-browser="hermes0_7_0">No</td>
+<td class="yes" data-browser="hermes0_12_0">Yes</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -33167,8 +33167,8 @@ try {
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-js-ecmascript-version-staging-note"><sup>[31]</sup></a></td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no obsolete" data-browser="hermes0_7_0">No</td>
+<td class="yes" data-browser="hermes0_12_0">Yes</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -33333,8 +33333,8 @@ return ok;
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-js-ecmascript-version-staging-note"><sup>[31]</sup></a></td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no obsolete" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -33492,8 +33492,8 @@ return ok;
 <td class="tally obsolete" data-browser="graalvm21" data-tally="0">0/16</td>
 <td class="tally" data-browser="graalvm21_3_3" data-tally="0.5" style="background-color:hsl(60,64%,50%)">8/16</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">16/16</td>
-<td class="tally obsolete" data-browser="hermes0_7_0" data-tally="0">0/16</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/16</td>
+<td class="tally obsolete" data-browser="hermes0_7_0" data-tally="0.4375" style="background-color:hsl(52,66%,50%)">7/16</td>
+<td class="tally" data-browser="hermes0_12_0" data-tally="0.875" style="background-color:hsl(105,47%,50%)">14/16</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">16/16</td>
@@ -33655,8 +33655,8 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no obsolete" data-browser="hermes0_7_0">No</td>
+<td class="yes" data-browser="hermes0_12_0">Yes</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -33817,8 +33817,8 @@ return !(&apos;cause&apos; in Error.prototype);
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_12_0">Yes</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -33980,8 +33980,8 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no obsolete" data-browser="hermes0_7_0">No</td>
+<td class="yes" data-browser="hermes0_12_0">Yes</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -34142,8 +34142,8 @@ return !(&apos;cause&apos; in EvalError.prototype);
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_12_0">Yes</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -34305,8 +34305,8 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no obsolete" data-browser="hermes0_7_0">No</td>
+<td class="yes" data-browser="hermes0_12_0">Yes</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -34467,8 +34467,8 @@ return !(&apos;cause&apos; in RangeError.prototype);
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_12_0">Yes</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -34630,8 +34630,8 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no obsolete" data-browser="hermes0_7_0">No</td>
+<td class="yes" data-browser="hermes0_12_0">Yes</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -34792,8 +34792,8 @@ return !(&apos;cause&apos; in ReferenceError.prototype);
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_12_0">Yes</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -34955,8 +34955,8 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no obsolete" data-browser="hermes0_7_0">No</td>
+<td class="yes" data-browser="hermes0_12_0">Yes</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -35117,8 +35117,8 @@ return !(&apos;cause&apos; in SyntaxError.prototype);
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_12_0">Yes</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -35280,8 +35280,8 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no obsolete" data-browser="hermes0_7_0">No</td>
+<td class="yes" data-browser="hermes0_12_0">Yes</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -35442,8 +35442,8 @@ return !(&apos;cause&apos; in TypeError.prototype);
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_12_0">Yes</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -35605,8 +35605,8 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no obsolete" data-browser="hermes0_7_0">No</td>
+<td class="yes" data-browser="hermes0_12_0">Yes</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -35767,8 +35767,8 @@ return !(&apos;cause&apos; in URIError.prototype);
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_12_0">Yes</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -35930,8 +35930,8 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no obsolete" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -36092,8 +36092,8 @@ return !(&apos;cause&apos; in AggregateError.prototype);
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no obsolete" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -36413,8 +36413,8 @@ return new RegExp(&apos;a&apos;, &apos;d&apos;) instanceof RegExp;
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-js-ecmascript-version-staging-note"><sup>[31]</sup></a></td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no obsolete" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -36590,8 +36590,8 @@ return true;
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-js-ecmascript-version-staging-note"><sup>[31]</sup></a></td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no obsolete" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -36752,7 +36752,7 @@ return true;
 <td class="tally" data-browser="graalvm21_3_3" data-tally="0">0/2</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="0" data-flagged-tally="1">0/2</td>
 <td class="tally obsolete" data-browser="hermes0_7_0" data-tally="0">0/2</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/2</td>
+<td class="tally" data-browser="hermes0_12_0" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">2/2</td>
@@ -36914,8 +36914,8 @@ return arr.findLast(function (o) { return o.x === 1; }) === arr[2];
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no flagged" data-browser="graalvm22_2">Flag<a href="#graalvm-js-ecmascript-version-staging-note"><sup>[31]</sup></a></td>
-<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no obsolete" data-browser="hermes0_7_0">No</td>
+<td class="yes" data-browser="hermes0_12_0">Yes</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -37077,8 +37077,8 @@ return arr.findLastIndex(function (o) { return o.x === 1; }) === 2;
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no flagged" data-browser="graalvm22_2">Flag<a href="#graalvm-js-ecmascript-version-staging-note"><sup>[31]</sup></a></td>
-<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no obsolete" data-browser="hermes0_7_0">No</td>
+<td class="yes" data-browser="hermes0_12_0">Yes</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -37243,8 +37243,8 @@ try {
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_12_0">Yes</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>

--- a/es5/index.html
+++ b/es5/index.html
@@ -3547,8 +3547,8 @@ return typeof Object.getOwnPropertyNames === 'function';
 <td class="tally obsolete" data-browser="graalvm21" data-tally="0.9230769230769231" style="background-color:hsl(110,45%,50%)">12/13</td>
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">13/13</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">13/13</td>
-<td class="tally obsolete" data-browser="hermes0_7_0" data-tally="0.9230769230769231" style="background-color:hsl(110,45%,50%)">12/13</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0.9230769230769231" style="background-color:hsl(110,45%,50%)">12/13</td>
+<td class="tally obsolete" data-browser="hermes0_7_0" data-tally="1">13/13</td>
+<td class="tally" data-browser="hermes0_12_0" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">13/13</td>
@@ -5651,8 +5651,8 @@ return [].unshift(0) === 1;
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_12_0">Yes</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -5804,8 +5804,8 @@ return [].unshift(0) === 1;
 <td class="tally obsolete" data-browser="graalvm21" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">4/4</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="hermes0_7_0" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td class="tally obsolete" data-browser="hermes0_7_0" data-tally="1">4/4</td>
+<td class="tally" data-browser="hermes0_12_0" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">4/4</td>
@@ -6302,8 +6302,8 @@ return '0b'.substr(-1) === 'b';
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_12_0">Yes</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -8196,8 +8196,8 @@ return result;
 <td class="tally obsolete" data-browser="graalvm21" data-tally="0">0/3</td>
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">3/3</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="hermes0_7_0" data-tally="0">0/3</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="hermes0_7_0" data-tally="1">3/3</td>
+<td class="tally" data-browser="hermes0_12_0" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">3/3</td>
@@ -8358,8 +8358,8 @@ return (-6.9e-11).toExponential(4) === '-6.9000e-11' // Edge <= 17
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_12_0">Yes</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -8528,8 +8528,8 @@ try {
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_12_0">Yes</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -8698,8 +8698,8 @@ try {
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_12_0">Yes</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>

--- a/esintl/index.html
+++ b/esintl/index.html
@@ -522,7 +522,7 @@ return typeof Intl === &apos;object&apos;;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -663,7 +663,7 @@ return Intl.constructor === Object;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -942,7 +942,7 @@ return typeof Intl.Collator === &apos;function&apos;;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -1083,7 +1083,7 @@ return new Intl.Collator() instanceof Intl.Collator;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -1224,7 +1224,7 @@ return Intl.Collator() instanceof Intl.Collator;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -1387,7 +1387,7 @@ try {
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -1545,7 +1545,7 @@ try {
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -1824,7 +1824,7 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -2103,7 +2103,7 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -2382,7 +2382,7 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -2523,7 +2523,7 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -2664,7 +2664,7 @@ return new Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -2805,7 +2805,7 @@ return Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -2968,7 +2968,7 @@ try {
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -3126,7 +3126,7 @@ try {
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -3405,7 +3405,7 @@ return typeof Intl.DateTimeFormat === &apos;function&apos;;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -3546,7 +3546,7 @@ return new Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -3687,7 +3687,7 @@ return Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -3850,7 +3850,7 @@ try {
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -4008,7 +4008,7 @@ try {
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -4150,7 +4150,7 @@ return tz !== void undefined &amp;&amp; tz.length &gt; 0;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -4299,7 +4299,7 @@ try {
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -4437,7 +4437,7 @@ try {
 <td class="tally obsolete" data-browser="graalvm21" data-tally="1">1/1</td>
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">1/1</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">1/1</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/1</td>
+<td class="tally" data-browser="hermes0_12_0" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">1/1</td>
@@ -4578,7 +4578,7 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="yes" data-browser="hermes0_12_0">Yes</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -4716,7 +4716,7 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="tally obsolete" data-browser="graalvm21" data-tally="1">1/1</td>
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">1/1</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">1/1</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/1</td>
+<td class="tally" data-browser="hermes0_12_0" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">1/1</td>
@@ -4857,7 +4857,7 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="yes" data-browser="hermes0_12_0">Yes</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -4995,7 +4995,7 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="graalvm21" data-tally="1">1/1</td>
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">1/1</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">1/1</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/1</td>
+<td class="tally" data-browser="hermes0_12_0" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">1/1</td>
@@ -5136,7 +5136,7 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="yes" data-browser="hermes0_12_0">Yes</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -5274,7 +5274,7 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="graalvm21" data-tally="1">1/1</td>
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">1/1</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">1/1</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/1</td>
+<td class="tally" data-browser="hermes0_12_0" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">1/1</td>
@@ -5415,7 +5415,7 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="yes" data-browser="hermes0_12_0">Yes</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -5553,7 +5553,7 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="graalvm21" data-tally="1">1/1</td>
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">1/1</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">1/1</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/1</td>
+<td class="tally" data-browser="hermes0_12_0" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">1/1</td>
@@ -5694,7 +5694,7 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="yes" data-browser="hermes0_12_0">Yes</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -5832,7 +5832,7 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="graalvm21" data-tally="1">1/1</td>
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">1/1</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">1/1</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/1</td>
+<td class="tally" data-browser="hermes0_12_0" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">1/1</td>
@@ -5973,7 +5973,7 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="yes" data-browser="hermes0_12_0">Yes</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -6111,7 +6111,7 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="graalvm21" data-tally="1">1/1</td>
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">1/1</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">1/1</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/1</td>
+<td class="tally" data-browser="hermes0_12_0" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">1/1</td>
@@ -6252,7 +6252,7 @@ return typeof Date.prototype.toLocaleTimeString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="yes" data-browser="hermes0_12_0">Yes</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -418,7 +418,7 @@ return typeof ShadowRealm === &quot;function&quot;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -572,7 +572,7 @@ return typeof ShadowRealm === &quot;function&quot;
 <td class="tally obsolete" data-browser="graalvm21" data-tally="1">2/2</td>
 <td class="tally" data-browser="graalvm21_3_3" data-tally="1">2/2</td>
 <td class="tally" data-browser="graalvm22_2" data-tally="1">2/2</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/2</td>
+<td class="tally" data-browser="hermes0_12_0" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="deno1_19" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="deno1_20" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="deno1_21" data-tally="1">2/2</td>
@@ -735,7 +735,7 @@ return RegExp.lastMatch === 'x';
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="yes" data-browser="hermes0_12_0">Yes</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -900,7 +900,7 @@ return true;
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="yes" data-browser="hermes0_12_0">Yes</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -1065,7 +1065,7 @@ return result === &apos;tromple&apos;;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -1384,7 +1384,7 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -1701,7 +1701,7 @@ try {
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -1868,7 +1868,7 @@ try {
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -2030,7 +2030,7 @@ try {
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -2192,7 +2192,7 @@ try {
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -2506,7 +2506,7 @@ return set.size === 2
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[9]</sup></a></td>
 <td class="no flagged" data-browser="graalvm22_2">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[9]</sup></a></td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -2667,7 +2667,7 @@ return set.size === 3
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[9]</sup></a></td>
 <td class="no flagged" data-browser="graalvm22_2">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[9]</sup></a></td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -2827,7 +2827,7 @@ return set.size === 2
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[9]</sup></a></td>
 <td class="no flagged" data-browser="graalvm22_2">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[9]</sup></a></td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -2987,7 +2987,7 @@ return set.size === 2
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[9]</sup></a></td>
 <td class="no flagged" data-browser="graalvm22_2">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[9]</sup></a></td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -3144,7 +3144,7 @@ return new Set([1, 2, 3]).isDisjointFrom([4, 5, 6]);
 <td class="no flagged obsolete" data-browser="graalvm21">Flag<a href="#graalvm-js-ecmascript-version-2021-note"><sup>[10]</sup></a></td>
 <td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[9]</sup></a></td>
 <td class="no flagged" data-browser="graalvm22_2">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[9]</sup></a></td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -3301,7 +3301,7 @@ return new Set([1, 2, 3]).isSubsetOf([5, 4, 3, 2, 1]);
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[9]</sup></a></td>
 <td class="no flagged" data-browser="graalvm22_2">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[9]</sup></a></td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -3458,7 +3458,7 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[9]</sup></a></td>
 <td class="no flagged" data-browser="graalvm22_2">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[9]</sup></a></td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -3772,7 +3772,7 @@ return buffer1.byteLength === 0
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -3932,7 +3932,7 @@ return buffer1.byteLength === 0
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -4246,7 +4246,7 @@ return Array.from(map).join() === &apos;a,2,b,3&apos;;
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -4407,7 +4407,7 @@ return map.get(a) === 2 &amp;&amp; map.get(b) === 3;
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -4565,7 +4565,7 @@ return !Array.isTemplateObject([])
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -4876,7 +4876,7 @@ return [1, 2, 3].values() instanceof Iterator;
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -5035,7 +5035,7 @@ return instance[Symbol.iterator]() === instance;
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -5195,7 +5195,7 @@ return &apos;next&apos; in iterator
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -5360,7 +5360,7 @@ return &apos;next&apos; in iterator
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -5517,7 +5517,7 @@ return Array.from([1, 2, 3].values().asIndexedPairs()).join() === &apos;0,1,1,2,
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -5674,7 +5674,7 @@ return Array.from([1, 2, 3].values().drop(1)).join() === &apos;2,3&apos;;
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -5831,7 +5831,7 @@ return [1, 2, 3].values().every(it =&gt; typeof it === &apos;number&apos;);
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -5988,7 +5988,7 @@ return Array.from([1, 2, 3].values().filter(it =&gt; it % 2)).join() === &apos;1
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -6145,7 +6145,7 @@ return [1, 2, 3].values().find(it =&gt; it % 2) === 1;
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -6302,7 +6302,7 @@ return Array.from([1, 2, 3].values().flatMap(it =&gt; [it, 0])).join() === &apos
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -6461,7 +6461,7 @@ return result === &apos;123&apos;;
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -6618,7 +6618,7 @@ return Array.from([1, 2, 3].values().map(it =&gt; it * it)).join() === &apos;1,4
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -6775,7 +6775,7 @@ return [1, 2, 3].values().reduce((a, b) =&gt; a + b) === 6;
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -6932,7 +6932,7 @@ return [1, 2, 3].values().some(it =&gt; typeof it === &apos;number&apos;);
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -7089,7 +7089,7 @@ return Array.from([1, 2, 3].values().take(2)).join() === &apos;1,2&apos;;
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -7247,7 +7247,7 @@ return Array.isArray(array) &amp;&amp; array.join() === &apos;1,2,3&apos;;
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -7404,7 +7404,7 @@ return Iterator.prototype[Symbol.toStringTag] === &apos;Iterator&apos;;
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -7561,7 +7561,7 @@ return (async function*() {})() instanceof AsyncIterator;
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -7720,7 +7720,7 @@ return instance[Symbol.asyncIterator]() === instance;
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -7889,7 +7889,7 @@ toArray(iterator).then(it =&gt; {
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -8058,7 +8058,7 @@ toArray(iterator).then(it =&gt; {
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -8227,7 +8227,7 @@ toArray(iterator).then(it =&gt; {
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -8392,7 +8392,7 @@ toArray((async function*() { yield * [1, 2, 3] })().asIndexedPairs()).then(it =&
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -8557,7 +8557,7 @@ toArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it =&gt; {
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -8716,7 +8716,7 @@ toArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it =&gt; {
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -8881,7 +8881,7 @@ toArray(async function*() { yield * [1, 2, 3] }().filter(it =&gt; it % 2)).then(
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -9040,7 +9040,7 @@ toArray(async function*() { yield * [1, 2, 3] }().filter(it =&gt; it % 2)).then(
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -9205,7 +9205,7 @@ toArray(async function*() { yield * [1, 2, 3] }().flatMap(it =&gt; [it, 0])).the
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -9365,7 +9365,7 @@ let result = &apos;&apos;;
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -9530,7 +9530,7 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -9689,7 +9689,7 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -9848,7 +9848,7 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -10013,7 +10013,7 @@ toArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it =&gt; {
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -10172,7 +10172,7 @@ toArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it =&gt; {
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -10329,7 +10329,7 @@ return AsyncIterator.prototype[Symbol.toStringTag] === &apos;AsyncIterator&apos;
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -522,7 +522,7 @@ return typeof SIMD !== &apos;undefined&apos;;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -666,7 +666,7 @@ return typeof SIMD.Float32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -810,7 +810,7 @@ return typeof SIMD.Int32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -954,7 +954,7 @@ return typeof SIMD.Int16x8 === &apos;function&apos;;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -1098,7 +1098,7 @@ return typeof SIMD.Int8x16 === &apos;function&apos;;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -1242,7 +1242,7 @@ return typeof SIMD.Uint32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -1386,7 +1386,7 @@ return typeof SIMD.Uint16x8 === &apos;function&apos;;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -1530,7 +1530,7 @@ return typeof SIMD.Uint8x16 === &apos;function&apos;;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -1674,7 +1674,7 @@ return typeof SIMD.Bool32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -1818,7 +1818,7 @@ return typeof SIMD.Bool16x8 === &apos;function&apos;;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -1962,7 +1962,7 @@ return typeof SIMD.Bool8x16 === &apos;function&apos;;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -2108,7 +2108,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -2254,7 +2254,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -2400,7 +2400,7 @@ return simdSmallIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -2546,7 +2546,7 @@ return simdBoolIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -2692,7 +2692,7 @@ return simdBoolTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -2838,7 +2838,7 @@ return simdBoolTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -2984,7 +2984,7 @@ return simdAllTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -3130,7 +3130,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -3276,7 +3276,7 @@ return simdAllTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -3422,7 +3422,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -3568,7 +3568,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -3714,7 +3714,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -3860,7 +3860,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -4006,7 +4006,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -4152,7 +4152,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -4298,7 +4298,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -4444,7 +4444,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -4590,7 +4590,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -4736,7 +4736,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -4882,7 +4882,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -5028,7 +5028,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -5174,7 +5174,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -5320,7 +5320,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -5466,7 +5466,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -5612,7 +5612,7 @@ return simdBoolTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -5758,7 +5758,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -5904,7 +5904,7 @@ return simdBoolIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -6050,7 +6050,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -6196,7 +6196,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -6342,7 +6342,7 @@ return simdAllTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -6488,7 +6488,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -6634,7 +6634,7 @@ return simdIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -6780,7 +6780,7 @@ return simdIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -6926,7 +6926,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -7072,7 +7072,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -7218,7 +7218,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -7364,7 +7364,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -7510,7 +7510,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -7656,7 +7656,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -7802,7 +7802,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -7948,7 +7948,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -8094,7 +8094,7 @@ return simdSmallIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -8240,7 +8240,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -8386,7 +8386,7 @@ return simdBoolIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -8532,7 +8532,7 @@ return [&apos;Float32x4&apos;,&apos;Int32x4&apos;,&apos;Int8x16&apos;,&apos;Uint
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -8676,7 +8676,7 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -8963,7 +8963,7 @@ return typeof uneval === &apos;function&apos;;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -9115,7 +9115,7 @@ return &apos;toSource&apos; in Object.prototype
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -9259,7 +9259,7 @@ return uneval({ toSource: function() { return &quot;pwnd!&quot; } }) === &quot;p
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -9489,7 +9489,7 @@ return true;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -9634,7 +9634,7 @@ return eval(&quot;x&quot;, { x: 2 }) === 2;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -9782,7 +9782,7 @@ return 'caller' in function(){};
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -9932,7 +9932,7 @@ return (function () {}).arity === 0 &&
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -10084,7 +10084,7 @@ return f(1, 'boo');
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-experimental-options-js-v8-compat-note"><sup>[7]</sup></a></td>
 <td class="no flagged" data-browser="graalvm22_2">Flag<a href="#graalvm-experimental-options-js-v8-compat-note"><sup>[7]</sup></a></td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -10230,7 +10230,7 @@ return typeof Function.prototype.isGenerator === 'function';
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -10377,7 +10377,7 @@ return new C instanceof C;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -10525,7 +10525,7 @@ return typeof ({}).__count__ === 'number' &&
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -10671,7 +10671,7 @@ return typeof ({}).__parent__ !== 'undefined';
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -10827,7 +10827,7 @@ return executed;
 <td class="no flagged obsolete" data-browser="graalvm21">Flag<a href="#graalvm-nashorn-compat-note"><sup>[8]</sup></a></td>
 <td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-experimental-options-js-nashorn-compat-note"><sup>[9]</sup></a></td>
 <td class="no flagged" data-browser="graalvm22_2">Flag<a href="#graalvm-experimental-options-js-nashorn-compat-note"><sup>[9]</sup></a></td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -10973,7 +10973,7 @@ return typeof Array.slice === 'function' && Array.slice('abc').length === 3;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -11119,7 +11119,7 @@ return typeof String.slice === 'function' && String.slice(123, 1) === "23";
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -11267,7 +11267,7 @@ return a instanceof Array &amp;&amp; a[0] === 4 &amp;&amp; a[1] === 8;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -11411,7 +11411,7 @@ return [for (a of [1, 2, 3]) a * a] + &apos;&apos; === &apos;1,4,9&apos;;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -11555,7 +11555,7 @@ return (function(x)x)(1) === 1;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-experimental-options-js-nashorn-compat-note"><sup>[9]</sup></a></td>
 <td class="no flagged" data-browser="graalvm22_2">Flag<a href="#graalvm-experimental-options-js-nashorn-compat-note"><sup>[9]</sup></a></td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -11699,7 +11699,7 @@ return typeof &lt;foo/&gt; === &quot;xml&quot;;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -11847,7 +11847,7 @@ return str === &quot;foobarbaz&quot;;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-experimental-options-js-nashorn-compat-note"><sup>[9]</sup></a></td>
 <td class="no flagged" data-browser="graalvm22_2">Flag<a href="#graalvm-experimental-options-js-nashorn-compat-note"><sup>[9]</sup></a></td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -11992,7 +11992,7 @@ return arr[1] === arr;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -12170,7 +12170,7 @@ catch(e) {
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -12354,7 +12354,7 @@ catch(e) {
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -12537,7 +12537,7 @@ global.test((function () {
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -12683,7 +12683,7 @@ return g.next() === 4 &amp;&amp; g.next() === 8;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -12834,7 +12834,7 @@ return passed;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -12996,7 +12996,7 @@ try {
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -13140,7 +13140,7 @@ return /\\w/(&quot;x&quot;)[0] === &quot;x&quot;;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -13285,7 +13285,7 @@ return /(?P&lt;name&gt;a)(?P=name)/.test(&quot;aa&quot;) &amp;&amp;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -13429,7 +13429,7 @@ function () { return typeof String.prototype.quote === 'function' }())</script><
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -13571,7 +13571,7 @@ function () { return 'foofoo'.replace('foo', 'bar', 'g') === 'barbar' }())</scri
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -13715,7 +13715,7 @@ function () { return typeof Date.prototype.toLocaleFormat === 'function' }())</s
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -13867,7 +13867,7 @@ return !brokenOnFirefox && !brokenOnIE10 && !brokenOnChrome;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -14011,7 +14011,7 @@ function () { return typeof Object.prototype.watch === 'function' }())</script><
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -14153,7 +14153,7 @@ function () { return typeof Object.prototype.unwatch === 'function' }())</script
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -14295,7 +14295,7 @@ function () { return typeof Object.prototype.eval === 'function' }())</script></
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -14439,7 +14439,7 @@ return typeof Object.observe === &apos;function&apos;;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -14595,7 +14595,7 @@ try {
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
 <td class="yes" data-browser="graalvm22_2">Yes</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="yes" data-browser="hermes0_12_0">Yes</td>
 <td class="yes obsolete" data-browser="deno1_19">Yes</td>
 <td class="yes obsolete" data-browser="deno1_20">Yes</td>
 <td class="yes obsolete" data-browser="deno1_21">Yes</td>
@@ -14741,7 +14741,7 @@ return 'lineNumber' in new Error();
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-experimental-options-js-nashorn-compat-note"><sup>[9]</sup></a></td>
 <td class="no flagged" data-browser="graalvm22_2">Flag<a href="#graalvm-experimental-options-js-nashorn-compat-note"><sup>[9]</sup></a></td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -14887,7 +14887,7 @@ return 'columnNumber' in new Error();
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-experimental-options-js-nashorn-compat-note"><sup>[9]</sup></a></td>
 <td class="no flagged" data-browser="graalvm22_2">Flag<a href="#graalvm-experimental-options-js-nashorn-compat-note"><sup>[9]</sup></a></td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -15033,7 +15033,7 @@ return 'fileName' in new Error();
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -15179,7 +15179,7 @@ return 'description' in new Error();
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -15468,7 +15468,7 @@ return typeof global === &apos;object&apos; &amp;&amp; global &amp;&amp; global 
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-experimental-options-js-global-property-note"><sup>[10]</sup></a></td>
 <td class="no flagged" data-browser="graalvm22_2">Flag<a href="#graalvm-experimental-options-js-global-property-note"><sup>[10]</sup></a></td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -15619,7 +15619,7 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-experimental-options-js-global-property-note"><sup>[10]</sup></a></td>
 <td class="no flagged" data-browser="graalvm22_2">Flag<a href="#graalvm-experimental-options-js-global-property-note"><sup>[10]</sup></a></td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>
@@ -15768,7 +15768,7 @@ return Object.getOwnPropertyNames(P) + &apos;&apos; === &quot;a,a,b,b&quot;;
 <td class="no obsolete" data-browser="graalvm21">No</td>
 <td class="no" data-browser="graalvm21_3_3">No</td>
 <td class="no" data-browser="graalvm22_2">No</td>
-<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_19">No</td>
 <td class="no obsolete" data-browser="deno1_20">No</td>
 <td class="no obsolete" data-browser="deno1_21">No</td>


### PR DESCRIPTION
## Overview

Hermes 0.7.0  was added in https://github.com/kangax/compat-table/pull/1685 I am expanding data to cover,
- es2016plus
- esintl
- esnext
- non-standard

Corrected some flags on,
- es5
- es6

Then verified data for hermes0_12_0 and added necessary override.

## Verified by checking out of date test count

```
node hermes.js --hermes-bin /Users/deepakjacob/Downloads/hermes-cli-darwin-v0.7.0/hermes  -s all 
0 tests are out of date (data-*.js file .res)
```

```
node hermes.js --hermes-bin /Users/deepakjacob/Downloads/hermes-cli-darwin-v0.12.0/hermes  -s all
0 tests are out of date (data-*.js file .res)
```

## Ran build and tested
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/430289/208099454-e7e3d54b-4ced-4e52-8854-aa733e31ac95.png">




