### PR TITLE
Firefox 116 now implements RegExp 'v' flag

### DIFF
--- a/data-es2016plus.js
+++ b/data-es2016plus.js
@@ -6792,7 +6792,9 @@ exports.tests = [
           chrome111: chrome.harmony,
           chrome112: true,
           firefox91: false,
-          firefox113: false,
+          firefox102: false,
+          firefox115: false,
+          firefox116: true,
           ie11: false,
           safari16: false,
         }
@@ -6808,7 +6810,9 @@ exports.tests = [
           chrome111: chrome.harmony,
           chrome112: true,
           firefox91: false,
-          firefox113: false,
+          firefox102: false,
+          firefox115: false,
+          firefox116: true,
           ie11: false,
           safari16: false,
         }
@@ -6823,7 +6827,9 @@ exports.tests = [
           chrome111: chrome.harmony,
           chrome112: true,
           firefox91: false,
-          firefox113: false,
+          firefox102: false,
+          firefox115: false,
+          firefox116: true,
           ie11: false,
           safari16: false,
         }
@@ -6841,7 +6847,9 @@ exports.tests = [
           chrome111: chrome.harmony,
           chrome112: true,
           firefox91: false,
-          firefox113: false,
+          firefox102: false,
+          firefox115: false,
+          firefox116: true,
           ie11: false,
           safari16: false,
         }

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -37089,7 +37089,7 @@ try {
 <td class="tally obsolete" data-browser="firefox113" data-tally="0">0/4</td>
 <td class="tally" data-browser="firefox114" data-tally="0">0/4</td>
 <td class="tally unstable" data-browser="firefox115" data-tally="0">0/4</td>
-<td class="tally unstable" data-browser="firefox116" data-tally="0">0/4</td>
+<td class="tally unstable" data-browser="firefox116" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="0">0/4</td>
@@ -37251,7 +37251,7 @@ return /[\p{ASCII}&amp;&amp;\p{Decimal_Number}]/v.test(&quot;0&quot;)
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no" data-browser="firefox114">No</td>
 <td class="no unstable" data-browser="firefox115">No</td>
-<td class="no unstable" data-browser="firefox116">No</td>
+<td class="yes unstable" data-browser="firefox116">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="unknown obsolete" data-browser="chrome102">?</td>
 <td class="unknown obsolete" data-browser="chrome103">?</td>
@@ -37413,7 +37413,7 @@ return /^\p{Emoji_Keycap_Sequence}$/v.test(&quot;*\uFE0F\u20E3&quot;)
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no" data-browser="firefox114">No</td>
 <td class="no unstable" data-browser="firefox115">No</td>
-<td class="no unstable" data-browser="firefox116">No</td>
+<td class="yes unstable" data-browser="firefox116">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="unknown obsolete" data-browser="chrome102">?</td>
 <td class="unknown obsolete" data-browser="chrome103">?</td>
@@ -37574,7 +37574,7 @@ return new RegExp(&apos;a&apos;, &apos;v&apos;) instanceof RegExp;
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no" data-browser="firefox114">No</td>
 <td class="no unstable" data-browser="firefox115">No</td>
-<td class="no unstable" data-browser="firefox116">No</td>
+<td class="yes unstable" data-browser="firefox116">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="unknown obsolete" data-browser="chrome102">?</td>
 <td class="unknown obsolete" data-browser="chrome103">?</td>
@@ -37738,7 +37738,7 @@ return flags.indexOf(&quot;unicodeSets&quot;) !== -1;
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no" data-browser="firefox114">No</td>
 <td class="no unstable" data-browser="firefox115">No</td>
-<td class="no unstable" data-browser="firefox116">No</td>
+<td class="yes unstable" data-browser="firefox116">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="unknown obsolete" data-browser="chrome102">?</td>
 <td class="unknown obsolete" data-browser="chrome103">?</td>


### PR DESCRIPTION
Enabled on today's nightly build.