### PR TITLE
Change colors for Opera (14+) & Deno

### DIFF
--- a/master.js
+++ b/master.js
@@ -338,11 +338,11 @@ $(function() {
       return "hsla(220, 25%, 70%, .5)";
     }
     /* Carakan */
-    if (/^opera\d|opera_mobile1[120]/.test(name)) {
+    if (/^opera([1-9]|1[0-2])(\D|$)|opera_mobile1[120]/.test(name)) {
       return "hsla(358, 86%, 43%, .5)";
     }
     /* V8 */
-    if (/^(chrome|node|iojs|android4[1-9]|android[5-9]|samsung|opera_mobile|edge)/.test(name)) {
+    if (/^(chrome|node|iojs|android4[1-9]|android[5-9]|samsung|opera(_mobile)?|edge|deno)/.test(name)) {
       return "hsla(79, 100%, 37%, .5)";
     }
     /* KJS */

--- a/master.js
+++ b/master.js
@@ -334,7 +334,7 @@ $(function() {
       return "hsla(35, 100%, 50%, .5)";
     }
     /* JavaScriptCore */
-    if (/^(webkit|safari|jxa|phantom|ios|android4_0)/.test(name)) {
+    if (/^(webkit|safari|jxa|phantom|ios|android4_0|bun)/.test(name)) {
       return "hsla(220, 25%, 70%, .5)";
     }
     /* Carakan */


### PR DESCRIPTION
Fixes #1848

These use V8, so colors for them are changed from yellow (other engine) to green (V8).

An additional future fix for Bun (uses JavaScriptCore) is included.