### PR TITLE
Safari TP 161 supports RegExp Lookbehind

### DIFF
--- a/data-es2016plus.js
+++ b/data-es2016plus.js
@@ -3270,7 +3270,8 @@ exports.tests = [
       graalvm19: true,
       hermes0_7_0: true,
       reactnative0_70_3: true,
-      rhino1_7_13: false
+      rhino1_7_13: false,
+      safaritp: true
     }
   },
   {

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -16115,8 +16115,8 @@ return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&a
 <td class="no" data-browser="safari15_2">No</td>
 <td class="no" data-browser="safari15_4">No</td>
 <td class="no" data-browser="safari16">No</td>
-<td class="no unstable" data-browser="safaritp">No</td>
-<td class="no unstable" data-browser="webkit">No</td>
+<td class="yes unstable" data-browser="safaritp">Yes</td>
+<td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="yes obsolete" data-browser="opera82">Yes</td>
 <td class="yes obsolete" data-browser="opera83">Yes</td>
 <td class="yes obsolete" data-browser="opera84">Yes</td>


### PR DESCRIPTION
See https://github.com/Fyrd/caniuse/pull/6584 and also

<img width="876" alt="image" src="https://user-images.githubusercontent.com/2644614/214370256-b7ced47b-bb17-4ab0-b643-1bef801d58b4.png">

Hope this change is the proper way to reflect that, please advise if not :)