### PR TITLE
Firefox 117 released

### DIFF
--- a/data-es2016plus.js
+++ b/data-es2016plus.js
@@ -6654,6 +6654,7 @@ exports.tests = [
           firefox68: false,
           firefox78: false,
           firefox91: true,
+          firefox116: false,
           safari15: true,
           chrome90: false,
           graalvm21_3_3: graalvm.esStagingFlag,

--- a/environments.json
+++ b/environments.json
@@ -1779,7 +1779,7 @@
     "short": "FF 91 ESR",
     "release": "2021-08-10",
     "retire": "2022-08-23",
-    "obsolete": true
+    "obsolete": "very"
   },
   "firefox92": {
     "full": "Firefox 92",
@@ -1875,7 +1875,7 @@
     "short": "FF 103",
     "release": "2022-07-26",
     "retire": "2022-08-23",
-    "obsolete": true
+    "obsolete": "very"
   },
   "firefox104": {
     "full": "Firefox 104",
@@ -1978,22 +1978,30 @@
     "short": "FF 116",
     "release": "2023-08-01",
     "retire": "2023-08-29",
-    "obsolete": false
+    "obsolete": true
   },
   "firefox117": {
-    "full": "Firefox 117 Beta",
+    "full": "Firefox 117",
     "family": "SpiderMonkey",
     "short": "FF 117",
     "release": "2023-08-29",
     "retire": "2023-09-26",
-    "unstable": true
+    "obsolete": false
   },
   "firefox118": {
-    "full": "Firefox 118 Nightly",
+    "full": "Firefox 118 Beta",
     "family": "SpiderMonkey",
     "short": "FF 118",
     "release": "2023-09-26",
     "retire": "2023-10-24",
+    "unstable": true
+  },
+  "firefox119": {
+    "full": "Firefox 119 Nightly",
+    "family": "SpiderMonkey",
+    "short": "FF 119",
+    "release": "2023-10-24",
+    "retire": "2023-11-21",
     "unstable": true
   },
   "opera7": {

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -144,9 +144,7 @@
 <th class="platform typescript5_1corejs3 compiler" data-browser="typescript5_1corejs3"><a href="#typescript5_1corejs3" class="browser-name"><abbr title="TypeScript 5.1 + core-js 3">Type-<br>Script +<br><nobr>core-js 3</nobr></abbr></a></th>
 <th class="platform es7shim compiler" data-browser="es7shim"><a href="#es7shim" class="browser-name"><abbr title="es7-shim">es7-shim</abbr></a></th>
 <th class="platform ie11 desktop" data-browser="ie11"><a href="#ie11" class="browser-name"><abbr title="Internet Explorer 11">IE 11</abbr></a></th>
-<th class="platform firefox91 desktop obsolete" data-browser="firefox91"><a href="#firefox91" class="browser-name"><abbr title="Firefox 91 Extended Support Release">FF 91 ESR</abbr></a></th>
 <th class="platform firefox102 desktop obsolete" data-browser="firefox102"><a href="#firefox102" class="browser-name"><abbr title="Firefox 102 Extended Support Release">FF 102 ESR</abbr></a></th>
-<th class="platform firefox103 desktop obsolete" data-browser="firefox103"><a href="#firefox103" class="browser-name"><abbr title="Firefox 103">FF 103</abbr></a></th>
 <th class="platform firefox104 desktop obsolete" data-browser="firefox104"><a href="#firefox104" class="browser-name"><abbr title="Firefox 104">FF 104</abbr></a></th>
 <th class="platform firefox105 desktop obsolete" data-browser="firefox105"><a href="#firefox105" class="browser-name"><abbr title="Firefox 105">FF 105</abbr></a></th>
 <th class="platform firefox106 desktop obsolete" data-browser="firefox106"><a href="#firefox106" class="browser-name"><abbr title="Firefox 106">FF 106</abbr></a></th>
@@ -159,9 +157,10 @@
 <th class="platform firefox113 desktop obsolete" data-browser="firefox113"><a href="#firefox113" class="browser-name"><abbr title="Firefox 113">FF 113</abbr></a></th>
 <th class="platform firefox114 desktop obsolete" data-browser="firefox114"><a href="#firefox114" class="browser-name"><abbr title="Firefox 114">FF 114</abbr></a></th>
 <th class="platform firefox115 desktop" data-browser="firefox115"><a href="#firefox115" class="browser-name"><abbr title="Firefox 115 Extended Support Release">FF 115 ESR</abbr></a></th>
-<th class="platform firefox116 desktop" data-browser="firefox116"><a href="#firefox116" class="browser-name"><abbr title="Firefox 116">FF 116</abbr></a></th>
-<th class="platform firefox117 desktop unstable" data-browser="firefox117"><a href="#firefox117" class="browser-name"><abbr title="Firefox 117 Beta">FF 117</abbr></a></th>
-<th class="platform firefox118 desktop unstable" data-browser="firefox118"><a href="#firefox118" class="browser-name"><abbr title="Firefox 118 Nightly">FF 118</abbr></a></th>
+<th class="platform firefox116 desktop obsolete" data-browser="firefox116"><a href="#firefox116" class="browser-name"><abbr title="Firefox 116">FF 116</abbr></a></th>
+<th class="platform firefox117 desktop" data-browser="firefox117"><a href="#firefox117" class="browser-name"><abbr title="Firefox 117">FF 117</abbr></a></th>
+<th class="platform firefox118 desktop unstable" data-browser="firefox118"><a href="#firefox118" class="browser-name"><abbr title="Firefox 118 Beta">FF 118</abbr></a></th>
+<th class="platform firefox119 desktop unstable" data-browser="firefox119"><a href="#firefox119" class="browser-name"><abbr title="Firefox 119 Nightly">FF 119</abbr></a></th>
 <th class="platform opera12_10 desktop obsolete" data-browser="opera12_10"><a href="#opera12_10" class="browser-name"><abbr title="Opera 12.10">OP 12.10</abbr></a></th>
 <th class="platform chrome102 desktop obsolete" data-browser="chrome102"><a href="#chrome102" class="browser-name"><abbr title="Chrome 102">CH 102</abbr></a></th>
 <th class="platform chrome103 desktop obsolete" data-browser="chrome103"><a href="#chrome103" class="browser-name"><abbr title="Chrome 103">CH 103</abbr></a></th>
@@ -279,7 +278,7 @@
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr class="category"><td colspan="153"><span>2016 features</span></td>
+      <tr class="category"><td colspan="152"><span>2016 features</span></td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-exponentiation_(**)_operator"><span><a class="anchor" href="#test-exponentiation_(**)_operator">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-exp-operator">exponentiation (**) operator</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Exponentiation_(**)" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -302,9 +301,7 @@
 <td class="tally" data-browser="typescript5_1corejs3" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/3</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">3/3</td>
@@ -317,9 +314,10 @@
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">3/3</td>
 <td class="tally" data-browser="firefox115" data-tally="1">3/3</td>
-<td class="tally" data-browser="firefox116" data-tally="1">3/3</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">3/3</td>
+<td class="tally" data-browser="firefox117" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">3/3</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">3/3</td>
@@ -457,9 +455,7 @@ return 2 ** 3 === 8 &amp;&amp; -(5 ** 2) === -25 &amp;&amp; (-5) ** 2 === 25;
 <td class="yes" data-browser="typescript5_1corejs3">Yes</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -472,9 +468,10 @@ return 2 ** 3 === 8 &amp;&amp; -(5 ** 2) === -25 &amp;&amp; (-5) ** 2 === 25;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -612,9 +609,7 @@ var a = 2; a **= 3; return a === 8;
 <td class="yes" data-browser="typescript5_1corejs3">Yes</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -627,9 +622,10 @@ var a = 2; a **= 3; return a === 8;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -772,9 +768,7 @@ return true;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -787,9 +781,10 @@ return true;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -924,9 +919,7 @@ return true;
 <td class="tally" data-browser="typescript5_1corejs3" data-tally="1">4/4</td>
 <td class="tally" data-browser="es7shim" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">4/4</td>
@@ -939,9 +932,10 @@ return true;
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">4/4</td>
 <td class="tally" data-browser="firefox115" data-tally="1">4/4</td>
-<td class="tally" data-browser="firefox116" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">4/4</td>
+<td class="tally" data-browser="firefox117" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">4/4</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">4/4</td>
@@ -1082,9 +1076,7 @@ return [1, 2, 3].includes(1)
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -1097,9 +1089,10 @@ return [1, 2, 3].includes(1)
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -1238,9 +1231,7 @@ return [,].includes()
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -1253,9 +1244,10 @@ return [,].includes()
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -1415,9 +1407,7 @@ return 24;
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -1430,9 +1420,10 @@ return 24;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -1575,9 +1566,7 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -1590,9 +1579,10 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -1706,7 +1696,7 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="yes" data-browser="opera_mobile76">Yes</td>
 <td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
-<tr class="category"><td colspan="153"><span>2016 misc</span></td>
+<tr class="category"><td colspan="152"><span>2016 misc</span></td>
 </tr>
 <tr significance="0.125"><td id="test-generator_functions_can&apos;t_be_used_with_new"><span><a class="anchor" href="#test-generator_functions_can&apos;t_be_used_with_new">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-createdynamicfunction">generator functions can&apos;t be used with &quot;new&quot;</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*#Generators_are_not_constructable" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;<a href="#new-gen-fn-note"><sup>[7]</sup></a></span><script data-source="
 function * generator() {
@@ -1739,9 +1729,7 @@ return true;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -1754,9 +1742,10 @@ return true;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -1907,9 +1896,7 @@ return iter[&apos;throw&apos;]().value === &apos;bar&apos;;
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -1922,9 +1909,10 @@ return iter[&apos;throw&apos;]().value === &apos;bar&apos;;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -2067,9 +2055,7 @@ return true;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -2082,9 +2068,10 @@ return true;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -2223,9 +2210,7 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes" data-browser="typescript5_1corejs3">Yes</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -2238,9 +2223,10 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -2380,9 +2366,7 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes" data-browser="typescript5_1corejs3">Yes</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -2395,9 +2379,10 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -2542,9 +2527,7 @@ return passed;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -2557,9 +2540,10 @@ return passed;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -2706,9 +2690,7 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -2721,9 +2703,10 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -2837,7 +2820,7 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="yes" data-browser="opera_mobile76">Yes</td>
 <td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
-<tr class="category"><td colspan="153"><span>2017 features</span></td>
+<tr class="category"><td colspan="152"><span>2017 features</span></td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-Object_static_methods"><span><a class="anchor" href="#test-Object_static_methods">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-properties-of-the-object-constructor">Object static methods</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/4</td>
@@ -2860,9 +2843,7 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="tally" data-browser="typescript5_1corejs3" data-tally="1">4/4</td>
 <td class="tally" data-browser="es7shim" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">4/4</td>
@@ -2875,9 +2856,10 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">4/4</td>
 <td class="tally" data-browser="firefox115" data-tally="1">4/4</td>
-<td class="tally" data-browser="firefox116" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">4/4</td>
+<td class="tally" data-browser="firefox117" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">4/4</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">4/4</td>
@@ -3018,9 +3000,7 @@ return Array.isArray(v) &amp;&amp; String(v) === &quot;foo,bar,baz&quot;;
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -3033,9 +3013,10 @@ return Array.isArray(v) &amp;&amp; String(v) === &quot;foo,bar,baz&quot;;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -3180,9 +3161,7 @@ return Array.isArray(e)
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -3195,9 +3174,10 @@ return Array.isArray(e)
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -3343,9 +3323,7 @@ return D.a.value === 1 &amp;&amp; D.a.enumerable === true &amp;&amp; D.a.configu
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -3358,9 +3336,10 @@ return D.a.value === 1 &amp;&amp; D.a.enumerable === true &amp;&amp; D.a.configu
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -3501,9 +3480,7 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -3516,9 +3493,10 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -3653,9 +3631,7 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="tally" data-browser="typescript5_1corejs3" data-tally="1">2/2</td>
 <td class="tally" data-browser="es7shim" data-tally="1">2/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">2/2</td>
@@ -3668,9 +3644,10 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">2/2</td>
 <td class="tally" data-browser="firefox115" data-tally="1">2/2</td>
-<td class="tally" data-browser="firefox116" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">2/2</td>
+<td class="tally" data-browser="firefox117" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">2/2</td>
@@ -3813,9 +3790,7 @@ return &apos;hello&apos;.padStart(10) === &apos;     hello&apos;
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -3828,9 +3803,10 @@ return &apos;hello&apos;.padStart(10) === &apos;     hello&apos;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -3973,9 +3949,7 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -3988,9 +3962,10 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -4125,9 +4100,7 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="tally" data-browser="typescript5_1corejs3" data-tally="1">2/2</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">2/2</td>
@@ -4140,9 +4113,10 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">2/2</td>
 <td class="tally" data-browser="firefox115" data-tally="1">2/2</td>
-<td class="tally" data-browser="firefox116" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">2/2</td>
+<td class="tally" data-browser="firefox117" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">2/2</td>
@@ -4280,9 +4254,7 @@ return typeof function f( a, b, ){} === &apos;function&apos;;
 <td class="yes" data-browser="typescript5_1corejs3">Yes</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -4295,9 +4267,10 @@ return typeof function f( a, b, ){} === &apos;function&apos;;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -4435,9 +4408,7 @@ return Math.min(1,2,3,) === 1;
 <td class="yes" data-browser="typescript5_1corejs3">Yes</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -4450,9 +4421,10 @@ return Math.min(1,2,3,) === 1;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -4587,9 +4559,7 @@ return Math.min(1,2,3,) === 1;
 <td class="tally" data-browser="typescript5_1corejs3" data-tally="0.5625" style="background-color:hsl(67,61%,50%)">9/16</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/16</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/16</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">16/16</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">16/16</td>
@@ -4602,9 +4572,10 @@ return Math.min(1,2,3,) === 1;
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">16/16</td>
 <td class="tally" data-browser="firefox115" data-tally="1">16/16</td>
-<td class="tally" data-browser="firefox116" data-tally="1">16/16</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">16/16</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">16/16</td>
+<td class="tally" data-browser="firefox117" data-tally="1">16/16</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">16/16</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/16</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">16/16</td>
@@ -4753,9 +4724,7 @@ p.then(function(result) {
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -4768,9 +4737,10 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -4919,9 +4889,7 @@ p.catch(function(result) {
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -4934,9 +4902,10 @@ p.catch(function(result) {
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -5075,9 +5044,7 @@ try { Function(&quot;async\n function a(){await 0}&quot;)(); } catch(e) { return
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -5090,9 +5057,10 @@ try { Function(&quot;async\n function a(){await 0}&quot;)(); } catch(e) { return
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -5231,9 +5199,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="no" data-browser="typescript5_1corejs3">No</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -5246,9 +5212,10 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -5393,9 +5360,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -5408,9 +5373,10 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -5557,9 +5523,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -5572,9 +5536,10 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -5713,9 +5678,7 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -5728,9 +5691,10 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -5874,9 +5838,7 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -5889,9 +5851,10 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -6030,9 +5993,7 @@ try { Function(&quot;(async function a(b = await Promise.resolve()){}())&quot;)(
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -6045,9 +6006,10 @@ try { Function(&quot;(async function a(b = await Promise.resolve()){}())&quot;)(
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -6196,9 +6158,7 @@ p.then(function(result) {
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -6211,9 +6171,10 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -6362,9 +6323,7 @@ p.then(function(result) {
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -6377,9 +6336,10 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -6528,9 +6488,7 @@ var p = new C().a();
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -6543,9 +6501,10 @@ var p = new C().a();
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -6692,9 +6651,7 @@ p.then(function(result) {
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -6707,9 +6664,10 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -6849,9 +6807,7 @@ return asyncFunctionProto !== function(){}.prototype
 <td class="no" data-browser="typescript5_1corejs3">No</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -6864,9 +6820,10 @@ return asyncFunctionProto !== function(){}.prototype
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -7004,9 +6961,7 @@ return Object.getPrototypeOf(async function (){})[Symbol.toStringTag] === &quot;
 <td class="no" data-browser="typescript5_1corejs3">No</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -7019,9 +6974,10 @@ return Object.getPrototypeOf(async function (){})[Symbol.toStringTag] === &quot;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -7168,9 +7124,7 @@ p.then(function(result) {
 <td class="no" data-browser="typescript5_1corejs3">No</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -7183,9 +7137,10 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -7320,9 +7275,7 @@ p.then(function(result) {
 <td class="tally" data-browser="typescript5_1corejs3" data-tally="0">0/17</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/17</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/17</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">17/17</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">17/17</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">17/17</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">17/17</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">17/17</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">17/17</td>
@@ -7335,9 +7288,10 @@ p.then(function(result) {
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">17/17</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">17/17</td>
 <td class="tally" data-browser="firefox115" data-tally="1">17/17</td>
-<td class="tally" data-browser="firefox116" data-tally="1">17/17</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">17/17</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">17/17</td>
+<td class="tally" data-browser="firefox117" data-tally="1">17/17</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">17/17</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">17/17</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">17/17</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">17/17</td>
@@ -7475,9 +7429,7 @@ return typeof SharedArrayBuffer === &apos;function&apos;;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox102">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox103">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox104">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox105">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox106">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
@@ -7490,9 +7442,10 @@ return typeof SharedArrayBuffer === &apos;function&apos;;
 <td class="yes obsolete" data-browser="firefox113">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox114">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
 <td class="yes" data-browser="firefox115">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
-<td class="yes" data-browser="firefox116">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
-<td class="yes unstable" data-browser="firefox117">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox116">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
+<td class="yes" data-browser="firefox117">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
 <td class="yes unstable" data-browser="firefox118">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
+<td class="yes unstable" data-browser="firefox119">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -7630,9 +7583,7 @@ return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox102">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox103">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox104">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox105">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox106">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
@@ -7645,9 +7596,10 @@ return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
 <td class="yes obsolete" data-browser="firefox113">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox114">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
 <td class="yes" data-browser="firefox115">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
-<td class="yes" data-browser="firefox116">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
-<td class="yes unstable" data-browser="firefox117">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox116">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
+<td class="yes" data-browser="firefox117">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
 <td class="yes unstable" data-browser="firefox118">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
+<td class="yes unstable" data-browser="firefox119">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -7785,9 +7737,7 @@ return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox102">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox103">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox104">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox105">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox106">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
@@ -7800,9 +7750,10 @@ return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
 <td class="yes obsolete" data-browser="firefox113">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox114">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
 <td class="yes" data-browser="firefox115">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
-<td class="yes" data-browser="firefox116">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
-<td class="yes unstable" data-browser="firefox117">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox116">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
+<td class="yes" data-browser="firefox117">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
 <td class="yes unstable" data-browser="firefox118">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
+<td class="yes unstable" data-browser="firefox119">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -7940,9 +7891,7 @@ return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox102">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox103">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox104">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox105">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox106">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
@@ -7955,9 +7904,10 @@ return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
 <td class="yes obsolete" data-browser="firefox113">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox114">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
 <td class="yes" data-browser="firefox115">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
-<td class="yes" data-browser="firefox116">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
-<td class="yes unstable" data-browser="firefox117">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox116">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
+<td class="yes" data-browser="firefox117">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
 <td class="yes unstable" data-browser="firefox118">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
+<td class="yes unstable" data-browser="firefox119">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -8095,9 +8045,7 @@ return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuff
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox102">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox103">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox104">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox105">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox106">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
@@ -8110,9 +8058,10 @@ return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuff
 <td class="yes obsolete" data-browser="firefox113">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox114">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
 <td class="yes" data-browser="firefox115">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
-<td class="yes" data-browser="firefox116">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
-<td class="yes unstable" data-browser="firefox117">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox116">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
+<td class="yes" data-browser="firefox117">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
 <td class="yes unstable" data-browser="firefox118">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
+<td class="yes unstable" data-browser="firefox119">Yes<a href="#fx-shared-memory-cors-isolation-note"><sup>[15]</sup></a></td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -8250,9 +8199,7 @@ return typeof Atomics.add === &apos;function&apos;;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -8265,9 +8212,10 @@ return typeof Atomics.add === &apos;function&apos;;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -8405,9 +8353,7 @@ return typeof Atomics.and === &apos;function&apos;;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -8420,9 +8366,10 @@ return typeof Atomics.and === &apos;function&apos;;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -8560,9 +8507,7 @@ return typeof Atomics.compareExchange === &apos;function&apos;;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -8575,9 +8520,10 @@ return typeof Atomics.compareExchange === &apos;function&apos;;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -8715,9 +8661,7 @@ return typeof Atomics.exchange === &apos;function&apos;;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -8730,9 +8674,10 @@ return typeof Atomics.exchange === &apos;function&apos;;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -8870,9 +8815,7 @@ return typeof Atomics.wait === &apos;function&apos;;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -8885,9 +8828,10 @@ return typeof Atomics.wait === &apos;function&apos;;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -9025,9 +8969,7 @@ return typeof Atomics.notify === &apos;function&apos;;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -9040,9 +8982,10 @@ return typeof Atomics.notify === &apos;function&apos;;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -9180,9 +9123,7 @@ return typeof Atomics.isLockFree === &apos;function&apos;;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -9195,9 +9136,10 @@ return typeof Atomics.isLockFree === &apos;function&apos;;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -9335,9 +9277,7 @@ return typeof Atomics.load === &apos;function&apos;;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -9350,9 +9290,10 @@ return typeof Atomics.load === &apos;function&apos;;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -9490,9 +9431,7 @@ return typeof Atomics.or === &apos;function&apos;;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -9505,9 +9444,10 @@ return typeof Atomics.or === &apos;function&apos;;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -9645,9 +9585,7 @@ return typeof Atomics.store === &apos;function&apos;;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -9660,9 +9598,10 @@ return typeof Atomics.store === &apos;function&apos;;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -9800,9 +9739,7 @@ return typeof Atomics.sub === &apos;function&apos;;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -9815,9 +9752,10 @@ return typeof Atomics.sub === &apos;function&apos;;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -9955,9 +9893,7 @@ return typeof Atomics.xor === &apos;function&apos;;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -9970,9 +9906,10 @@ return typeof Atomics.xor === &apos;function&apos;;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -10086,7 +10023,7 @@ return typeof Atomics.xor === &apos;function&apos;;
 <td class="yes" data-browser="opera_mobile76">Yes</td>
 <td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
-<tr class="category"><td colspan="153"><span>2017 misc</span></td>
+<tr class="category"><td colspan="152"><span>2017 misc</span></td>
 </tr>
 <tr significance="0.125"><td id="test-RegExp_u_flag,_case_folding"><span><a class="anchor" href="#test-RegExp_u_flag,_case_folding">&#xA7;</a><a href="https://github.com/tc39/ecma262/pull/525">RegExp &quot;u&quot; flag, case folding</a></span><script data-source="
 return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/\W/iu)
@@ -10115,9 +10052,7 @@ return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -10130,9 +10065,10 @@ return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -10273,9 +10209,7 @@ return (function(){
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -10288,9 +10222,10 @@ return (function(){
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -10404,7 +10339,7 @@ return (function(){
 <td class="yes" data-browser="opera_mobile76">Yes</td>
 <td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
-<tr class="category"><td colspan="153"><span>2017 annex b</span></td>
+<tr class="category"><td colspan="152"><span>2017 annex b</span></td>
 </tr>
 <tr class="supertest optional-feature" significance="0.125"><td id="test-Object.prototype_getter/setter_methods"><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-object.prototype.__defineGetter__">Object.prototype getter/setter methods</a></span></td>
 <td class="tally obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
@@ -10427,9 +10362,7 @@ return (function(){
 <td class="tally not-applicable" data-browser="typescript5_1corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally" data-browser="ie11" data-tally="0.5" style="background-color:hsl(60,64%,50%)">8/16</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">16/16</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">16/16</td>
@@ -10442,9 +10375,10 @@ return (function(){
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">16/16</td>
 <td class="tally" data-browser="firefox115" data-tally="1">16/16</td>
-<td class="tally" data-browser="firefox116" data-tally="1">16/16</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">16/16</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">16/16</td>
+<td class="tally" data-browser="firefox117" data-tally="1">16/16</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">16/16</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">16/16</td>
@@ -10587,9 +10521,7 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes not-applicable" data-browser="typescript5_1corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -10602,9 +10534,10 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -10748,9 +10681,7 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes not-applicable" data-browser="typescript5_1corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -10763,9 +10694,10 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -10909,9 +10841,7 @@ return true;
 <td class="yes not-applicable" data-browser="typescript5_1corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -10924,9 +10854,10 @@ return true;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -11069,9 +11000,7 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes not-applicable" data-browser="typescript5_1corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -11084,9 +11013,10 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -11230,9 +11160,7 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes not-applicable" data-browser="typescript5_1corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -11245,9 +11173,10 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -11391,9 +11320,7 @@ return true;
 <td class="yes not-applicable" data-browser="typescript5_1corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -11406,9 +11333,10 @@ return true;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -11553,9 +11481,7 @@ return foo() === &quot;bar&quot;
 <td class="yes not-applicable" data-browser="typescript5_1corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -11568,9 +11494,10 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -11715,9 +11642,7 @@ return foo() === &quot;bar&quot;
 <td class="yes not-applicable" data-browser="typescript5_1corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -11730,9 +11655,10 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -11878,9 +11804,7 @@ return foo() === &quot;bar&quot;
 <td class="yes not-applicable" data-browser="typescript5_1corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -11893,9 +11817,10 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -12038,9 +11963,7 @@ return true;
 <td class="yes not-applicable" data-browser="typescript5_1corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -12053,9 +11976,10 @@ return true;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -12197,9 +12121,7 @@ return b.__lookupGetter__(&quot;foo&quot;) === void undefined
 <td class="yes not-applicable" data-browser="typescript5_1corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -12212,9 +12134,10 @@ return b.__lookupGetter__(&quot;foo&quot;) === void undefined
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -12359,9 +12282,7 @@ return foo() === &quot;bar&quot;
 <td class="yes not-applicable" data-browser="typescript5_1corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -12374,9 +12295,10 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -12521,9 +12443,7 @@ return foo() === &quot;bar&quot;
 <td class="yes not-applicable" data-browser="typescript5_1corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -12536,9 +12456,10 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -12684,9 +12605,7 @@ return foo() === &quot;bar&quot;
 <td class="yes not-applicable" data-browser="typescript5_1corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -12699,9 +12618,10 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -12844,9 +12764,7 @@ return true;
 <td class="yes not-applicable" data-browser="typescript5_1corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -12859,9 +12777,10 @@ return true;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -13003,9 +12922,7 @@ return b.__lookupSetter__(&quot;foo&quot;) === void undefined
 <td class="yes not-applicable" data-browser="typescript5_1corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -13018,9 +12935,10 @@ return b.__lookupSetter__(&quot;foo&quot;) === void undefined
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -13155,9 +13073,7 @@ return b.__lookupSetter__(&quot;foo&quot;) === void undefined
 <td class="tally not-applicable" data-browser="typescript5_1corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">4/4</td>
@@ -13170,9 +13086,10 @@ return b.__lookupSetter__(&quot;foo&quot;) === void undefined
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">4/4</td>
 <td class="tally" data-browser="firefox115" data-tally="1">4/4</td>
-<td class="tally" data-browser="firefox116" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">4/4</td>
+<td class="tally" data-browser="firefox117" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">4/4</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">4/4</td>
@@ -13314,9 +13231,7 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="unknown not-applicable" data-browser="typescript5_1corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -13329,9 +13244,10 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -13473,9 +13389,7 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="unknown not-applicable" data-browser="typescript5_1corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -13488,9 +13402,10 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -13637,9 +13552,7 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="unknown not-applicable" data-browser="typescript5_1corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -13652,9 +13565,10 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -13801,9 +13715,7 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="unknown not-applicable" data-browser="typescript5_1corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -13816,9 +13728,10 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -13957,9 +13870,7 @@ return i === 0;
 <td class="unknown not-applicable" data-browser="typescript5_1corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -13972,9 +13883,10 @@ return i === 0;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -14088,7 +14000,7 @@ return i === 0;
 <td class="yes" data-browser="opera_mobile76">Yes</td>
 <td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
-<tr class="category"><td colspan="153"><span>2018 features</span></td>
+<tr class="category"><td colspan="152"><span>2018 features</span></td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-object_rest/spread_properties"><span><a class="anchor" href="#test-object_rest/spread_properties">&#xA7;</a><a href="https://github.com/tc39/proposal-object-rest-spread">object rest/spread properties</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/2</td>
@@ -14111,9 +14023,7 @@ return i === 0;
 <td class="tally" data-browser="typescript5_1corejs3" data-tally="1">2/2</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">2/2</td>
@@ -14126,9 +14036,10 @@ return i === 0;
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">2/2</td>
 <td class="tally" data-browser="firefox115" data-tally="1">2/2</td>
-<td class="tally" data-browser="firefox116" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">2/2</td>
+<td class="tally" data-browser="firefox117" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">2/2</td>
@@ -14267,9 +14178,7 @@ return a === 1 &amp;&amp; rest.a === void undefined &amp;&amp; rest.b === 2 &amp
 <td class="yes" data-browser="typescript5_1corejs3">Yes</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -14282,9 +14191,10 @@ return a === 1 &amp;&amp; rest.a === void undefined &amp;&amp; rest.b === 2 &amp
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -14424,9 +14334,7 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="yes" data-browser="typescript5_1corejs3">Yes</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -14439,9 +14347,10 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -14576,9 +14485,7 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="tally" data-browser="typescript5_1corejs3" data-tally="1">3/3</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/3</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">3/3</td>
@@ -14591,9 +14498,10 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">3/3</td>
 <td class="tally" data-browser="firefox115" data-tally="1">3/3</td>
-<td class="tally" data-browser="firefox116" data-tally="1">3/3</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">3/3</td>
+<td class="tally" data-browser="firefox117" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">3/3</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">3/3</td>
@@ -14757,9 +14665,7 @@ function check() {
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -14772,9 +14678,10 @@ function check() {
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -14930,9 +14837,7 @@ function check() {
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -14945,9 +14850,10 @@ function check() {
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -15105,9 +15011,7 @@ function check() {
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -15120,9 +15024,10 @@ function check() {
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -15261,9 +15166,7 @@ return regex.test(&apos;foo\nbar&apos;);
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -15276,9 +15179,10 @@ return regex.test(&apos;foo\nbar&apos;);
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -15423,9 +15327,7 @@ return result.groups.year === &apos;2016&apos;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -15438,9 +15340,10 @@ return result.groups.year === &apos;2016&apos;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -15579,9 +15482,7 @@ return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&a
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -15594,9 +15495,10 @@ return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&a
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -15735,9 +15637,7 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -15750,9 +15650,10 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -15887,9 +15788,7 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="tally" data-browser="typescript5_1corejs3" data-tally="1">2/2</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">2/2</td>
@@ -15902,9 +15801,10 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">2/2</td>
 <td class="tally" data-browser="firefox115" data-tally="1">2/2</td>
-<td class="tally" data-browser="firefox116" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">2/2</td>
+<td class="tally" data-browser="firefox117" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">2/2</td>
@@ -16049,9 +15949,7 @@ iterator.next().then(function(step){
 <td class="yes" data-browser="typescript5_1corejs3">Yes</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -16064,9 +15962,10 @@ iterator.next().then(function(step){
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -16221,9 +16120,7 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="yes" data-browser="typescript5_1corejs3">Yes</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -16236,9 +16133,10 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -16352,7 +16250,7 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="yes" data-browser="opera_mobile76">Yes</td>
 <td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
-<tr class="category"><td colspan="153"><span>2018 misc</span></td>
+<tr class="category"><td colspan="152"><span>2018 misc</span></td>
 </tr>
 <tr significance="0.125"><td id="test-Proxy_ownKeys_handler,_duplicate_keys_for_non-extensible_targets"><span><a class="anchor" href="#test-Proxy_ownKeys_handler,_duplicate_keys_for_non-extensible_targets">&#xA7;</a><a href="https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-ownpropertykeys">Proxy &quot;ownKeys&quot; handler, duplicate keys for non-extensible targets</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/ownKeys" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var p = new Proxy({}, {
@@ -16388,9 +16286,7 @@ return false;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="unknown" data-browser="ie11">?</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -16403,9 +16299,10 @@ return false;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -16550,9 +16447,7 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -16565,9 +16460,10 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -16681,7 +16577,7 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="yes" data-browser="opera_mobile76">Yes</td>
 <td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
-<tr class="category"><td colspan="153"><span>2019 features</span></td>
+<tr class="category"><td colspan="152"><span>2019 features</span></td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Symbol.prototype.description"><span><a class="anchor" href="#test-Symbol.prototype.description">&#xA7;</a><a href="https://github.com/tc39/proposal-Symbol-description">Symbol.prototype.description</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/description" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/3</td>
@@ -16704,9 +16600,7 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="tally" data-browser="typescript5_1corejs3" data-tally="1">3/3</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/3</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">3/3</td>
@@ -16719,9 +16613,10 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">3/3</td>
 <td class="tally" data-browser="firefox115" data-tally="1">3/3</td>
-<td class="tally" data-browser="firefox116" data-tally="1">3/3</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">3/3</td>
+<td class="tally" data-browser="firefox117" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">3/3</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">3/3</td>
@@ -16859,9 +16754,7 @@ return Symbol(&apos;foo&apos;).description === &apos;foo&apos;;
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -16874,9 +16767,10 @@ return Symbol(&apos;foo&apos;).description === &apos;foo&apos;;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -17014,9 +16908,7 @@ return Symbol(&apos;&apos;).description === &apos;&apos;;
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -17029,9 +16921,10 @@ return Symbol(&apos;&apos;).description === &apos;&apos;;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -17170,9 +17063,7 @@ return Symbol.prototype.hasOwnProperty(&apos;description&apos;)
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -17185,9 +17076,10 @@ return Symbol.prototype.hasOwnProperty(&apos;description&apos;)
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -17326,9 +17218,7 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -17341,9 +17231,10 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -17478,9 +17369,7 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="tally" data-browser="typescript5_1corejs3" data-tally="1">4/4</td>
 <td class="tally" data-browser="es7shim" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">4/4</td>
@@ -17493,9 +17382,10 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">4/4</td>
 <td class="tally" data-browser="firefox115" data-tally="1">4/4</td>
-<td class="tally" data-browser="firefox116" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">4/4</td>
+<td class="tally" data-browser="firefox117" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">4/4</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">4/4</td>
@@ -17633,9 +17523,7 @@ return &apos; \t \n abc   \t\n&apos;.trimLeft() === &apos;abc   \t\n&apos;;
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -17648,9 +17536,10 @@ return &apos; \t \n abc   \t\n&apos;.trimLeft() === &apos;abc   \t\n&apos;;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -17788,9 +17677,7 @@ return &apos; \t \n abc   \t\n&apos;.trimRight() === &apos; \t \n abc&apos;;
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -17803,9 +17690,10 @@ return &apos; \t \n abc   \t\n&apos;.trimRight() === &apos; \t \n abc&apos;;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -17943,9 +17831,7 @@ return &apos; \t \n abc   \t\n&apos;.trimStart() === &apos;abc   \t\n&apos;;
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -17958,9 +17844,10 @@ return &apos; \t \n abc   \t\n&apos;.trimStart() === &apos;abc   \t\n&apos;;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -18098,9 +17985,7 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -18113,9 +17998,10 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -18250,9 +18136,7 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="tally" data-browser="typescript5_1corejs3" data-tally="1">3/3</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/3</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">3/3</td>
@@ -18265,9 +18149,10 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">3/3</td>
 <td class="tally" data-browser="firefox115" data-tally="1">3/3</td>
-<td class="tally" data-browser="firefox116" data-tally="1">3/3</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">3/3</td>
+<td class="tally" data-browser="firefox117" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">3/3</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">3/3</td>
@@ -18405,9 +18290,7 @@ return [1, [2, 3], [4, [5, 6]]].flat().join(&apos;&apos;) === &apos;12345,6&apos
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -18420,9 +18303,10 @@ return [1, [2, 3], [4, [5, 6]]].flat().join(&apos;&apos;) === &apos;12345,6&apos
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -18562,9 +18446,7 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -18577,9 +18459,10 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -18718,9 +18601,7 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -18733,9 +18614,10 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -18849,7 +18731,7 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="yes" data-browser="opera_mobile76">Yes</td>
 <td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
-<tr class="category"><td colspan="153"><span>2019 misc</span></td>
+<tr class="category"><td colspan="152"><span>2019 misc</span></td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-optional_catch_binding"><span><a class="anchor" href="#test-optional_catch_binding">&#xA7;</a><a href="https://github.com/tc39/proposal-optional-catch-binding">optional catch binding</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/3</td>
@@ -18872,9 +18754,7 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="tally" data-browser="typescript5_1corejs3" data-tally="1">3/3</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/3</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">3/3</td>
@@ -18887,9 +18767,10 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">3/3</td>
 <td class="tally" data-browser="firefox115" data-tally="1">3/3</td>
-<td class="tally" data-browser="firefox116" data-tally="1">3/3</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">3/3</td>
+<td class="tally" data-browser="firefox117" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">3/3</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">3/3</td>
@@ -19033,9 +18914,7 @@ return false;
 <td class="yes" data-browser="typescript5_1corejs3">Yes</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -19048,9 +18927,10 @@ return false;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -19195,9 +19075,7 @@ return false;
 <td class="yes" data-browser="typescript5_1corejs3">Yes</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -19210,9 +19088,10 @@ return false;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -19361,9 +19240,7 @@ return it.throw().value;
 <td class="yes" data-browser="typescript5_1corejs3">Yes</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -19376,9 +19253,10 @@ return it.throw().value;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -19513,9 +19391,7 @@ return it.throw().value;
 <td class="tally" data-browser="typescript5_1corejs3" data-tally="0">0/7</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/7</td>
 <td class="tally" data-browser="ie11" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">7/7</td>
@@ -19528,9 +19404,10 @@ return it.throw().value;
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">7/7</td>
 <td class="tally" data-browser="firefox115" data-tally="1">7/7</td>
-<td class="tally" data-browser="firefox116" data-tally="1">7/7</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">7/7</td>
+<td class="tally" data-browser="firefox117" data-tally="1">7/7</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">7/7</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">7/7</td>
@@ -19670,9 +19547,7 @@ return fn + &apos;&apos; === str;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -19685,9 +19560,10 @@ return fn + &apos;&apos; === str;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -19826,9 +19702,7 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -19841,9 +19715,10 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -19982,9 +19857,7 @@ return NATIVE_EVAL_RE.test(eval + &apos;&apos;);
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -19997,9 +19870,10 @@ return NATIVE_EVAL_RE.test(eval + &apos;&apos;);
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -20138,9 +20012,7 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -20153,9 +20025,10 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -20294,9 +20167,7 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -20309,9 +20180,10 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -20450,9 +20322,7 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -20465,9 +20335,10 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -20606,9 +20477,7 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -20621,9 +20490,10 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -20758,9 +20628,7 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="tally" data-browser="typescript5_1corejs3" data-tally="0">0/2</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">2/2</td>
@@ -20773,9 +20641,10 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">2/2</td>
 <td class="tally" data-browser="firefox115" data-tally="1">2/2</td>
-<td class="tally" data-browser="firefox116" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">2/2</td>
+<td class="tally" data-browser="firefox117" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">2/2</td>
@@ -20913,9 +20782,7 @@ return eval(&quot;&apos;\u2028&apos;&quot;) === &quot;\u2028&quot;;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -20928,9 +20795,10 @@ return eval(&quot;&apos;\u2028&apos;&quot;) === &quot;\u2028&quot;;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -21068,9 +20936,7 @@ return eval(&quot;&apos;\u2029&apos;&quot;) === &quot;\u2029&quot;;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -21083,9 +20949,10 @@ return eval(&quot;&apos;\u2029&apos;&quot;) === &quot;\u2029&quot;;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -21224,9 +21091,7 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -21239,9 +21104,10 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -21355,7 +21221,7 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 <td class="yes" data-browser="opera_mobile76">Yes</td>
 <td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
-<tr class="category"><td colspan="153"><span>2020 features</span></td>
+<tr class="category"><td colspan="152"><span>2020 features</span></td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-String.prototype.matchAll"><span><a class="anchor" href="#test-String.prototype.matchAll">&#xA7;</a><a href="https://github.com/tc39/String.prototype.matchAll">String.prototype.matchAll</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/matchAll" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/2</td>
@@ -21378,9 +21244,7 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 <td class="tally" data-browser="typescript5_1corejs3" data-tally="1">2/2</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">2/2</td>
@@ -21393,9 +21257,10 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">2/2</td>
 <td class="tally" data-browser="firefox115" data-tally="1">2/2</td>
-<td class="tally" data-browser="firefox116" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">2/2</td>
+<td class="tally" data-browser="firefox117" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">2/2</td>
@@ -21543,9 +21408,7 @@ return a === &apos;1a2b&apos;
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -21558,9 +21421,10 @@ return a === &apos;1a2b&apos;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -21703,9 +21567,7 @@ try {
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -21718,9 +21580,10 @@ try {
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -21855,9 +21718,7 @@ try {
 <td class="tally" data-browser="typescript5_1corejs3" data-tally="0">0/8</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/8</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">8/8</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">8/8</td>
@@ -21870,9 +21731,10 @@ try {
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">8/8</td>
 <td class="tally" data-browser="firefox115" data-tally="1">8/8</td>
-<td class="tally" data-browser="firefox116" data-tally="1">8/8</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">8/8</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">8/8</td>
+<td class="tally" data-browser="firefox117" data-tally="1">8/8</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">8/8</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">8/8</td>
@@ -22010,9 +21872,7 @@ return (1n + 2n) === 3n;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -22025,9 +21885,10 @@ return (1n + 2n) === 3n;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -22165,9 +22026,7 @@ return BigInt(&quot;3&quot;) === 3n;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -22180,9 +22039,10 @@ return BigInt(&quot;3&quot;) === 3n;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -22320,9 +22180,7 @@ return typeof BigInt.asUintN === &apos;function&apos;;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -22335,9 +22193,10 @@ return typeof BigInt.asUintN === &apos;function&apos;;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -22475,9 +22334,7 @@ return typeof BigInt.asIntN === &apos;function&apos;;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -22490,9 +22347,10 @@ return typeof BigInt.asIntN === &apos;function&apos;;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -22633,9 +22491,7 @@ return view[0] === -0x8000000000000000n;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -22648,9 +22504,10 @@ return view[0] === -0x8000000000000000n;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -22791,9 +22648,7 @@ return view[0] === 0n;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -22806,9 +22661,10 @@ return view[0] === 0n;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -22949,9 +22805,7 @@ return view.getBigInt64(0) === 1n;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -22964,9 +22818,10 @@ return view.getBigInt64(0) === 1n;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -23107,9 +22962,7 @@ return view.getBigUint64(0) === 1n;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -23122,9 +22975,10 @@ return view.getBigUint64(0) === 1n;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -23273,9 +23127,7 @@ Promise.allSettled([
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -23288,9 +23140,10 @@ Promise.allSettled([
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -23425,9 +23278,7 @@ Promise.allSettled([
 <td class="tally" data-browser="typescript5_1corejs3" data-tally="1">2/2</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">2/2</td>
@@ -23440,9 +23291,10 @@ Promise.allSettled([
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">2/2</td>
 <td class="tally" data-browser="firefox115" data-tally="1">2/2</td>
-<td class="tally" data-browser="firefox116" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">2/2</td>
+<td class="tally" data-browser="firefox117" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">2/2</td>
@@ -23582,9 +23434,7 @@ return typeof globalThis === &apos;object&apos; &amp;&amp; globalThis &amp;&amp;
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -23597,9 +23447,10 @@ return typeof globalThis === &apos;object&apos; &amp;&amp; globalThis &amp;&amp;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -23743,9 +23594,7 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -23758,9 +23607,10 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -23895,9 +23745,7 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="tally" data-browser="typescript5_1corejs3" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/5</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">5/5</td>
@@ -23910,9 +23758,10 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">5/5</td>
 <td class="tally" data-browser="firefox115" data-tally="1">5/5</td>
-<td class="tally" data-browser="firefox116" data-tally="1">5/5</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">5/5</td>
+<td class="tally" data-browser="firefox117" data-tally="1">5/5</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">5/5</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">5/5</td>
@@ -24052,9 +23901,7 @@ return foo?.baz === 42 &amp;&amp; bar?.baz === void undefined;
 <td class="yes" data-browser="typescript5_1corejs3">Yes</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -24067,9 +23914,10 @@ return foo?.baz === 42 &amp;&amp; bar?.baz === void undefined;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -24209,9 +24057,7 @@ return foo?.[&apos;baz&apos;] === 42 &amp;&amp; bar?.[&apos;baz&apos;] === void 
 <td class="yes" data-browser="typescript5_1corejs3">Yes</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -24224,9 +24070,10 @@ return foo?.[&apos;baz&apos;] === 42 &amp;&amp; bar?.[&apos;baz&apos;] === void 
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -24366,9 +24213,7 @@ return foo?.baz() === 42 &amp;&amp; bar?.baz() === void undefined;
 <td class="yes" data-browser="typescript5_1corejs3">Yes</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -24381,9 +24226,10 @@ return foo?.baz() === 42 &amp;&amp; bar?.baz() === void undefined;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -24525,9 +24371,7 @@ return foo.baz?.() === 42 &amp;&amp; bar.baz?.() === void undefined &amp;&amp; b
 <td class="yes" data-browser="typescript5_1corejs3">Yes</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -24540,9 +24384,10 @@ return foo.baz?.() === 42 &amp;&amp; bar.baz?.() === void undefined &amp;&amp; b
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -24684,9 +24529,7 @@ return fn?.(...[], 1) === void undefined &amp;&amp; fn?.(...[], ...[]) === void 
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -24699,9 +24542,10 @@ return fn?.(...[], 1) === void undefined &amp;&amp; fn?.(...[], ...[]) === void 
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -24844,9 +24688,7 @@ return (null ?? 42) === 42 &amp;&amp;
 <td class="yes" data-browser="typescript5_1corejs3">Yes</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -24859,9 +24701,10 @@ return (null ?? 42) === 42 &amp;&amp;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -24975,7 +24818,7 @@ return (null ?? 42) === 42 &amp;&amp;
 <td class="yes" data-browser="opera_mobile76">Yes</td>
 <td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
-<tr class="category"><td colspan="153"><span>2021 features</span></td>
+<tr class="category"><td colspan="152"><span>2021 features</span></td>
 </tr>
 <tr significance="0.25"><td id="test-String.prototype.replaceAll"><span><a class="anchor" href="#test-String.prototype.replaceAll">&#xA7;</a><a href="https://github.com/tc39/proposal-string-replace-all">String.prototype.replaceAll</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &apos;) === &apos;q=query string parameters&apos;;
@@ -25001,9 +24844,7 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -25016,9 +24857,10 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -25153,9 +24995,7 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="tally" data-browser="typescript5_1corejs3" data-tally="1">2/2</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">2/2</td>
@@ -25168,9 +25008,10 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">2/2</td>
 <td class="tally" data-browser="firefox115" data-tally="1">2/2</td>
-<td class="tally" data-browser="firefox116" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">2/2</td>
+<td class="tally" data-browser="firefox117" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">2/2</td>
@@ -25314,9 +25155,7 @@ Promise.any([
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -25329,9 +25168,10 @@ Promise.any([
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -25475,9 +25315,7 @@ Promise.any([
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -25490,9 +25328,10 @@ Promise.any([
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -25627,9 +25466,7 @@ Promise.any([
 <td class="tally" data-browser="typescript5_1corejs3" data-tally="0">0/2</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">2/2</td>
@@ -25642,9 +25479,10 @@ Promise.any([
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">2/2</td>
 <td class="tally" data-browser="firefox115" data-tally="1">2/2</td>
-<td class="tally" data-browser="firefox116" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">2/2</td>
+<td class="tally" data-browser="firefox117" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">2/2</td>
@@ -25784,9 +25622,7 @@ return weakref.deref() === O;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -25799,9 +25635,10 @@ return weakref.deref() === O;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -25940,9 +25777,7 @@ return Object.getPrototypeOf(fr) === FinalizationRegistry.prototype;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -25955,9 +25790,10 @@ return Object.getPrototypeOf(fr) === FinalizationRegistry.prototype;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -26092,9 +25928,7 @@ return Object.getPrototypeOf(fr) === FinalizationRegistry.prototype;
 <td class="tally" data-browser="typescript5_1corejs3" data-tally="0">0/9</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/9</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/9</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">9/9</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">9/9</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">9/9</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">9/9</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">9/9</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">9/9</td>
@@ -26107,9 +25941,10 @@ return Object.getPrototypeOf(fr) === FinalizationRegistry.prototype;
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">9/9</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">9/9</td>
 <td class="tally" data-browser="firefox115" data-tally="1">9/9</td>
-<td class="tally" data-browser="firefox116" data-tally="1">9/9</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">9/9</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">9/9</td>
+<td class="tally" data-browser="firefox117" data-tally="1">9/9</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">9/9</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">9/9</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">9/9</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">9/9</td>
@@ -26253,9 +26088,7 @@ return a === 2 &amp;&amp; b === 2 &amp;&amp; c === 1;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -26268,9 +26101,10 @@ return a === 2 &amp;&amp; b === 2 &amp;&amp; c === 1;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -26411,9 +26245,7 @@ return a === 1 &amp;&amp; i === 1;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -26426,9 +26258,10 @@ return a === 1 &amp;&amp; i === 1;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -26569,9 +26402,7 @@ return i === 1;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -26584,9 +26415,10 @@ return i === 1;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -26730,9 +26562,7 @@ return typeof a === &apos;undefined&apos; &amp;&amp; b === 0 &amp;&amp; c === 2;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -26745,9 +26575,10 @@ return typeof a === &apos;undefined&apos; &amp;&amp; b === 0 &amp;&amp; c === 2;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -26888,9 +26719,7 @@ return typeof a === &apos;undefined&apos; &amp;&amp; i === 1;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -26903,9 +26732,10 @@ return typeof a === &apos;undefined&apos; &amp;&amp; i === 1;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -27046,9 +26876,7 @@ return i === 1;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -27061,9 +26889,10 @@ return i === 1;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -27207,9 +27036,7 @@ return a === 2 &amp;&amp; b === 0 &amp;&amp; c === 1;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -27222,9 +27049,10 @@ return a === 2 &amp;&amp; b === 0 &amp;&amp; c === 1;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -27365,9 +27193,7 @@ return a === 1 &amp;&amp; i === 1;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -27380,9 +27206,10 @@ return a === 1 &amp;&amp; i === 1;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -27523,9 +27350,7 @@ return i === 1;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -27538,9 +27363,10 @@ return i === 1;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -27679,9 +27505,7 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="yes" data-browser="typescript5_1corejs3">Yes</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -27694,9 +27518,10 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -27810,7 +27635,7 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="yes" data-browser="opera_mobile76">Yes</td>
 <td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
-<tr class="category"><td colspan="153"><span>2022 features</span></td>
+<tr class="category"><td colspan="152"><span>2022 features</span></td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-instance_class_fields"><span><a class="anchor" href="#test-instance_class_fields">&#xA7;</a><a href="https://github.com/tc39/proposal-class-fields">instance class fields</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
@@ -27833,9 +27658,7 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="tally" data-browser="typescript5_1corejs3" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/6</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">6/6</td>
@@ -27848,9 +27671,10 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">6/6</td>
 <td class="tally" data-browser="firefox115" data-tally="1">6/6</td>
-<td class="tally" data-browser="firefox116" data-tally="1">6/6</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">6/6</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">6/6</td>
+<td class="tally" data-browser="firefox117" data-tally="1">6/6</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">6/6</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">6/6</td>
@@ -27991,9 +27815,7 @@ return new C().x === &apos;x&apos;;
 <td class="yes" data-browser="typescript5_1corejs3">Yes</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -28006,9 +27828,10 @@ return new C().x === &apos;x&apos;;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -28155,9 +27978,7 @@ return new C(42).x() === 42;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -28170,9 +27991,10 @@ return new C(42).x() === 42;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -28316,9 +28138,7 @@ return new C().x() === 42;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -28331,9 +28151,10 @@ return new C().x() === 42;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -28477,9 +28298,7 @@ return new C().x() === 42 &amp;&amp; new C().x(null) === void 0;
 <td class="no" data-browser="typescript5_1corejs3">No</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -28492,9 +28311,10 @@ return new C().x() === 42 &amp;&amp; new C().x(null) === void 0;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -28638,9 +28458,7 @@ return new C().x() === 42 &amp;&amp; new C().x(null) === void 0;
 <td class="no" data-browser="typescript5_1corejs3">No</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -28653,9 +28471,10 @@ return new C().x() === 42 &amp;&amp; new C().x(null) === void 0;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -28796,9 +28615,7 @@ return new C().x === 42;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -28811,9 +28628,10 @@ return new C().x === 42;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -28948,9 +28766,7 @@ return new C().x === 42;
 <td class="tally" data-browser="typescript5_1corejs3" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">4/4</td>
@@ -28963,9 +28779,10 @@ return new C().x === 42;
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">4/4</td>
 <td class="tally" data-browser="firefox115" data-tally="1">4/4</td>
-<td class="tally" data-browser="firefox116" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">4/4</td>
+<td class="tally" data-browser="firefox117" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">4/4</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">4/4</td>
@@ -29106,9 +28923,7 @@ return C.x === &apos;x&apos;;
 <td class="yes" data-browser="typescript5_1corejs3">Yes</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -29121,9 +28936,10 @@ return C.x === &apos;x&apos;;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -29261,9 +29077,7 @@ return (class X { static name = &quot;name&quot;; }).name === &apos;name&apos;;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="unknown" data-browser="ie11">?</td>
-<td class="unknown obsolete" data-browser="firefox91">?</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -29276,9 +29090,10 @@ return (class X { static name = &quot;name&quot;; }).name === &apos;name&apos;;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -29422,9 +29237,7 @@ return new C().x() === 42;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -29437,9 +29250,10 @@ return new C().x() === 42;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -29580,9 +29394,7 @@ return C.x === 42;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -29595,9 +29407,10 @@ return C.x === 42;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -29732,9 +29545,7 @@ return C.x === 42;
 <td class="tally" data-browser="typescript5_1corejs3" data-tally="0">0/4</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">4/4</td>
@@ -29747,9 +29558,10 @@ return C.x === 42;
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">4/4</td>
 <td class="tally" data-browser="firefox115" data-tally="1">4/4</td>
-<td class="tally" data-browser="firefox116" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">4/4</td>
+<td class="tally" data-browser="firefox117" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">4/4</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">4/4</td>
@@ -29893,9 +29705,7 @@ return new C().x() === 42;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -29908,9 +29718,10 @@ return new C().x() === 42;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -30054,9 +29865,7 @@ return new C().x() === 42;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -30069,9 +29878,10 @@ return new C().x() === 42;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -30218,9 +30028,7 @@ return new C().x() === 42 &amp;&amp; y;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -30233,9 +30041,10 @@ return new C().x() === 42 &amp;&amp; y;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -30382,9 +30191,7 @@ return new C().x() === 42 &amp;&amp; y;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -30397,9 +30204,10 @@ return new C().x() === 42 &amp;&amp; y;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -30543,9 +30351,7 @@ return A.check(new A) &amp;&amp; !A.check({});
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -30558,9 +30364,10 @@ return A.check(new A) &amp;&amp; !A.check({});
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -30695,9 +30502,7 @@ return A.check(new A) &amp;&amp; !A.check({});
 <td class="tally" data-browser="typescript5_1corejs3" data-tally="1">3/3</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/3</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">3/3</td>
@@ -30710,9 +30515,10 @@ return A.check(new A) &amp;&amp; !A.check({});
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">3/3</td>
 <td class="tally" data-browser="firefox115" data-tally="1">3/3</td>
-<td class="tally" data-browser="firefox116" data-tally="1">3/3</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">3/3</td>
+<td class="tally" data-browser="firefox117" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">3/3</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">3/3</td>
@@ -30858,9 +30664,7 @@ return arr.at(0) === 1
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -30873,9 +30677,10 @@ return arr.at(0) === 1
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -31021,9 +30826,7 @@ return str.at(0) === &apos;a&apos;
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -31036,9 +30839,10 @@ return str.at(0) === &apos;a&apos;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -31200,9 +31004,7 @@ return [
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -31215,9 +31017,10 @@ return [
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -31352,9 +31155,7 @@ return [
 <td class="tally" data-browser="typescript5_1corejs3" data-tally="1">2/2</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="0" data-flagged-tally="1">0/2</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">2/2</td>
@@ -31367,9 +31168,10 @@ return [
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">2/2</td>
 <td class="tally" data-browser="firefox115" data-tally="1">2/2</td>
-<td class="tally" data-browser="firefox116" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">2/2</td>
+<td class="tally" data-browser="firefox117" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">2/2</td>
@@ -31507,9 +31309,7 @@ return Object.hasOwn({ x: 2 }, &quot;x&quot;) === true;
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged obsolete" data-browser="firefox91">Flag<a href="#firefox-nightly-note"><sup>[33]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -31522,9 +31322,10 @@ return Object.hasOwn({ x: 2 }, &quot;x&quot;) === true;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -31668,9 +31469,7 @@ try {
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged obsolete" data-browser="firefox91">Flag<a href="#firefox-nightly-note"><sup>[33]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -31683,9 +31482,10 @@ try {
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -31827,9 +31627,7 @@ return ok;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no flagged obsolete" data-browser="firefox91">Flag<a href="#ff-static-init-blocks-note"><sup>[34]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -31842,9 +31640,10 @@ return ok;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -31905,7 +31704,7 @@ return ok;
 <td class="no obsolete" data-browser="node0_12">No</td>
 <td class="no obsolete" data-browser="node14_6">No</td>
 <td class="no obsolete" data-browser="node16_0">No</td>
-<td class="no flagged obsolete" data-browser="node16_9">Flag<a href="#ch-static-init-blocks-note"><sup>[35]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node16_9">Flag<a href="#ch-static-init-blocks-note"><sup>[33]</sup></a></td>
 <td class="yes" data-browser="node16_11">Yes</td>
 <td class="yes obsolete" data-browser="node17_0">Yes</td>
 <td class="yes obsolete" data-browser="node17_2">Yes</td>
@@ -31979,9 +31778,7 @@ return ok;
 <td class="tally" data-browser="typescript5_1corejs3" data-tally="0">0/16</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/16</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/16</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">16/16</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">16/16</td>
@@ -31994,9 +31791,10 @@ return ok;
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">16/16</td>
 <td class="tally" data-browser="firefox115" data-tally="1">16/16</td>
-<td class="tally" data-browser="firefox116" data-tally="1">16/16</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">16/16</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">16/16</td>
+<td class="tally" data-browser="firefox117" data-tally="1">16/16</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">16/16</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/16</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">16/16</td>
@@ -32135,9 +31933,7 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -32150,9 +31946,10 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -32290,9 +32087,7 @@ return !(&apos;cause&apos; in Error.prototype);
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -32305,9 +32100,10 @@ return !(&apos;cause&apos; in Error.prototype);
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -32446,9 +32242,7 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -32461,9 +32255,10 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -32601,9 +32396,7 @@ return !(&apos;cause&apos; in EvalError.prototype);
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -32616,9 +32409,10 @@ return !(&apos;cause&apos; in EvalError.prototype);
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -32757,9 +32551,7 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -32772,9 +32564,10 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -32912,9 +32705,7 @@ return !(&apos;cause&apos; in RangeError.prototype);
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -32927,9 +32718,10 @@ return !(&apos;cause&apos; in RangeError.prototype);
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -33068,9 +32860,7 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -33083,9 +32873,10 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -33223,9 +33014,7 @@ return !(&apos;cause&apos; in ReferenceError.prototype);
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -33238,9 +33027,10 @@ return !(&apos;cause&apos; in ReferenceError.prototype);
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -33379,9 +33169,7 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -33394,9 +33182,10 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -33534,9 +33323,7 @@ return !(&apos;cause&apos; in SyntaxError.prototype);
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -33549,9 +33336,10 @@ return !(&apos;cause&apos; in SyntaxError.prototype);
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -33690,9 +33478,7 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -33705,9 +33491,10 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -33845,9 +33632,7 @@ return !(&apos;cause&apos; in TypeError.prototype);
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -33860,9 +33645,10 @@ return !(&apos;cause&apos; in TypeError.prototype);
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -34001,9 +33787,7 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -34016,9 +33800,10 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -34156,9 +33941,7 @@ return !(&apos;cause&apos; in URIError.prototype);
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -34171,9 +33954,10 @@ return !(&apos;cause&apos; in URIError.prototype);
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -34312,9 +34096,7 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -34327,9 +34109,10 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -34467,9 +34250,7 @@ return !(&apos;cause&apos; in AggregateError.prototype);
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -34482,9 +34263,10 @@ return !(&apos;cause&apos; in AggregateError.prototype);
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -34619,9 +34401,7 @@ return !(&apos;cause&apos; in AggregateError.prototype);
 <td class="tally" data-browser="typescript5_1corejs3" data-tally="0">0/2</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">2/2</td>
@@ -34634,9 +34414,10 @@ return !(&apos;cause&apos; in AggregateError.prototype);
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">2/2</td>
 <td class="tally" data-browser="firefox115" data-tally="1">2/2</td>
-<td class="tally" data-browser="firefox116" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="firefox118" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally" data-browser="firefox117" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally unstable" data-browser="firefox118" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
@@ -34774,9 +34555,7 @@ return new RegExp(&apos;a&apos;, &apos;d&apos;) instanceof RegExp;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="unknown" data-browser="ie11">?</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -34789,9 +34568,10 @@ return new RegExp(&apos;a&apos;, &apos;d&apos;) instanceof RegExp;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -34944,9 +34724,7 @@ return true;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="unknown" data-browser="ie11">?</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -34959,9 +34737,10 @@ return true;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
-<td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
+<td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -35075,7 +34854,7 @@ return true;
 <td class="no" data-browser="opera_mobile76">No</td>
 <td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
-<tr class="category"><td colspan="153"><span>2023 features</span></td>
+<tr class="category"><td colspan="152"><span>2023 features</span></td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Array_find_from_last"><span><a class="anchor" href="#test-Array_find_from_last">&#xA7;</a><a href="https://github.com/tc39/proposal-array-find-from-last">Array find from last</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/2</td>
@@ -35098,9 +34877,7 @@ return true;
 <td class="tally" data-browser="typescript5_1corejs3" data-tally="1">2/2</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="0" data-flagged-tally="1">0/2</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">2/2</td>
@@ -35113,9 +34890,10 @@ return true;
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">2/2</td>
 <td class="tally" data-browser="firefox115" data-tally="1">2/2</td>
-<td class="tally" data-browser="firefox116" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">2/2</td>
+<td class="tally" data-browser="firefox117" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">2/2</td>
@@ -35254,9 +35032,7 @@ return arr.findLast(function (o) { return o.x === 1; }) === arr[2];
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no flagged obsolete" data-browser="firefox103">Flag<a href="#firefox-arrayfindfromlast-note"><sup>[36]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -35269,9 +35045,10 @@ return arr.findLast(function (o) { return o.x === 1; }) === arr[2];
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -35410,9 +35187,7 @@ return arr.findLastIndex(function (o) { return o.x === 1; }) === 2;
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no flagged obsolete" data-browser="firefox103">Flag<a href="#firefox-arrayfindfromlast-note"><sup>[36]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -35425,9 +35200,10 @@ return arr.findLastIndex(function (o) { return o.x === 1; }) === 2;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -35569,9 +35345,7 @@ try {
 <td class="no" data-browser="typescript5_1corejs3">No</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -35584,9 +35358,10 @@ try {
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -35700,7 +35475,7 @@ try {
 <td class="yes" data-browser="opera_mobile76">Yes</td>
 <td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
-<tr class="category"><td colspan="153"><span>Finished (stage 4)</span></td>
+<tr class="category"><td colspan="152"><span>Finished (stage 4)</span></td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-RegExp_`v`_flag"><span><a class="anchor" href="#test-RegExp_`v`_flag">&#xA7;</a><a href="https://github.com/tc39/proposal-regexp-v-flag">RegExp `v` flag</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/4</td>
@@ -35723,9 +35498,7 @@ try {
 <td class="tally" data-browser="typescript5_1corejs3" data-tally="0">0/4</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="0">0/4</td>
@@ -35738,9 +35511,10 @@ try {
 <td class="tally obsolete" data-browser="firefox113" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="0">0/4</td>
 <td class="tally" data-browser="firefox115" data-tally="0">0/4</td>
-<td class="tally" data-browser="firefox116" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">4/4</td>
+<td class="tally" data-browser="firefox117" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">4/4</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="0">0/4</td>
@@ -35879,9 +35653,7 @@ return /[\p{ASCII}&amp;&amp;\p{Decimal_Number}]/v.test(&quot;0&quot;)
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -35894,9 +35666,10 @@ return /[\p{ASCII}&amp;&amp;\p{Decimal_Number}]/v.test(&quot;0&quot;)
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="unknown obsolete" data-browser="chrome102">?</td>
 <td class="unknown obsolete" data-browser="chrome103">?</td>
@@ -35907,7 +35680,7 @@ return /[\p{ASCII}&amp;&amp;\p{Decimal_Number}]/v.test(&quot;0&quot;)
 <td class="unknown obsolete" data-browser="chrome108">?</td>
 <td class="unknown obsolete" data-browser="chrome109">?</td>
 <td class="no obsolete" data-browser="chrome110">No</td>
-<td class="no flagged obsolete" data-browser="chrome111">Flag<a href="#chrome-harmony-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome111">Flag<a href="#chrome-harmony-note"><sup>[34]</sup></a></td>
 <td class="yes obsolete" data-browser="chrome112">Yes</td>
 <td class="yes" data-browser="chrome113">Yes</td>
 <td class="yes unstable" data-browser="chrome114">Yes</td>
@@ -35922,7 +35695,7 @@ return /[\p{ASCII}&amp;&amp;\p{Decimal_Number}]/v.test(&quot;0&quot;)
 <td class="unknown obsolete" data-browser="edge108">?</td>
 <td class="unknown obsolete" data-browser="edge109">?</td>
 <td class="no obsolete" data-browser="edge110">No</td>
-<td class="no flagged obsolete" data-browser="edge111">Flag<a href="#chrome-harmony-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge111">Flag<a href="#chrome-harmony-note"><sup>[34]</sup></a></td>
 <td class="yes obsolete" data-browser="edge112">Yes</td>
 <td class="yes" data-browser="edge113">Yes</td>
 <td class="yes unstable" data-browser="edge114">Yes</td>
@@ -35944,7 +35717,7 @@ return /[\p{ASCII}&amp;&amp;\p{Decimal_Number}]/v.test(&quot;0&quot;)
 <td class="unknown obsolete" data-browser="opera94">?</td>
 <td class="unknown obsolete" data-browser="opera95">?</td>
 <td class="no obsolete" data-browser="opera96">No</td>
-<td class="no flagged obsolete" data-browser="opera97">Flag<a href="#chrome-harmony-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="opera97">Flag<a href="#chrome-harmony-note"><sup>[34]</sup></a></td>
 <td class="yes" data-browser="opera98">Yes</td>
 <td class="yes unstable" data-browser="opera99">Yes</td>
 <td class="unknown obsolete" data-browser="rhino1_7_13">?</td>
@@ -36035,9 +35808,7 @@ return /^\p{Emoji_Keycap_Sequence}$/v.test(&quot;*\uFE0F\u20E3&quot;)
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -36050,9 +35821,10 @@ return /^\p{Emoji_Keycap_Sequence}$/v.test(&quot;*\uFE0F\u20E3&quot;)
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="unknown obsolete" data-browser="chrome102">?</td>
 <td class="unknown obsolete" data-browser="chrome103">?</td>
@@ -36063,7 +35835,7 @@ return /^\p{Emoji_Keycap_Sequence}$/v.test(&quot;*\uFE0F\u20E3&quot;)
 <td class="unknown obsolete" data-browser="chrome108">?</td>
 <td class="unknown obsolete" data-browser="chrome109">?</td>
 <td class="no obsolete" data-browser="chrome110">No</td>
-<td class="no flagged obsolete" data-browser="chrome111">Flag<a href="#chrome-harmony-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome111">Flag<a href="#chrome-harmony-note"><sup>[34]</sup></a></td>
 <td class="yes obsolete" data-browser="chrome112">Yes</td>
 <td class="yes" data-browser="chrome113">Yes</td>
 <td class="yes unstable" data-browser="chrome114">Yes</td>
@@ -36078,7 +35850,7 @@ return /^\p{Emoji_Keycap_Sequence}$/v.test(&quot;*\uFE0F\u20E3&quot;)
 <td class="unknown obsolete" data-browser="edge108">?</td>
 <td class="unknown obsolete" data-browser="edge109">?</td>
 <td class="no obsolete" data-browser="edge110">No</td>
-<td class="no flagged obsolete" data-browser="edge111">Flag<a href="#chrome-harmony-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge111">Flag<a href="#chrome-harmony-note"><sup>[34]</sup></a></td>
 <td class="yes obsolete" data-browser="edge112">Yes</td>
 <td class="yes" data-browser="edge113">Yes</td>
 <td class="yes unstable" data-browser="edge114">Yes</td>
@@ -36100,7 +35872,7 @@ return /^\p{Emoji_Keycap_Sequence}$/v.test(&quot;*\uFE0F\u20E3&quot;)
 <td class="unknown obsolete" data-browser="opera94">?</td>
 <td class="unknown obsolete" data-browser="opera95">?</td>
 <td class="no obsolete" data-browser="opera96">No</td>
-<td class="no flagged obsolete" data-browser="opera97">Flag<a href="#chrome-harmony-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="opera97">Flag<a href="#chrome-harmony-note"><sup>[34]</sup></a></td>
 <td class="yes" data-browser="opera98">Yes</td>
 <td class="yes unstable" data-browser="opera99">Yes</td>
 <td class="unknown obsolete" data-browser="rhino1_7_13">?</td>
@@ -36190,9 +35962,7 @@ return new RegExp(&apos;a&apos;, &apos;v&apos;) instanceof RegExp;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -36205,9 +35975,10 @@ return new RegExp(&apos;a&apos;, &apos;v&apos;) instanceof RegExp;
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="unknown obsolete" data-browser="chrome102">?</td>
 <td class="unknown obsolete" data-browser="chrome103">?</td>
@@ -36218,7 +35989,7 @@ return new RegExp(&apos;a&apos;, &apos;v&apos;) instanceof RegExp;
 <td class="unknown obsolete" data-browser="chrome108">?</td>
 <td class="unknown obsolete" data-browser="chrome109">?</td>
 <td class="no obsolete" data-browser="chrome110">No</td>
-<td class="no flagged obsolete" data-browser="chrome111">Flag<a href="#chrome-harmony-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome111">Flag<a href="#chrome-harmony-note"><sup>[34]</sup></a></td>
 <td class="yes obsolete" data-browser="chrome112">Yes</td>
 <td class="yes" data-browser="chrome113">Yes</td>
 <td class="yes unstable" data-browser="chrome114">Yes</td>
@@ -36233,7 +36004,7 @@ return new RegExp(&apos;a&apos;, &apos;v&apos;) instanceof RegExp;
 <td class="unknown obsolete" data-browser="edge108">?</td>
 <td class="unknown obsolete" data-browser="edge109">?</td>
 <td class="no obsolete" data-browser="edge110">No</td>
-<td class="no flagged obsolete" data-browser="edge111">Flag<a href="#chrome-harmony-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge111">Flag<a href="#chrome-harmony-note"><sup>[34]</sup></a></td>
 <td class="yes obsolete" data-browser="edge112">Yes</td>
 <td class="yes" data-browser="edge113">Yes</td>
 <td class="yes unstable" data-browser="edge114">Yes</td>
@@ -36255,7 +36026,7 @@ return new RegExp(&apos;a&apos;, &apos;v&apos;) instanceof RegExp;
 <td class="unknown obsolete" data-browser="opera94">?</td>
 <td class="unknown obsolete" data-browser="opera95">?</td>
 <td class="no obsolete" data-browser="opera96">No</td>
-<td class="no flagged obsolete" data-browser="opera97">Flag<a href="#chrome-harmony-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="opera97">Flag<a href="#chrome-harmony-note"><sup>[34]</sup></a></td>
 <td class="yes" data-browser="opera98">Yes</td>
 <td class="yes unstable" data-browser="opera99">Yes</td>
 <td class="unknown obsolete" data-browser="rhino1_7_13">?</td>
@@ -36348,9 +36119,7 @@ return flags.indexOf(&quot;unicodeSets&quot;) !== -1;
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -36363,9 +36132,10 @@ return flags.indexOf(&quot;unicodeSets&quot;) !== -1;
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="unknown obsolete" data-browser="chrome102">?</td>
 <td class="unknown obsolete" data-browser="chrome103">?</td>
@@ -36376,7 +36146,7 @@ return flags.indexOf(&quot;unicodeSets&quot;) !== -1;
 <td class="unknown obsolete" data-browser="chrome108">?</td>
 <td class="unknown obsolete" data-browser="chrome109">?</td>
 <td class="no obsolete" data-browser="chrome110">No</td>
-<td class="no flagged obsolete" data-browser="chrome111">Flag<a href="#chrome-harmony-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome111">Flag<a href="#chrome-harmony-note"><sup>[34]</sup></a></td>
 <td class="yes obsolete" data-browser="chrome112">Yes</td>
 <td class="yes" data-browser="chrome113">Yes</td>
 <td class="yes unstable" data-browser="chrome114">Yes</td>
@@ -36391,7 +36161,7 @@ return flags.indexOf(&quot;unicodeSets&quot;) !== -1;
 <td class="unknown obsolete" data-browser="edge108">?</td>
 <td class="unknown obsolete" data-browser="edge109">?</td>
 <td class="no obsolete" data-browser="edge110">No</td>
-<td class="no flagged obsolete" data-browser="edge111">Flag<a href="#chrome-harmony-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge111">Flag<a href="#chrome-harmony-note"><sup>[34]</sup></a></td>
 <td class="yes obsolete" data-browser="edge112">Yes</td>
 <td class="yes" data-browser="edge113">Yes</td>
 <td class="yes unstable" data-browser="edge114">Yes</td>
@@ -36413,7 +36183,7 @@ return flags.indexOf(&quot;unicodeSets&quot;) !== -1;
 <td class="unknown obsolete" data-browser="opera94">?</td>
 <td class="unknown obsolete" data-browser="opera95">?</td>
 <td class="no obsolete" data-browser="opera96">No</td>
-<td class="no flagged obsolete" data-browser="opera97">Flag<a href="#chrome-harmony-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="opera97">Flag<a href="#chrome-harmony-note"><sup>[34]</sup></a></td>
 <td class="yes" data-browser="opera98">Yes</td>
 <td class="yes unstable" data-browser="opera99">Yes</td>
 <td class="unknown obsolete" data-browser="rhino1_7_13">?</td>
@@ -36483,7 +36253,7 @@ return flags.indexOf(&quot;unicodeSets&quot;) !== -1;
     </table>
     <div id="footnotes">
       <!-- FOOTNOTES -->
-    <p id="harmony-flag-old-note">  <sup>[1]</sup> Flagged features have to be enabled via <code>--harmony</code> flag</p><p id="harmony-flag-note">  <sup>[2]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="graalvm-node-mode-note">  <sup>[3]</sup> Executed in Node.js/JVM mode via <code>graalvm/bin/node --jvm</code>.</p><p id="graalvm-js-intl-mode-note">  <sup>[4]</sup> Executed using <code>js --js.intl-402</code>.</p><p id="babel-core-js-note">  <sup>[5]</sup> This feature is supported when using Babel with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="typescript-core-js-note">  <sup>[6]</sup> This feature is supported when using TypeScript with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="new-gen-fn-note">  <sup>[7]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#67-new--generatorfunction">TC39 meeting notes from July 28, 2015.</a></p><p id="gen-throw-note">  <sup>[8]</sup> <a href="https://github.com/tc39/ecma262/issues/293">&apos;Semantics of yield* in throw case&apos; GitHub issue in ECMA-262 repo.</a></p><p id="typescript-downlevel-iteration-note">  <sup>[9]</sup> Requires the <code>downlevelIteration</code> compile option.</p><p id="strict-fn-non-strict-params-note">  <sup>[10]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-29.md#611-the-scope-of-use-strict-with-respect-to-destructuring-in-parameter-lists">TC39 meeting notes from July 29, 2015.</a></p><p id="nested-rest-destruct-decl-note">  <sup>[11]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#66-bindingrestelement-should-allow-a-bindingpattern-ala-assignmentrestelement">TC39 meeting notes from July 28, 2015.</a></p><p id="nested-rest-destruct-params-note">  <sup>[12]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#66-bindingrestelement-should-allow-a-bindingpattern-ala-assignmentrestelement">TC39 meeting notes from July 28, 2015.</a></p><p id="proxy-enumerate-removed-note">  <sup>[13]</sup> <a href="https://github.com/tc39/ecma262/pull/367">&apos;Normative: Remove [[Enumerate]] and associated reflective capabilities&apos; GitHub Pull Request in ECMA-262 repo.</a></p><p id="babel-regenerator-note">  <sup>[14]</sup> This feature requires native generators or <code>regenerator-runtime</code>, it&apos;s a part of <code>babel-polyfill</code> or <code>babel-runtime</code>.</p><p id="fx-shared-memory-cors-isolation-note">  <sup>[15]</sup> The feature is available with <a href="https://hacks.mozilla.org/2020/07/safely-reviving-shared-memory/">properly set CORS isolation headers</a> or via enabling <code>dom.postMessage.sharedArrayBuffer.bypassCOOP_COEP.insecure.enabled</code> setting under <code>about:config</code></p><p id="edg-shared-memory-spectre-note">  <sup>[16]</sup> The feature was temporarily disabled to mitigate the Meltdown and Spectre CPU bugs.</p><p id="sf-shared-memory-spectre-note">  <sup>[17]</sup> The feature was <a href="https://webkit.org/blog/8048/what-spectre-and-meltdown-mean-for-webkit/">temporarily disabled</a> to mitigate the Meltdown and Spectre CPU bugs.</p><p id="chrome-experimental-note">  <sup>[18]</sup> The feature has to be enabled via &quot;Experimental Javascript features&quot; setting under <code>about:flags</code></p><p id="closure-object-assign-note">  <sup>[19]</sup> Requires native support for <code>Object.assign</code></p><p id="typescript-es6-note">  <sup>[20]</sup> TypeScript&apos;s compiler will accept code using this feature if the <code>--target ES6</code> flag is set, but passes it through unmodified and does not supply a runtime polyfill.</p><p id="flatten-compat-issue-note">  <sup>[21]</sup> Name of <code>Array.prototype.flatten()</code> changed to <code>Array.prototype.flat()</code> due to <a href="https://github.com/tc39/proposal-flatMap/pull/56">web compatibility issues.</a></p><p id="graalvm-js-ecmascript-version-2020-note">  <sup>[22]</sup> Requires the <code>--js.ecmascript-version=2020</code> flag.</p><p id="chrome-string-prototype-replace-all-note">  <sup>[23]</sup> The feature is considered unstable, but can be enabled via <code>--js-flags=&quot;--harmony-string-replaceall&quot;</code> flag</p><p id="graalvm-js-ecmascript-version-2021-note">  <sup>[24]</sup> Requires the <code>--js.ecmascript-version=2021</code> flag.</p><p id="chrome-promise-any-note">  <sup>[25]</sup> Available behind the <a href="https://bugs.chromium.org/p/v8/issues/detail?id=9808"><code>--js-flags=&quot;--harmony-promise-any&quot;</code></a> flag in V8.</p><p id="chrome-weakrefs-note">  <sup>[26]</sup> Available behind the <a href="https://bugs.chromium.org/p/v8/issues/detail?id=8179"><code>--js-flags=&quot;--harmony-weak-refs --expose-gc&quot;</code></a> flag in V8.</p><p id="chrome-logical-assignment-note">  <sup>[27]</sup> Available behind the <a href="https://github.com/v8/v8/commit/b151d8db22be308738192497a68c2c7c0d8d4070"><code>--js-flags=&quot;--logical-assignment&quot;</code></a> flag in V8.</p><p id="graalvm-js-ecmascript-version-staging-note">  <sup>[28]</sup> Requires the <code>--js.ecmascript-version=staging</code> flag.</p><p id="closure-at-method-note">  <sup>[29]</sup> Requires native support for <code>Math.trunc</code></p><p id="graalvm-js-ecmascript-version-2022-note">  <sup>[30]</sup> Requires the <code>--js.ecmascript-version=2022</code> flag.</p><p id="safari-at-method-note">  <sup>[31]</sup> The feature has to be enabled via <code>jscOptions=--useAtMethod=true</code> flag.</p><p id="closure-typed-array-note">  <sup>[32]</sup> Requires native support for typed arrays</p><p id="firefox-nightly-note">  <sup>[33]</sup> The feature is available only in Firefox Nightly builds.</p><p id="ff-static-init-blocks-note">  <sup>[34]</sup> The feature has to be enabled via <code>javascript.options.experimental.class_static_blocks=true</code> flag.</p><p id="ch-static-init-blocks-note">  <sup>[35]</sup> The feature has to be enabled via <code>harmony_class_static_blocks</code> flag.</p><p id="firefox-arrayfindfromlast-note">  <sup>[36]</sup> The feature has to be enabled via <code>javascript.options.experimental.array_find_last</code> setting under <code>about:config</code>.</p><p id="chrome-harmony-note">  <sup>[37]</sup> The feature has to be enabled via <code>--js-flags=&quot;--harmony&quot;</code> flag</p></div>
+    <p id="harmony-flag-old-note">  <sup>[1]</sup> Flagged features have to be enabled via <code>--harmony</code> flag</p><p id="harmony-flag-note">  <sup>[2]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="graalvm-node-mode-note">  <sup>[3]</sup> Executed in Node.js/JVM mode via <code>graalvm/bin/node --jvm</code>.</p><p id="graalvm-js-intl-mode-note">  <sup>[4]</sup> Executed using <code>js --js.intl-402</code>.</p><p id="babel-core-js-note">  <sup>[5]</sup> This feature is supported when using Babel with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="typescript-core-js-note">  <sup>[6]</sup> This feature is supported when using TypeScript with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="new-gen-fn-note">  <sup>[7]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#67-new--generatorfunction">TC39 meeting notes from July 28, 2015.</a></p><p id="gen-throw-note">  <sup>[8]</sup> <a href="https://github.com/tc39/ecma262/issues/293">&apos;Semantics of yield* in throw case&apos; GitHub issue in ECMA-262 repo.</a></p><p id="typescript-downlevel-iteration-note">  <sup>[9]</sup> Requires the <code>downlevelIteration</code> compile option.</p><p id="strict-fn-non-strict-params-note">  <sup>[10]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-29.md#611-the-scope-of-use-strict-with-respect-to-destructuring-in-parameter-lists">TC39 meeting notes from July 29, 2015.</a></p><p id="nested-rest-destruct-decl-note">  <sup>[11]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#66-bindingrestelement-should-allow-a-bindingpattern-ala-assignmentrestelement">TC39 meeting notes from July 28, 2015.</a></p><p id="nested-rest-destruct-params-note">  <sup>[12]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#66-bindingrestelement-should-allow-a-bindingpattern-ala-assignmentrestelement">TC39 meeting notes from July 28, 2015.</a></p><p id="proxy-enumerate-removed-note">  <sup>[13]</sup> <a href="https://github.com/tc39/ecma262/pull/367">&apos;Normative: Remove [[Enumerate]] and associated reflective capabilities&apos; GitHub Pull Request in ECMA-262 repo.</a></p><p id="babel-regenerator-note">  <sup>[14]</sup> This feature requires native generators or <code>regenerator-runtime</code>, it&apos;s a part of <code>babel-polyfill</code> or <code>babel-runtime</code>.</p><p id="fx-shared-memory-cors-isolation-note">  <sup>[15]</sup> The feature is available with <a href="https://hacks.mozilla.org/2020/07/safely-reviving-shared-memory/">properly set CORS isolation headers</a> or via enabling <code>dom.postMessage.sharedArrayBuffer.bypassCOOP_COEP.insecure.enabled</code> setting under <code>about:config</code></p><p id="edg-shared-memory-spectre-note">  <sup>[16]</sup> The feature was temporarily disabled to mitigate the Meltdown and Spectre CPU bugs.</p><p id="sf-shared-memory-spectre-note">  <sup>[17]</sup> The feature was <a href="https://webkit.org/blog/8048/what-spectre-and-meltdown-mean-for-webkit/">temporarily disabled</a> to mitigate the Meltdown and Spectre CPU bugs.</p><p id="chrome-experimental-note">  <sup>[18]</sup> The feature has to be enabled via &quot;Experimental Javascript features&quot; setting under <code>about:flags</code></p><p id="closure-object-assign-note">  <sup>[19]</sup> Requires native support for <code>Object.assign</code></p><p id="typescript-es6-note">  <sup>[20]</sup> TypeScript&apos;s compiler will accept code using this feature if the <code>--target ES6</code> flag is set, but passes it through unmodified and does not supply a runtime polyfill.</p><p id="flatten-compat-issue-note">  <sup>[21]</sup> Name of <code>Array.prototype.flatten()</code> changed to <code>Array.prototype.flat()</code> due to <a href="https://github.com/tc39/proposal-flatMap/pull/56">web compatibility issues.</a></p><p id="graalvm-js-ecmascript-version-2020-note">  <sup>[22]</sup> Requires the <code>--js.ecmascript-version=2020</code> flag.</p><p id="chrome-string-prototype-replace-all-note">  <sup>[23]</sup> The feature is considered unstable, but can be enabled via <code>--js-flags=&quot;--harmony-string-replaceall&quot;</code> flag</p><p id="graalvm-js-ecmascript-version-2021-note">  <sup>[24]</sup> Requires the <code>--js.ecmascript-version=2021</code> flag.</p><p id="chrome-promise-any-note">  <sup>[25]</sup> Available behind the <a href="https://bugs.chromium.org/p/v8/issues/detail?id=9808"><code>--js-flags=&quot;--harmony-promise-any&quot;</code></a> flag in V8.</p><p id="chrome-weakrefs-note">  <sup>[26]</sup> Available behind the <a href="https://bugs.chromium.org/p/v8/issues/detail?id=8179"><code>--js-flags=&quot;--harmony-weak-refs --expose-gc&quot;</code></a> flag in V8.</p><p id="chrome-logical-assignment-note">  <sup>[27]</sup> Available behind the <a href="https://github.com/v8/v8/commit/b151d8db22be308738192497a68c2c7c0d8d4070"><code>--js-flags=&quot;--logical-assignment&quot;</code></a> flag in V8.</p><p id="graalvm-js-ecmascript-version-staging-note">  <sup>[28]</sup> Requires the <code>--js.ecmascript-version=staging</code> flag.</p><p id="closure-at-method-note">  <sup>[29]</sup> Requires native support for <code>Math.trunc</code></p><p id="graalvm-js-ecmascript-version-2022-note">  <sup>[30]</sup> Requires the <code>--js.ecmascript-version=2022</code> flag.</p><p id="safari-at-method-note">  <sup>[31]</sup> The feature has to be enabled via <code>jscOptions=--useAtMethod=true</code> flag.</p><p id="closure-typed-array-note">  <sup>[32]</sup> Requires native support for typed arrays</p><p id="ch-static-init-blocks-note">  <sup>[33]</sup> The feature has to be enabled via <code>harmony_class_static_blocks</code> flag.</p><p id="chrome-harmony-note">  <sup>[34]</sup> The feature has to be enabled via <code>--js-flags=&quot;--harmony&quot;</code> flag</p></div>
   </div>
   <pre class="info-tooltip" style="display:none"></pre>
 </body>

--- a/es5/index.html
+++ b/es5/index.html
@@ -133,9 +133,7 @@
 <th class="platform ie9 desktop obsolete" data-browser="ie9"><a href="#ie9" class="browser-name"><abbr title="Internet Explorer 9">IE 9</abbr></a></th>
 <th class="platform ie10 desktop obsolete" data-browser="ie10"><a href="#ie10" class="browser-name"><abbr title="Internet Explorer 10">IE 10</abbr></a></th>
 <th class="platform ie11 desktop" data-browser="ie11"><a href="#ie11" class="browser-name"><abbr title="Internet Explorer 11">IE 11</abbr></a></th>
-<th class="platform firefox91 desktop obsolete" data-browser="firefox91"><a href="#firefox91" class="browser-name"><abbr title="Firefox 91 Extended Support Release">FF 91 ESR</abbr></a></th>
 <th class="platform firefox102 desktop obsolete" data-browser="firefox102"><a href="#firefox102" class="browser-name"><abbr title="Firefox 102 Extended Support Release">FF 102 ESR</abbr></a></th>
-<th class="platform firefox103 desktop obsolete" data-browser="firefox103"><a href="#firefox103" class="browser-name"><abbr title="Firefox 103">FF 103</abbr></a></th>
 <th class="platform firefox104 desktop obsolete" data-browser="firefox104"><a href="#firefox104" class="browser-name"><abbr title="Firefox 104">FF 104</abbr></a></th>
 <th class="platform firefox105 desktop obsolete" data-browser="firefox105"><a href="#firefox105" class="browser-name"><abbr title="Firefox 105">FF 105</abbr></a></th>
 <th class="platform firefox106 desktop obsolete" data-browser="firefox106"><a href="#firefox106" class="browser-name"><abbr title="Firefox 106">FF 106</abbr></a></th>
@@ -148,9 +146,10 @@
 <th class="platform firefox113 desktop obsolete" data-browser="firefox113"><a href="#firefox113" class="browser-name"><abbr title="Firefox 113">FF 113</abbr></a></th>
 <th class="platform firefox114 desktop obsolete" data-browser="firefox114"><a href="#firefox114" class="browser-name"><abbr title="Firefox 114">FF 114</abbr></a></th>
 <th class="platform firefox115 desktop" data-browser="firefox115"><a href="#firefox115" class="browser-name"><abbr title="Firefox 115 Extended Support Release">FF 115 ESR</abbr></a></th>
-<th class="platform firefox116 desktop" data-browser="firefox116"><a href="#firefox116" class="browser-name"><abbr title="Firefox 116">FF 116</abbr></a></th>
-<th class="platform firefox117 desktop unstable" data-browser="firefox117"><a href="#firefox117" class="browser-name"><abbr title="Firefox 117 Beta">FF 117</abbr></a></th>
-<th class="platform firefox118 desktop unstable" data-browser="firefox118"><a href="#firefox118" class="browser-name"><abbr title="Firefox 118 Nightly">FF 118</abbr></a></th>
+<th class="platform firefox116 desktop obsolete" data-browser="firefox116"><a href="#firefox116" class="browser-name"><abbr title="Firefox 116">FF 116</abbr></a></th>
+<th class="platform firefox117 desktop" data-browser="firefox117"><a href="#firefox117" class="browser-name"><abbr title="Firefox 117">FF 117</abbr></a></th>
+<th class="platform firefox118 desktop unstable" data-browser="firefox118"><a href="#firefox118" class="browser-name"><abbr title="Firefox 118 Beta">FF 118</abbr></a></th>
+<th class="platform firefox119 desktop unstable" data-browser="firefox119"><a href="#firefox119" class="browser-name"><abbr title="Firefox 119 Nightly">FF 119</abbr></a></th>
 <th class="platform opera12_10 desktop obsolete" data-browser="opera12_10"><a href="#opera12_10" class="browser-name"><abbr title="Opera 12.10">OP 12.10</abbr></a></th>
 <th class="platform chrome102 desktop obsolete" data-browser="chrome102"><a href="#chrome102" class="browser-name"><abbr title="Chrome 102">CH 102</abbr></a></th>
 <th class="platform chrome103 desktop obsolete" data-browser="chrome103"><a href="#chrome103" class="browser-name"><abbr title="Chrome 103">CH 103</abbr></a></th>
@@ -285,9 +284,7 @@
 <td class="tally obsolete" data-browser="ie9" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="1">5/5</td>
 <td class="tally" data-browser="ie11" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">5/5</td>
@@ -300,9 +297,10 @@
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">5/5</td>
 <td class="tally" data-browser="firefox115" data-tally="1">5/5</td>
-<td class="tally" data-browser="firefox116" data-tally="1">5/5</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">5/5</td>
+<td class="tally" data-browser="firefox117" data-tally="1">5/5</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">5/5</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">5/5</td>
@@ -436,9 +434,7 @@ return ({ get x(){ return 1 } }).x === 1;
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -451,9 +447,10 @@ return ({ get x(){ return 1 } }).x === 1;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -589,9 +586,7 @@ return value === 1;
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -604,9 +599,10 @@ return value === 1;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -740,9 +736,7 @@ return { a: true, }.a === true;
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -755,9 +749,10 @@ return { a: true, }.a === true;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -891,9 +886,7 @@ return [1,].length === 1;
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -906,9 +899,10 @@ return [1,].length === 1;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -1042,9 +1036,7 @@ return ({ if: 1 }).if === 1;
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -1057,9 +1049,10 @@ return ({ if: 1 }).if === 1;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -1182,7 +1175,7 @@ return ({ if: 1 }).if === 1;
 <td class="yes" data-browser="opera_mobile76">Yes</td>
 <td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
-<tr><th colspan="149" class="separator"></th>
+<tr><th colspan="148" class="separator"></th>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Object_static_methods"><span><a class="anchor" href="#test-Object_static_methods">&#xA7;</a>Object static methods</span></td>
 <td class="tally" data-browser="es5shim" data-tally="0.07692307692307693" style="background-color:hsl(9,82%,50%)">1/13</td>
@@ -1192,9 +1185,7 @@ return ({ if: 1 }).if === 1;
 <td class="tally obsolete" data-browser="ie9" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="1">13/13</td>
 <td class="tally" data-browser="ie11" data-tally="1">13/13</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">13/13</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">13/13</td>
@@ -1207,9 +1198,10 @@ return ({ if: 1 }).if === 1;
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">13/13</td>
 <td class="tally" data-browser="firefox115" data-tally="1">13/13</td>
-<td class="tally" data-browser="firefox116" data-tally="1">13/13</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">13/13</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">13/13</td>
+<td class="tally" data-browser="firefox117" data-tally="1">13/13</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">13/13</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">13/13</td>
@@ -1345,9 +1337,7 @@ return typeof Object.create === 'function';
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -1360,9 +1350,10 @@ return typeof Object.create === 'function';
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -1498,9 +1489,7 @@ return typeof Object.defineProperty === 'function';
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -1513,9 +1502,10 @@ return typeof Object.defineProperty === 'function';
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -1651,9 +1641,7 @@ return typeof Object.defineProperties === 'function';
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -1666,9 +1654,10 @@ return typeof Object.defineProperties === 'function';
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -1804,9 +1793,7 @@ return typeof Object.getPrototypeOf === 'function';
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -1819,9 +1806,10 @@ return typeof Object.getPrototypeOf === 'function';
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -1957,9 +1945,7 @@ return typeof Object.keys === 'function';
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -1972,9 +1958,10 @@ return typeof Object.keys === 'function';
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -2110,9 +2097,7 @@ return typeof Object.seal === 'function';
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -2125,9 +2110,10 @@ return typeof Object.seal === 'function';
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -2263,9 +2249,7 @@ return typeof Object.freeze === 'function';
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -2278,9 +2262,10 @@ return typeof Object.freeze === 'function';
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -2416,9 +2401,7 @@ return typeof Object.preventExtensions === 'function';
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -2431,9 +2414,10 @@ return typeof Object.preventExtensions === 'function';
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -2569,9 +2553,7 @@ return typeof Object.isSealed === 'function';
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -2584,9 +2566,10 @@ return typeof Object.isSealed === 'function';
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -2722,9 +2705,7 @@ return typeof Object.isFrozen === 'function';
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -2737,9 +2718,10 @@ return typeof Object.isFrozen === 'function';
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -2875,9 +2857,7 @@ return typeof Object.isExtensible === 'function';
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -2890,9 +2870,10 @@ return typeof Object.isExtensible === 'function';
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -3028,9 +3009,7 @@ return typeof Object.getOwnPropertyDescriptor === 'function';
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -3043,9 +3022,10 @@ return typeof Object.getOwnPropertyDescriptor === 'function';
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -3181,9 +3161,7 @@ return typeof Object.getOwnPropertyNames === 'function';
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -3196,9 +3174,10 @@ return typeof Object.getOwnPropertyNames === 'function';
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -3329,9 +3308,7 @@ return typeof Object.getOwnPropertyNames === 'function';
 <td class="tally obsolete" data-browser="ie9" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="1">13/13</td>
 <td class="tally" data-browser="ie11" data-tally="1">13/13</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">13/13</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">13/13</td>
@@ -3344,9 +3321,10 @@ return typeof Object.getOwnPropertyNames === 'function';
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">13/13</td>
 <td class="tally" data-browser="firefox115" data-tally="1">13/13</td>
-<td class="tally" data-browser="firefox116" data-tally="1">13/13</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">13/13</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">13/13</td>
+<td class="tally" data-browser="firefox117" data-tally="1">13/13</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">13/13</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">13/13</td>
@@ -3482,9 +3460,7 @@ return typeof Array.isArray === 'function';
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -3497,9 +3473,10 @@ return typeof Array.isArray === 'function';
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -3635,9 +3612,7 @@ return typeof Array.prototype.indexOf === 'function';
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -3650,9 +3625,10 @@ return typeof Array.prototype.indexOf === 'function';
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -3788,9 +3764,7 @@ return typeof Array.prototype.lastIndexOf === 'function';
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -3803,9 +3777,10 @@ return typeof Array.prototype.lastIndexOf === 'function';
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -3941,9 +3916,7 @@ return typeof Array.prototype.every === 'function';
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -3956,9 +3929,10 @@ return typeof Array.prototype.every === 'function';
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -4094,9 +4068,7 @@ return typeof Array.prototype.some === 'function';
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -4109,9 +4081,10 @@ return typeof Array.prototype.some === 'function';
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -4247,9 +4220,7 @@ return typeof Array.prototype.forEach === 'function';
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -4262,9 +4233,10 @@ return typeof Array.prototype.forEach === 'function';
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -4400,9 +4372,7 @@ return typeof Array.prototype.map === 'function';
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -4415,9 +4385,10 @@ return typeof Array.prototype.map === 'function';
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -4553,9 +4524,7 @@ return typeof Array.prototype.filter === 'function';
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -4568,9 +4537,10 @@ return typeof Array.prototype.filter === 'function';
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -4706,9 +4676,7 @@ return typeof Array.prototype.reduce === 'function';
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -4721,9 +4689,10 @@ return typeof Array.prototype.reduce === 'function';
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -4859,9 +4828,7 @@ return typeof Array.prototype.reduceRight === 'function';
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -4874,9 +4841,10 @@ return typeof Array.prototype.reduceRight === 'function';
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -5052,9 +5020,7 @@ return true;
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -5067,9 +5033,10 @@ return true;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -5215,9 +5182,7 @@ try {
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -5230,9 +5195,10 @@ try {
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -5368,9 +5334,7 @@ return [].unshift(0) === 1;
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -5383,9 +5347,10 @@ return [].unshift(0) === 1;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -5516,9 +5481,7 @@ return [].unshift(0) === 1;
 <td class="tally obsolete" data-browser="ie9" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="1">4/4</td>
 <td class="tally" data-browser="ie11" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">4/4</td>
@@ -5531,9 +5494,10 @@ return [].unshift(0) === 1;
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">4/4</td>
 <td class="tally" data-browser="firefox115" data-tally="1">4/4</td>
-<td class="tally" data-browser="firefox116" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">4/4</td>
+<td class="tally" data-browser="firefox117" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">4/4</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">4/4</td>
@@ -5669,9 +5633,7 @@ return "foobar"[3] === "b";
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -5684,9 +5646,10 @@ return "foobar"[3] === "b";
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -5846,9 +5809,7 @@ return typeof String.prototype.split === 'function'
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -5861,9 +5822,10 @@ return typeof String.prototype.split === 'function'
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -5999,9 +5961,7 @@ return '0b'.substr(-1) === 'b';
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -6014,9 +5974,10 @@ return '0b'.substr(-1) === 'b';
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -6152,9 +6113,7 @@ return typeof String.prototype.trim === 'function';
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -6167,9 +6126,10 @@ return typeof String.prototype.trim === 'function';
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -6300,9 +6260,7 @@ return typeof String.prototype.trim === 'function';
 <td class="tally obsolete" data-browser="ie9" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="1">3/3</td>
 <td class="tally" data-browser="ie11" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">3/3</td>
@@ -6315,9 +6273,10 @@ return typeof String.prototype.trim === 'function';
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">3/3</td>
 <td class="tally" data-browser="firefox115" data-tally="1">3/3</td>
-<td class="tally" data-browser="firefox116" data-tally="1">3/3</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">3/3</td>
+<td class="tally" data-browser="firefox117" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">3/3</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">3/3</td>
@@ -6453,9 +6412,7 @@ return typeof Date.prototype.toISOString === 'function';
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -6468,9 +6425,10 @@ return typeof Date.prototype.toISOString === 'function';
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -6606,9 +6564,7 @@ return typeof Date.now === 'function';
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -6621,9 +6577,10 @@ return typeof Date.now === 'function';
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -6767,9 +6724,7 @@ try {
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -6782,9 +6737,10 @@ try {
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -6920,9 +6876,7 @@ return typeof Function.prototype.bind === 'function';
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -6935,9 +6889,10 @@ return typeof Function.prototype.bind === 'function';
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -7073,9 +7028,7 @@ return typeof JSON === 'object';
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -7088,9 +7041,10 @@ return typeof JSON === 'object';
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -7213,7 +7167,7 @@ return typeof JSON === 'object';
 <td class="yes" data-browser="opera_mobile76">Yes</td>
 <td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
-<tr><th colspan="149" class="separator"></th>
+<tr><th colspan="148" class="separator"></th>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Immutable_globals"><span><a class="anchor" href="#test-Immutable_globals">&#xA7;</a>Immutable globals</span></td>
 <td class="tally" data-browser="es5shim" data-tally="0">0/3</td>
@@ -7223,9 +7177,7 @@ return typeof JSON === 'object';
 <td class="tally obsolete" data-browser="ie9" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="1">3/3</td>
 <td class="tally" data-browser="ie11" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">3/3</td>
@@ -7238,9 +7190,10 @@ return typeof JSON === 'object';
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">3/3</td>
 <td class="tally" data-browser="firefox115" data-tally="1">3/3</td>
-<td class="tally" data-browser="firefox116" data-tally="1">3/3</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">3/3</td>
+<td class="tally" data-browser="firefox117" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">3/3</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">3/3</td>
@@ -7377,9 +7330,7 @@ return result;
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -7392,9 +7343,10 @@ return result;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -7531,9 +7483,7 @@ return result;
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -7546,9 +7496,10 @@ return result;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -7685,9 +7636,7 @@ return result;
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -7700,9 +7649,10 @@ return result;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -7833,9 +7783,7 @@ return result;
 <td class="tally obsolete" data-browser="ie9" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally" data-browser="ie11" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">3/3</td>
@@ -7848,9 +7796,10 @@ return result;
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">3/3</td>
 <td class="tally" data-browser="firefox115" data-tally="1">3/3</td>
-<td class="tally" data-browser="firefox116" data-tally="1">3/3</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">3/3</td>
+<td class="tally" data-browser="firefox117" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">3/3</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">3/3</td>
@@ -7990,9 +7939,7 @@ return (-6.9e-11).toExponential(4) === '-6.9000e-11' // Edge <= 17
 <td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -8005,9 +7952,10 @@ return (-6.9e-11).toExponential(4) === '-6.9000e-11' // Edge <= 17
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -8155,9 +8103,7 @@ try {
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -8170,9 +8116,10 @@ try {
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -8320,9 +8267,7 @@ try {
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -8335,9 +8280,10 @@ try {
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -8468,9 +8414,7 @@ try {
 <td class="tally obsolete" data-browser="ie9" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally" data-browser="ie11" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">8/8</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">8/8</td>
@@ -8483,9 +8427,10 @@ try {
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">8/8</td>
 <td class="tally" data-browser="firefox115" data-tally="1">8/8</td>
-<td class="tally" data-browser="firefox116" data-tally="1">8/8</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">8/8</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">8/8</td>
+<td class="tally" data-browser="firefox117" data-tally="1">8/8</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">8/8</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">8/8</td>
@@ -8629,9 +8574,7 @@ try {
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -8644,9 +8587,10 @@ try {
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -8782,9 +8726,7 @@ return parseInt('010') === 10;
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -8797,9 +8739,10 @@ return parseInt('010') === 10;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -8933,9 +8876,7 @@ return !Function().propertyIsEnumerable(&apos;prototype&apos;);
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -8948,9 +8889,10 @@ return !Function().propertyIsEnumerable(&apos;prototype&apos;);
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -9084,9 +9026,7 @@ return (function(){ return Object.prototype.toString.call(arguments) === &apos;[
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -9099,9 +9039,10 @@ return (function(){ return Object.prototype.toString.call(arguments) === &apos;[
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -9236,9 +9177,7 @@ return _\u200c\u200d;
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -9251,9 +9190,10 @@ return _\u200c\u200d;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -9389,9 +9329,7 @@ return true;
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -9404,9 +9342,10 @@ return true;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -9548,9 +9487,7 @@ return result;
 <td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -9563,9 +9500,10 @@ return result;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -9705,9 +9643,7 @@ catch(e) {
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -9720,9 +9656,10 @@ catch(e) {
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -9853,9 +9790,7 @@ catch(e) {
 <td class="tally obsolete" data-browser="ie9" data-tally="0">0/19</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="1">19/19</td>
 <td class="tally" data-browser="ie11" data-tally="1">19/19</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">19/19</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">19/19</td>
@@ -9868,9 +9803,10 @@ catch(e) {
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">19/19</td>
 <td class="tally" data-browser="firefox115" data-tally="1">19/19</td>
-<td class="tally" data-browser="firefox116" data-tally="1">19/19</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">19/19</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">19/19</td>
+<td class="tally" data-browser="firefox117" data-tally="1">19/19</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">19/19</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">19/19</td>
@@ -10009,9 +9945,7 @@ return true;
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -10024,9 +9958,10 @@ return true;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -10161,9 +10096,7 @@ return this === void undefined &amp;&amp; (function(){ return this === void unde
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="yes obsolete" data-browser="ie10">Yes<a href="#strict-mode-ie10-note"><sup>[10]</sup></a></td>
 <td class="yes" data-browser="ie11">Yes<a href="#strict-mode-ie10-note"><sup>[10]</sup></a></td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -10176,9 +10109,10 @@ return this === void undefined &amp;&amp; (function(){ return this === void unde
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -10315,9 +10249,7 @@ return (function(){ return typeof this === &apos;string&apos; }).call(&apos;&apo
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -10330,9 +10262,10 @@ return (function(){ return typeof this === &apos;string&apos; }).call(&apos;&apo
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -10483,9 +10416,7 @@ return test(String, &apos;&apos;)
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -10498,9 +10429,10 @@ return test(String, &apos;&apos;)
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -10637,9 +10569,7 @@ return true;
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -10652,9 +10582,10 @@ return true;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -10789,9 +10720,7 @@ try { eval(&apos;__i_dont_exist = 1&apos;); } catch (err) { return err instanceo
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -10804,9 +10733,10 @@ try { eval(&apos;__i_dont_exist = 1&apos;); } catch (err) { return err instanceo
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -10945,9 +10875,7 @@ return true;
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -10960,9 +10888,10 @@ return true;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -11101,9 +11030,7 @@ return true;
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -11116,9 +11043,10 @@ return true;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -11259,9 +11187,7 @@ return true;
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -11274,9 +11200,10 @@ return true;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -11414,9 +11341,7 @@ return true;
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -11429,9 +11354,10 @@ return true;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -11567,9 +11493,7 @@ return true;
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -11582,9 +11506,10 @@ return true;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -11721,9 +11646,7 @@ return true;
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -11736,9 +11659,10 @@ return true;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -11879,9 +11803,7 @@ return (function(x){
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -11894,9 +11816,10 @@ return (function(x){
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -12031,9 +11954,7 @@ try { eval(&apos;var __some_unique_variable;&apos;); __some_unique_variable; } c
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -12046,9 +11967,10 @@ try { eval(&apos;var __some_unique_variable;&apos;); __some_unique_variable; } c
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -12183,9 +12105,7 @@ try { eval(&apos;var x; delete x;&apos;); } catch (err) { return err instanceof 
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -12198,9 +12118,10 @@ try { eval(&apos;var x; delete x;&apos;); } catch (err) { return err instanceof 
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -12335,9 +12256,7 @@ try { delete Object.prototype; } catch (err) { return err instanceof TypeError; 
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -12350,9 +12269,10 @@ try { delete Object.prototype; } catch (err) { return err instanceof TypeError; 
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -12487,9 +12407,7 @@ try { eval(&apos;with({}){}&apos;); } catch (err) { return err instanceof Syntax
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -12502,9 +12420,10 @@ try { eval(&apos;with({}){}&apos;); } catch (err) { return err instanceof Syntax
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -12639,9 +12558,7 @@ try { eval(&apos;function f(x, x) { }&apos;); } catch (err) { return err instanc
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -12654,9 +12571,10 @@ try { eval(&apos;function f(x, x) { }&apos;); } catch (err) { return err instanc
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -12791,9 +12709,7 @@ return typeof foo === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -12806,9 +12722,10 @@ return typeof foo === &apos;function&apos;;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>

--- a/esintl/index.html
+++ b/esintl/index.html
@@ -137,9 +137,7 @@
 <th class="platform ie9 desktop obsolete" data-browser="ie9"><a href="#ie9" class="browser-name"><abbr title="Internet Explorer 9">IE 9</abbr></a></th>
 <th class="platform ie10 desktop obsolete" data-browser="ie10"><a href="#ie10" class="browser-name"><abbr title="Internet Explorer 10">IE 10</abbr></a></th>
 <th class="platform ie11 desktop" data-browser="ie11"><a href="#ie11" class="browser-name"><abbr title="Internet Explorer 11">IE 11</abbr></a></th>
-<th class="platform firefox91 desktop obsolete" data-browser="firefox91"><a href="#firefox91" class="browser-name"><abbr title="Firefox 91 Extended Support Release">FF 91 ESR</abbr></a></th>
 <th class="platform firefox102 desktop obsolete" data-browser="firefox102"><a href="#firefox102" class="browser-name"><abbr title="Firefox 102 Extended Support Release">FF 102 ESR</abbr></a></th>
-<th class="platform firefox103 desktop obsolete" data-browser="firefox103"><a href="#firefox103" class="browser-name"><abbr title="Firefox 103">FF 103</abbr></a></th>
 <th class="platform firefox104 desktop obsolete" data-browser="firefox104"><a href="#firefox104" class="browser-name"><abbr title="Firefox 104">FF 104</abbr></a></th>
 <th class="platform firefox105 desktop obsolete" data-browser="firefox105"><a href="#firefox105" class="browser-name"><abbr title="Firefox 105">FF 105</abbr></a></th>
 <th class="platform firefox106 desktop obsolete" data-browser="firefox106"><a href="#firefox106" class="browser-name"><abbr title="Firefox 106">FF 106</abbr></a></th>
@@ -152,9 +150,10 @@
 <th class="platform firefox113 desktop obsolete" data-browser="firefox113"><a href="#firefox113" class="browser-name"><abbr title="Firefox 113">FF 113</abbr></a></th>
 <th class="platform firefox114 desktop obsolete" data-browser="firefox114"><a href="#firefox114" class="browser-name"><abbr title="Firefox 114">FF 114</abbr></a></th>
 <th class="platform firefox115 desktop" data-browser="firefox115"><a href="#firefox115" class="browser-name"><abbr title="Firefox 115 Extended Support Release">FF 115 ESR</abbr></a></th>
-<th class="platform firefox116 desktop" data-browser="firefox116"><a href="#firefox116" class="browser-name"><abbr title="Firefox 116">FF 116</abbr></a></th>
-<th class="platform firefox117 desktop unstable" data-browser="firefox117"><a href="#firefox117" class="browser-name"><abbr title="Firefox 117 Beta">FF 117</abbr></a></th>
-<th class="platform firefox118 desktop unstable" data-browser="firefox118"><a href="#firefox118" class="browser-name"><abbr title="Firefox 118 Nightly">FF 118</abbr></a></th>
+<th class="platform firefox116 desktop obsolete" data-browser="firefox116"><a href="#firefox116" class="browser-name"><abbr title="Firefox 116">FF 116</abbr></a></th>
+<th class="platform firefox117 desktop" data-browser="firefox117"><a href="#firefox117" class="browser-name"><abbr title="Firefox 117">FF 117</abbr></a></th>
+<th class="platform firefox118 desktop unstable" data-browser="firefox118"><a href="#firefox118" class="browser-name"><abbr title="Firefox 118 Beta">FF 118</abbr></a></th>
+<th class="platform firefox119 desktop unstable" data-browser="firefox119"><a href="#firefox119" class="browser-name"><abbr title="Firefox 119 Nightly">FF 119</abbr></a></th>
 <th class="platform opera12_10 desktop obsolete" data-browser="opera12_10"><a href="#opera12_10" class="browser-name"><abbr title="Opera 12.10">OP 12.10</abbr></a></th>
 <th class="platform chrome102 desktop obsolete" data-browser="chrome102"><a href="#chrome102" class="browser-name"><abbr title="Chrome 102">CH 102</abbr></a></th>
 <th class="platform chrome103 desktop obsolete" data-browser="chrome103"><a href="#chrome103" class="browser-name"><abbr title="Chrome 103">CH 103</abbr></a></th>
@@ -274,9 +273,7 @@
 <td class="tally obsolete" data-browser="ie9" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">2/2</td>
@@ -289,9 +286,10 @@
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">2/2</td>
 <td class="tally" data-browser="firefox115" data-tally="1">2/2</td>
-<td class="tally" data-browser="firefox116" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">2/2</td>
+<td class="tally" data-browser="firefox117" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">2/2</td>
@@ -410,9 +408,7 @@ return typeof Intl === &apos;object&apos;;
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -425,9 +421,10 @@ return typeof Intl === &apos;object&apos;;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -546,9 +543,7 @@ return Intl.constructor === Object;
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -561,9 +556,10 @@ return Intl.constructor === Object;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -679,9 +675,7 @@ return Intl.constructor === Object;
 <td class="tally obsolete" data-browser="ie9" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/5</td>
 <td class="tally" data-browser="ie11" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">5/5</td>
@@ -694,9 +688,10 @@ return Intl.constructor === Object;
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">5/5</td>
 <td class="tally" data-browser="firefox115" data-tally="1">5/5</td>
-<td class="tally" data-browser="firefox116" data-tally="1">5/5</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">5/5</td>
+<td class="tally" data-browser="firefox117" data-tally="1">5/5</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">5/5</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">5/5</td>
@@ -815,9 +810,7 @@ return typeof Intl.Collator === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -830,9 +823,10 @@ return typeof Intl.Collator === &apos;function&apos;;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -951,9 +945,7 @@ return new Intl.Collator() instanceof Intl.Collator;
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -966,9 +958,10 @@ return new Intl.Collator() instanceof Intl.Collator;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -1087,9 +1080,7 @@ return Intl.Collator() instanceof Intl.Collator;
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -1102,9 +1093,10 @@ return Intl.Collator() instanceof Intl.Collator;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -1245,9 +1237,7 @@ try {
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -1260,9 +1250,10 @@ try {
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -1398,9 +1389,7 @@ try {
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="unknown" data-browser="ie11">?</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -1413,9 +1402,10 @@ try {
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -1531,9 +1521,7 @@ try {
 <td class="tally obsolete" data-browser="ie9" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">1/1</td>
@@ -1546,9 +1534,10 @@ try {
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">1/1</td>
 <td class="tally" data-browser="firefox115" data-tally="1">1/1</td>
-<td class="tally" data-browser="firefox116" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">1/1</td>
+<td class="tally" data-browser="firefox117" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">1/1</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">1/1</td>
@@ -1667,9 +1656,7 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -1682,9 +1669,10 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -1800,9 +1788,7 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="tally obsolete" data-browser="ie9" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">1/1</td>
@@ -1815,9 +1801,10 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">1/1</td>
 <td class="tally" data-browser="firefox115" data-tally="1">1/1</td>
-<td class="tally" data-browser="firefox116" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">1/1</td>
+<td class="tally" data-browser="firefox117" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">1/1</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">1/1</td>
@@ -1936,9 +1923,7 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -1951,9 +1936,10 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -2069,9 +2055,7 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="tally obsolete" data-browser="ie9" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/6</td>
 <td class="tally" data-browser="ie11" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">6/6</td>
@@ -2084,9 +2068,10 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">6/6</td>
 <td class="tally" data-browser="firefox115" data-tally="1">6/6</td>
-<td class="tally" data-browser="firefox116" data-tally="1">6/6</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">6/6</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">6/6</td>
+<td class="tally" data-browser="firefox117" data-tally="1">6/6</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">6/6</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">6/6</td>
@@ -2205,9 +2190,7 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -2220,9 +2203,10 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -2341,9 +2325,7 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -2356,9 +2338,10 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -2477,9 +2460,7 @@ return new Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -2492,9 +2473,10 @@ return new Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -2613,9 +2595,7 @@ return Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -2628,9 +2608,10 @@ return Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -2771,9 +2752,7 @@ try {
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -2786,9 +2765,10 @@ try {
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -2924,9 +2904,7 @@ try {
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="unknown" data-browser="ie11">?</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -2939,9 +2917,10 @@ try {
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -3057,9 +3036,7 @@ try {
 <td class="tally obsolete" data-browser="ie9" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/7</td>
 <td class="tally" data-browser="ie11" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">7/7</td>
@@ -3072,9 +3049,10 @@ try {
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">7/7</td>
 <td class="tally" data-browser="firefox115" data-tally="1">7/7</td>
-<td class="tally" data-browser="firefox116" data-tally="1">7/7</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">7/7</td>
+<td class="tally" data-browser="firefox117" data-tally="1">7/7</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">7/7</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">7/7</td>
@@ -3193,9 +3171,7 @@ return typeof Intl.DateTimeFormat === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -3208,9 +3184,10 @@ return typeof Intl.DateTimeFormat === &apos;function&apos;;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -3329,9 +3306,7 @@ return new Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -3344,9 +3319,10 @@ return new Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -3465,9 +3441,7 @@ return Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -3480,9 +3454,10 @@ return Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -3623,9 +3598,7 @@ try {
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -3638,9 +3611,10 @@ try {
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -3776,9 +3750,7 @@ try {
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="unknown" data-browser="ie11">?</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -3791,9 +3763,10 @@ try {
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -3913,9 +3886,7 @@ return tz !== void undefined &amp;&amp; tz.length &gt; 0;
 <td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -3928,9 +3899,10 @@ return tz !== void undefined &amp;&amp; tz.length &gt; 0;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -4057,9 +4029,7 @@ try {
 <td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -4072,9 +4042,10 @@ try {
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -4190,9 +4161,7 @@ try {
 <td class="tally obsolete" data-browser="ie9" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="1">1/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">1/1</td>
@@ -4205,9 +4174,10 @@ try {
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">1/1</td>
 <td class="tally" data-browser="firefox115" data-tally="1">1/1</td>
-<td class="tally" data-browser="firefox116" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">1/1</td>
+<td class="tally" data-browser="firefox117" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">1/1</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">1/1</td>
@@ -4326,9 +4296,7 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -4341,9 +4309,10 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -4459,9 +4428,7 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="tally obsolete" data-browser="ie9" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="1">1/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">1/1</td>
@@ -4474,9 +4441,10 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">1/1</td>
 <td class="tally" data-browser="firefox115" data-tally="1">1/1</td>
-<td class="tally" data-browser="firefox116" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">1/1</td>
+<td class="tally" data-browser="firefox117" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">1/1</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">1/1</td>
@@ -4595,9 +4563,7 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -4610,9 +4576,10 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -4728,9 +4695,7 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="ie9" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="1">1/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">1/1</td>
@@ -4743,9 +4708,10 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">1/1</td>
 <td class="tally" data-browser="firefox115" data-tally="1">1/1</td>
-<td class="tally" data-browser="firefox116" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">1/1</td>
+<td class="tally" data-browser="firefox117" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">1/1</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">1/1</td>
@@ -4864,9 +4830,7 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -4879,9 +4843,10 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -4997,9 +4962,7 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="ie9" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="1">1/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">1/1</td>
@@ -5012,9 +4975,10 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">1/1</td>
 <td class="tally" data-browser="firefox115" data-tally="1">1/1</td>
-<td class="tally" data-browser="firefox116" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">1/1</td>
+<td class="tally" data-browser="firefox117" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">1/1</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">1/1</td>
@@ -5133,9 +5097,7 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -5148,9 +5110,10 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -5266,9 +5229,7 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="ie9" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="1">1/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">1/1</td>
@@ -5281,9 +5242,10 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">1/1</td>
 <td class="tally" data-browser="firefox115" data-tally="1">1/1</td>
-<td class="tally" data-browser="firefox116" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">1/1</td>
+<td class="tally" data-browser="firefox117" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">1/1</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">1/1</td>
@@ -5402,9 +5364,7 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -5417,9 +5377,10 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -5535,9 +5496,7 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="ie9" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="1">1/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">1/1</td>
@@ -5550,9 +5509,10 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">1/1</td>
 <td class="tally" data-browser="firefox115" data-tally="1">1/1</td>
-<td class="tally" data-browser="firefox116" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">1/1</td>
+<td class="tally" data-browser="firefox117" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">1/1</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">1/1</td>
@@ -5671,9 +5631,7 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -5686,9 +5644,10 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -5804,9 +5763,7 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="ie9" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="1">1/1</td>
 <td class="tally" data-browser="ie11" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">1/1</td>
@@ -5819,9 +5776,10 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">1/1</td>
 <td class="tally" data-browser="firefox115" data-tally="1">1/1</td>
-<td class="tally" data-browser="firefox116" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">1/1</td>
+<td class="tally" data-browser="firefox117" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">1/1</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">1/1</td>
@@ -5940,9 +5898,7 @@ return typeof Date.prototype.toLocaleTimeString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -5955,9 +5911,10 @@ return typeof Date.prototype.toLocaleTimeString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -148,9 +148,7 @@
 <th class="platform typescript4_9corejs3 compiler obsolete" data-browser="typescript4_9corejs3"><a href="#typescript4_9corejs3" class="browser-name"><abbr title="TypeScript 4.9 + core-js 3">Type-<br>Script +<br><nobr>core-js 3</nobr></abbr></a></th>
 <th class="platform typescript5_0corejs3 compiler obsolete" data-browser="typescript5_0corejs3"><a href="#typescript5_0corejs3" class="browser-name"><abbr title="TypeScript 5.0 + core-js 3">Type-<br>Script +<br><nobr>core-js 3</nobr></abbr></a></th>
 <th class="platform typescript5_1corejs3 compiler" data-browser="typescript5_1corejs3"><a href="#typescript5_1corejs3" class="browser-name"><abbr title="TypeScript 5.1 + core-js 3">Type-<br>Script +<br><nobr>core-js 3</nobr></abbr></a></th>
-<th class="platform firefox91 desktop obsolete" data-browser="firefox91"><a href="#firefox91" class="browser-name"><abbr title="Firefox 91 Extended Support Release">FF 91 ESR</abbr></a></th>
 <th class="platform firefox102 desktop obsolete" data-browser="firefox102"><a href="#firefox102" class="browser-name"><abbr title="Firefox 102 Extended Support Release">FF 102 ESR</abbr></a></th>
-<th class="platform firefox103 desktop obsolete" data-browser="firefox103"><a href="#firefox103" class="browser-name"><abbr title="Firefox 103">FF 103</abbr></a></th>
 <th class="platform firefox104 desktop obsolete" data-browser="firefox104"><a href="#firefox104" class="browser-name"><abbr title="Firefox 104">FF 104</abbr></a></th>
 <th class="platform firefox105 desktop obsolete" data-browser="firefox105"><a href="#firefox105" class="browser-name"><abbr title="Firefox 105">FF 105</abbr></a></th>
 <th class="platform firefox106 desktop obsolete" data-browser="firefox106"><a href="#firefox106" class="browser-name"><abbr title="Firefox 106">FF 106</abbr></a></th>
@@ -163,9 +161,10 @@
 <th class="platform firefox113 desktop obsolete" data-browser="firefox113"><a href="#firefox113" class="browser-name"><abbr title="Firefox 113">FF 113</abbr></a></th>
 <th class="platform firefox114 desktop obsolete" data-browser="firefox114"><a href="#firefox114" class="browser-name"><abbr title="Firefox 114">FF 114</abbr></a></th>
 <th class="platform firefox115 desktop" data-browser="firefox115"><a href="#firefox115" class="browser-name"><abbr title="Firefox 115 Extended Support Release">FF 115 ESR</abbr></a></th>
-<th class="platform firefox116 desktop" data-browser="firefox116"><a href="#firefox116" class="browser-name"><abbr title="Firefox 116">FF 116</abbr></a></th>
-<th class="platform firefox117 desktop unstable" data-browser="firefox117"><a href="#firefox117" class="browser-name"><abbr title="Firefox 117 Beta">FF 117</abbr></a></th>
-<th class="platform firefox118 desktop unstable" data-browser="firefox118"><a href="#firefox118" class="browser-name"><abbr title="Firefox 118 Nightly">FF 118</abbr></a></th>
+<th class="platform firefox116 desktop obsolete" data-browser="firefox116"><a href="#firefox116" class="browser-name"><abbr title="Firefox 116">FF 116</abbr></a></th>
+<th class="platform firefox117 desktop" data-browser="firefox117"><a href="#firefox117" class="browser-name"><abbr title="Firefox 117">FF 117</abbr></a></th>
+<th class="platform firefox118 desktop unstable" data-browser="firefox118"><a href="#firefox118" class="browser-name"><abbr title="Firefox 118 Beta">FF 118</abbr></a></th>
+<th class="platform firefox119 desktop unstable" data-browser="firefox119"><a href="#firefox119" class="browser-name"><abbr title="Firefox 119 Nightly">FF 119</abbr></a></th>
 <th class="platform opera12_10 desktop obsolete" data-browser="opera12_10"><a href="#opera12_10" class="browser-name"><abbr title="Opera 12.10">OP 12.10</abbr></a></th>
 <th class="platform chrome102 desktop obsolete" data-browser="chrome102"><a href="#chrome102" class="browser-name"><abbr title="Chrome 102">CH 102</abbr></a></th>
 <th class="platform chrome103 desktop obsolete" data-browser="chrome103"><a href="#chrome103" class="browser-name"><abbr title="Chrome 103">CH 103</abbr></a></th>
@@ -280,7 +279,7 @@
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr class="category"><td colspan="148"><span>Stage 3</span></td>
+      <tr class="category"><td colspan="147"><span>Stage 3</span></td>
 </tr>
 <tr significance="1"><td id="test-ShadowRealm"><span><a class="anchor" href="#test-ShadowRealm">&#xA7;</a><a href="https://github.com/tc39/proposal-shadowrealm">ShadowRealm</a></span><script data-source="
 return typeof ShadowRealm === &quot;function&quot;
@@ -307,9 +306,7 @@ return typeof ShadowRealm === &quot;function&quot;
 <td class="unknown obsolete" data-browser="typescript4_9corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript5_0corejs3">?</td>
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -322,9 +319,10 @@ return typeof ShadowRealm === &quot;function&quot;
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -454,9 +452,7 @@ return typeof ShadowRealm === &quot;function&quot;
 <td class="tally obsolete" data-browser="typescript4_9corejs3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript5_0corejs3" data-tally="0">0/2</td>
 <td class="tally" data-browser="typescript5_1corejs3" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="1">2/2</td>
@@ -469,9 +465,10 @@ return typeof ShadowRealm === &quot;function&quot;
 <td class="tally obsolete" data-browser="firefox113" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="1">2/2</td>
 <td class="tally" data-browser="firefox115" data-tally="1">2/2</td>
-<td class="tally" data-browser="firefox116" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="1">2/2</td>
+<td class="tally" data-browser="firefox117" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="1">2/2</td>
@@ -610,9 +607,7 @@ return RegExp.lastMatch === 'x';
 <td class="unknown obsolete" data-browser="typescript4_9corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript5_0corejs3">?</td>
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -625,9 +620,10 @@ return RegExp.lastMatch === 'x';
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -768,9 +764,7 @@ return true;
 <td class="unknown obsolete" data-browser="typescript4_9corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript5_0corejs3">?</td>
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -783,9 +777,10 @@ return true;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -896,7 +891,7 @@ return true;
 <td class="yes" data-browser="opera_mobile76">Yes</td>
 <td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
-<tr class="category"><td colspan="148"><span>Stage 2</span></td>
+<tr class="category"><td colspan="147"><span>Stage 2</span></td>
 </tr>
 <tr significance="0.25"><td id="test-Generator_function.sent_Meta_Property"><span><a class="anchor" href="#test-Generator_function.sent_Meta_Property">&#xA7;</a><a href="https://github.com/tc39/proposal-function.sent">Generator function.sent Meta Property</a></span><script data-source="
 var result;
@@ -926,9 +921,7 @@ return result === &apos;tromple&apos;;
 <td class="unknown obsolete" data-browser="typescript4_9corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript5_0corejs3">?</td>
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -941,9 +934,10 @@ return result === &apos;tromple&apos;;
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -1073,9 +1067,7 @@ return result === &apos;tromple&apos;;
 <td class="tally obsolete" data-browser="typescript4_9corejs3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="typescript5_0corejs3" data-tally="1">1/1</td>
 <td class="tally" data-browser="typescript5_1corejs3" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="0">0/1</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="0">0/1</td>
@@ -1088,9 +1080,10 @@ return result === &apos;tromple&apos;;
 <td class="tally obsolete" data-browser="firefox113" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="0">0/1</td>
 <td class="tally" data-browser="firefox115" data-tally="0">0/1</td>
-<td class="tally" data-browser="firefox116" data-tally="0">0/1</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="0">0/1</td>
+<td class="tally" data-browser="firefox117" data-tally="0">0/1</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="0">0/1</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="0">0/1</td>
@@ -1231,9 +1224,7 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="yes obsolete" data-browser="typescript4_9corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript5_0corejs3">Yes</td>
 <td class="yes" data-browser="typescript5_1corejs3">Yes</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -1246,9 +1237,10 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -1378,9 +1370,7 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="tally obsolete" data-browser="typescript4_9corejs3" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript5_0corejs3" data-tally="0">0/4</td>
 <td class="tally" data-browser="typescript5_1corejs3" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="0">0/4</td>
@@ -1393,9 +1383,10 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="tally obsolete" data-browser="firefox113" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="0">0/4</td>
 <td class="tally" data-browser="firefox115" data-tally="0">0/4</td>
-<td class="tally" data-browser="firefox116" data-tally="0">0/4</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="0">0/4</td>
+<td class="tally" data-browser="firefox117" data-tally="0">0/4</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="0">0/4</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="0">0/4</td>
@@ -1534,9 +1525,7 @@ try {
 <td class="unknown obsolete" data-browser="typescript4_9corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript5_0corejs3">?</td>
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -1549,9 +1538,10 @@ try {
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -1694,9 +1684,7 @@ try {
 <td class="unknown obsolete" data-browser="typescript4_9corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript5_0corejs3">?</td>
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -1709,9 +1697,10 @@ try {
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -1849,9 +1838,7 @@ try {
 <td class="unknown obsolete" data-browser="typescript4_9corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript5_0corejs3">?</td>
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -1864,9 +1851,10 @@ try {
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -2004,9 +1992,7 @@ try {
 <td class="unknown obsolete" data-browser="typescript4_9corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript5_0corejs3">?</td>
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -2019,9 +2005,10 @@ try {
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -2151,9 +2138,7 @@ try {
 <td class="tally obsolete" data-browser="typescript4_9corejs3" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript5_0corejs3" data-tally="1">7/7</td>
 <td class="tally" data-browser="typescript5_1corejs3" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="0">0/7</td>
@@ -2166,9 +2151,10 @@ try {
 <td class="tally obsolete" data-browser="firefox113" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="0">0/7</td>
 <td class="tally" data-browser="firefox115" data-tally="0">0/7</td>
-<td class="tally" data-browser="firefox116" data-tally="0">0/7</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="0">0/7</td>
+<td class="tally" data-browser="firefox117" data-tally="0">0/7</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="0">0/7</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="0">0/7</td>
@@ -2304,9 +2290,7 @@ return set.size === 2
 <td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript5_0corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -2319,9 +2303,10 @@ return set.size === 2
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -2458,9 +2443,7 @@ return set.size === 3
 <td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript5_0corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -2473,9 +2456,10 @@ return set.size === 3
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -2611,9 +2595,7 @@ return set.size === 2
 <td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript5_0corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -2626,9 +2608,10 @@ return set.size === 2
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -2764,9 +2747,7 @@ return set.size === 2
 <td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript5_0corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -2779,9 +2760,10 @@ return set.size === 2
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -2914,9 +2896,7 @@ return new Set([1, 2, 3]).isDisjointFrom([4, 5, 6]);
 <td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript5_0corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -2929,9 +2909,10 @@ return new Set([1, 2, 3]).isDisjointFrom([4, 5, 6]);
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -3064,9 +3045,7 @@ return new Set([1, 2, 3]).isSubsetOf([5, 4, 3, 2, 1]);
 <td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript5_0corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -3079,9 +3058,10 @@ return new Set([1, 2, 3]).isSubsetOf([5, 4, 3, 2, 1]);
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -3214,9 +3194,7 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
 <td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript5_0corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -3229,9 +3207,10 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -3361,9 +3340,7 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
 <td class="tally obsolete" data-browser="typescript4_9corejs3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript5_0corejs3" data-tally="0">0/2</td>
 <td class="tally" data-browser="typescript5_1corejs3" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="0">0/2</td>
@@ -3376,9 +3353,10 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
 <td class="tally obsolete" data-browser="firefox113" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="0">0/2</td>
 <td class="tally" data-browser="firefox115" data-tally="0">0/2</td>
-<td class="tally" data-browser="firefox116" data-tally="0">0/2</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="0">0/2</td>
+<td class="tally" data-browser="firefox117" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="0">0/2</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="0">0/2</td>
@@ -3514,9 +3492,7 @@ return buffer1.byteLength === 0
 <td class="unknown obsolete" data-browser="typescript4_9corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript5_0corejs3">?</td>
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -3529,9 +3505,10 @@ return buffer1.byteLength === 0
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -3667,9 +3644,7 @@ return buffer1.byteLength === 0
 <td class="unknown obsolete" data-browser="typescript4_9corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript5_0corejs3">?</td>
 <td class="unknown" data-browser="typescript5_1corejs3">?</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -3682,9 +3657,10 @@ return buffer1.byteLength === 0
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -3814,9 +3790,7 @@ return buffer1.byteLength === 0
 <td class="tally obsolete" data-browser="typescript4_9corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript5_0corejs3" data-tally="1">2/2</td>
 <td class="tally" data-browser="typescript5_1corejs3" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="0">0/2</td>
@@ -3829,9 +3803,10 @@ return buffer1.byteLength === 0
 <td class="tally obsolete" data-browser="firefox113" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="0">0/2</td>
 <td class="tally" data-browser="firefox115" data-tally="0">0/2</td>
-<td class="tally" data-browser="firefox116" data-tally="0">0/2</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="0">0/2</td>
+<td class="tally" data-browser="firefox117" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="0">0/2</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="0">0/2</td>
@@ -3967,9 +3942,7 @@ return Array.from(map).join() === &apos;a,2,b,3&apos;;
 <td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript5_0corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -3982,9 +3955,10 @@ return Array.from(map).join() === &apos;a,2,b,3&apos;;
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -4121,9 +4095,7 @@ return map.get(a) === 2 &amp;&amp; map.get(b) === 3;
 <td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript5_0corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -4136,9 +4108,10 @@ return map.get(a) === 2 &amp;&amp; map.get(b) === 3;
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -4272,9 +4245,7 @@ return !Array.isTemplateObject([])
 <td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript5_0corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -4287,9 +4258,10 @@ return !Array.isTemplateObject([])
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -4419,9 +4391,7 @@ return !Array.isTemplateObject([])
 <td class="tally obsolete" data-browser="typescript4_9corejs3" data-tally="1">35/35</td>
 <td class="tally obsolete" data-browser="typescript5_0corejs3" data-tally="1">35/35</td>
 <td class="tally" data-browser="typescript5_1corejs3" data-tally="1">35/35</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="0">0/35</td>
@@ -4434,9 +4404,10 @@ return !Array.isTemplateObject([])
 <td class="tally obsolete" data-browser="firefox113" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="0">0/35</td>
 <td class="tally" data-browser="firefox115" data-tally="0">0/35</td>
-<td class="tally" data-browser="firefox116" data-tally="0">0/35</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="0">0/35</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="0">0/35</td>
+<td class="tally" data-browser="firefox117" data-tally="0">0/35</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="0">0/35</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="0">0/35</td>
@@ -4569,9 +4540,7 @@ return [1, 2, 3].values() instanceof Iterator;
 <td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript5_0corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -4584,9 +4553,10 @@ return [1, 2, 3].values() instanceof Iterator;
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -4721,9 +4691,7 @@ return instance[Symbol.iterator]() === instance;
 <td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript5_0corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -4736,9 +4704,10 @@ return instance[Symbol.iterator]() === instance;
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -4874,9 +4843,7 @@ return &apos;next&apos; in iterator
 <td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript5_0corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -4889,9 +4856,10 @@ return &apos;next&apos; in iterator
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -5032,9 +5000,7 @@ return &apos;next&apos; in iterator
 <td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript5_0corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -5047,9 +5013,10 @@ return &apos;next&apos; in iterator
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -5182,9 +5149,7 @@ return Array.from([1, 2, 3].values().asIndexedPairs()).join() === &apos;0,1,1,2,
 <td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript5_0corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -5197,9 +5162,10 @@ return Array.from([1, 2, 3].values().asIndexedPairs()).join() === &apos;0,1,1,2,
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -5332,9 +5298,7 @@ return Array.from([1, 2, 3].values().drop(1)).join() === &apos;2,3&apos;;
 <td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript5_0corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -5347,9 +5311,10 @@ return Array.from([1, 2, 3].values().drop(1)).join() === &apos;2,3&apos;;
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -5482,9 +5447,7 @@ return [1, 2, 3].values().every(it =&gt; typeof it === &apos;number&apos;);
 <td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript5_0corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -5497,9 +5460,10 @@ return [1, 2, 3].values().every(it =&gt; typeof it === &apos;number&apos;);
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -5632,9 +5596,7 @@ return Array.from([1, 2, 3].values().filter(it =&gt; it % 2)).join() === &apos;1
 <td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript5_0corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -5647,9 +5609,10 @@ return Array.from([1, 2, 3].values().filter(it =&gt; it % 2)).join() === &apos;1
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -5782,9 +5745,7 @@ return [1, 2, 3].values().find(it =&gt; it % 2) === 1;
 <td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript5_0corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -5797,9 +5758,10 @@ return [1, 2, 3].values().find(it =&gt; it % 2) === 1;
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -5932,9 +5894,7 @@ return Array.from([1, 2, 3].values().flatMap(it =&gt; [it, 0])).join() === &apos
 <td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript5_0corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -5947,9 +5907,10 @@ return Array.from([1, 2, 3].values().flatMap(it =&gt; [it, 0])).join() === &apos
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -6084,9 +6045,7 @@ return result === &apos;123&apos;;
 <td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript5_0corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -6099,9 +6058,10 @@ return result === &apos;123&apos;;
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -6234,9 +6194,7 @@ return Array.from([1, 2, 3].values().map(it =&gt; it * it)).join() === &apos;1,4
 <td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript5_0corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -6249,9 +6207,10 @@ return Array.from([1, 2, 3].values().map(it =&gt; it * it)).join() === &apos;1,4
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -6384,9 +6343,7 @@ return [1, 2, 3].values().reduce((a, b) =&gt; a + b) === 6;
 <td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript5_0corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -6399,9 +6356,10 @@ return [1, 2, 3].values().reduce((a, b) =&gt; a + b) === 6;
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -6534,9 +6492,7 @@ return [1, 2, 3].values().some(it =&gt; typeof it === &apos;number&apos;);
 <td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript5_0corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -6549,9 +6505,10 @@ return [1, 2, 3].values().some(it =&gt; typeof it === &apos;number&apos;);
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -6684,9 +6641,7 @@ return Array.from([1, 2, 3].values().take(2)).join() === &apos;1,2&apos;;
 <td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript5_0corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -6699,9 +6654,10 @@ return Array.from([1, 2, 3].values().take(2)).join() === &apos;1,2&apos;;
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -6835,9 +6791,7 @@ return Array.isArray(array) &amp;&amp; array.join() === &apos;1,2,3&apos;;
 <td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript5_0corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -6850,9 +6804,10 @@ return Array.isArray(array) &amp;&amp; array.join() === &apos;1,2,3&apos;;
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -6985,9 +6940,7 @@ return Iterator.prototype[Symbol.toStringTag] === &apos;Iterator&apos;;
 <td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript5_0corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -7000,9 +6953,10 @@ return Iterator.prototype[Symbol.toStringTag] === &apos;Iterator&apos;;
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -7135,9 +7089,7 @@ return (async function*() {})() instanceof AsyncIterator;
 <td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript5_0corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -7150,9 +7102,10 @@ return (async function*() {})() instanceof AsyncIterator;
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -7287,9 +7240,7 @@ return instance[Symbol.asyncIterator]() === instance;
 <td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript5_0corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -7302,9 +7253,10 @@ return instance[Symbol.asyncIterator]() === instance;
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -7449,9 +7401,7 @@ toArray(iterator).then(it =&gt; {
 <td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript5_0corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -7464,9 +7414,10 @@ toArray(iterator).then(it =&gt; {
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -7611,9 +7562,7 @@ toArray(iterator).then(it =&gt; {
 <td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript5_0corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -7626,9 +7575,10 @@ toArray(iterator).then(it =&gt; {
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -7773,9 +7723,7 @@ toArray(iterator).then(it =&gt; {
 <td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript5_0corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -7788,9 +7736,10 @@ toArray(iterator).then(it =&gt; {
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -7931,9 +7880,7 @@ toArray((async function*() { yield * [1, 2, 3] })().asIndexedPairs()).then(it =&
 <td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript5_0corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -7946,9 +7893,10 @@ toArray((async function*() { yield * [1, 2, 3] })().asIndexedPairs()).then(it =&
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -8089,9 +8037,7 @@ toArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it =&gt; {
 <td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript5_0corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -8104,9 +8050,10 @@ toArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it =&gt; {
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -8241,9 +8188,7 @@ toArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it =&gt; {
 <td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript5_0corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -8256,9 +8201,10 @@ toArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it =&gt; {
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -8399,9 +8345,7 @@ toArray(async function*() { yield * [1, 2, 3] }().filter(it =&gt; it % 2)).then(
 <td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript5_0corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -8414,9 +8358,10 @@ toArray(async function*() { yield * [1, 2, 3] }().filter(it =&gt; it % 2)).then(
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -8551,9 +8496,7 @@ toArray(async function*() { yield * [1, 2, 3] }().filter(it =&gt; it % 2)).then(
 <td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript5_0corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -8566,9 +8509,10 @@ toArray(async function*() { yield * [1, 2, 3] }().filter(it =&gt; it % 2)).then(
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -8709,9 +8653,7 @@ toArray(async function*() { yield * [1, 2, 3] }().flatMap(it =&gt; [it, 0])).the
 <td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript5_0corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -8724,9 +8666,10 @@ toArray(async function*() { yield * [1, 2, 3] }().flatMap(it =&gt; [it, 0])).the
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -8862,9 +8805,7 @@ let result = &apos;&apos;;
 <td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript5_0corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -8877,9 +8818,10 @@ let result = &apos;&apos;;
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -9020,9 +8962,7 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript5_0corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -9035,9 +8975,10 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -9172,9 +9113,7 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript5_0corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -9187,9 +9126,10 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -9324,9 +9264,7 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript5_0corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -9339,9 +9277,10 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -9482,9 +9421,7 @@ toArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it =&gt; {
 <td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript5_0corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -9497,9 +9434,10 @@ toArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it =&gt; {
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -9634,9 +9572,7 @@ toArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it =&gt; {
 <td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript5_0corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -9649,9 +9585,10 @@ toArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it =&gt; {
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -9784,9 +9721,7 @@ return AsyncIterator.prototype[Symbol.toStringTag] === &apos;AsyncIterator&apos;
 <td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript5_0corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="typescript5_1corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -9799,9 +9734,10 @@ return AsyncIterator.prototype[Symbol.toStringTag] === &apos;AsyncIterator&apos;
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -122,9 +122,7 @@
 <th class="platform ie9 desktop obsolete" data-browser="ie9"><a href="#ie9" class="browser-name"><abbr title="Internet Explorer 9">IE 9</abbr></a></th>
 <th class="platform ie10 desktop obsolete" data-browser="ie10"><a href="#ie10" class="browser-name"><abbr title="Internet Explorer 10">IE 10</abbr></a></th>
 <th class="platform ie11 desktop" data-browser="ie11"><a href="#ie11" class="browser-name"><abbr title="Internet Explorer 11">IE 11</abbr></a></th>
-<th class="platform firefox91 desktop obsolete" data-browser="firefox91"><a href="#firefox91" class="browser-name"><abbr title="Firefox 91 Extended Support Release">FF 91 ESR</abbr></a></th>
 <th class="platform firefox102 desktop obsolete" data-browser="firefox102"><a href="#firefox102" class="browser-name"><abbr title="Firefox 102 Extended Support Release">FF 102 ESR</abbr></a></th>
-<th class="platform firefox103 desktop obsolete" data-browser="firefox103"><a href="#firefox103" class="browser-name"><abbr title="Firefox 103">FF 103</abbr></a></th>
 <th class="platform firefox104 desktop obsolete" data-browser="firefox104"><a href="#firefox104" class="browser-name"><abbr title="Firefox 104">FF 104</abbr></a></th>
 <th class="platform firefox105 desktop obsolete" data-browser="firefox105"><a href="#firefox105" class="browser-name"><abbr title="Firefox 105">FF 105</abbr></a></th>
 <th class="platform firefox106 desktop obsolete" data-browser="firefox106"><a href="#firefox106" class="browser-name"><abbr title="Firefox 106">FF 106</abbr></a></th>
@@ -137,9 +135,10 @@
 <th class="platform firefox113 desktop obsolete" data-browser="firefox113"><a href="#firefox113" class="browser-name"><abbr title="Firefox 113">FF 113</abbr></a></th>
 <th class="platform firefox114 desktop obsolete" data-browser="firefox114"><a href="#firefox114" class="browser-name"><abbr title="Firefox 114">FF 114</abbr></a></th>
 <th class="platform firefox115 desktop" data-browser="firefox115"><a href="#firefox115" class="browser-name"><abbr title="Firefox 115 Extended Support Release">FF 115 ESR</abbr></a></th>
-<th class="platform firefox116 desktop" data-browser="firefox116"><a href="#firefox116" class="browser-name"><abbr title="Firefox 116">FF 116</abbr></a></th>
-<th class="platform firefox117 desktop unstable" data-browser="firefox117"><a href="#firefox117" class="browser-name"><abbr title="Firefox 117 Beta">FF 117</abbr></a></th>
-<th class="platform firefox118 desktop unstable" data-browser="firefox118"><a href="#firefox118" class="browser-name"><abbr title="Firefox 118 Nightly">FF 118</abbr></a></th>
+<th class="platform firefox116 desktop obsolete" data-browser="firefox116"><a href="#firefox116" class="browser-name"><abbr title="Firefox 116">FF 116</abbr></a></th>
+<th class="platform firefox117 desktop" data-browser="firefox117"><a href="#firefox117" class="browser-name"><abbr title="Firefox 117">FF 117</abbr></a></th>
+<th class="platform firefox118 desktop unstable" data-browser="firefox118"><a href="#firefox118" class="browser-name"><abbr title="Firefox 118 Beta">FF 118</abbr></a></th>
+<th class="platform firefox119 desktop unstable" data-browser="firefox119"><a href="#firefox119" class="browser-name"><abbr title="Firefox 119 Nightly">FF 119</abbr></a></th>
 <th class="platform opera12_10 desktop obsolete" data-browser="opera12_10"><a href="#opera12_10" class="browser-name"><abbr title="Opera 12.10">OP 12.10</abbr></a></th>
 <th class="platform chrome102 desktop obsolete" data-browser="chrome102"><a href="#chrome102" class="browser-name"><abbr title="Chrome 102">CH 102</abbr></a></th>
 <th class="platform chrome103 desktop obsolete" data-browser="chrome103"><a href="#chrome103" class="browser-name"><abbr title="Chrome 103">CH 103</abbr></a></th>
@@ -262,9 +261,7 @@
 <td class="tally obsolete" data-browser="ie9" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/57</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/57</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="0">0/57</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="0">0/57</td>
@@ -277,9 +274,10 @@
 <td class="tally obsolete" data-browser="firefox113" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="0">0/57</td>
 <td class="tally" data-browser="firefox115" data-tally="0">0/57</td>
-<td class="tally" data-browser="firefox116" data-tally="0">0/57</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="0">0/57</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="0">0/57</td>
+<td class="tally" data-browser="firefox117" data-tally="0">0/57</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="0">0/57</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="0">0/57</td>
@@ -409,9 +407,7 @@ return typeof SIMD !== &apos;undefined&apos;;
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -424,9 +420,10 @@ return typeof SIMD !== &apos;undefined&apos;;
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -548,9 +545,7 @@ return typeof SIMD.Float32x4 === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -563,9 +558,10 @@ return typeof SIMD.Float32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -687,9 +683,7 @@ return typeof SIMD.Int32x4 === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -702,9 +696,10 @@ return typeof SIMD.Int32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -826,9 +821,7 @@ return typeof SIMD.Int16x8 === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -841,9 +834,10 @@ return typeof SIMD.Int16x8 === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -965,9 +959,7 @@ return typeof SIMD.Int8x16 === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -980,9 +972,10 @@ return typeof SIMD.Int8x16 === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -1104,9 +1097,7 @@ return typeof SIMD.Uint32x4 === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -1119,9 +1110,10 @@ return typeof SIMD.Uint32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -1243,9 +1235,7 @@ return typeof SIMD.Uint16x8 === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -1258,9 +1248,10 @@ return typeof SIMD.Uint16x8 === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -1382,9 +1373,7 @@ return typeof SIMD.Uint8x16 === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -1397,9 +1386,10 @@ return typeof SIMD.Uint8x16 === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -1521,9 +1511,7 @@ return typeof SIMD.Bool32x4 === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -1536,9 +1524,10 @@ return typeof SIMD.Bool32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -1660,9 +1649,7 @@ return typeof SIMD.Bool16x8 === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -1675,9 +1662,10 @@ return typeof SIMD.Bool16x8 === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -1799,9 +1787,7 @@ return typeof SIMD.Bool8x16 === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -1814,9 +1800,10 @@ return typeof SIMD.Bool8x16 === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -1940,9 +1927,7 @@ return simdFloatTypes.every(function(type){
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -1955,9 +1940,10 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -2081,9 +2067,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -2096,9 +2080,10 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -2222,9 +2207,7 @@ return simdSmallIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -2237,9 +2220,10 @@ return simdSmallIntTypes.every(function(type){
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -2363,9 +2347,7 @@ return simdBoolIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -2378,9 +2360,10 @@ return simdBoolIntTypes.every(function(type){
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -2504,9 +2487,7 @@ return simdBoolTypes.every(function(type){
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -2519,9 +2500,10 @@ return simdBoolTypes.every(function(type){
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -2645,9 +2627,7 @@ return simdBoolTypes.every(function(type){
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -2660,9 +2640,10 @@ return simdBoolTypes.every(function(type){
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -2786,9 +2767,7 @@ return simdAllTypes.every(function(type){
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -2801,9 +2780,10 @@ return simdAllTypes.every(function(type){
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -2927,9 +2907,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -2942,9 +2920,10 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -3068,9 +3047,7 @@ return simdAllTypes.every(function(type){
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -3083,9 +3060,10 @@ return simdAllTypes.every(function(type){
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -3209,9 +3187,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -3224,9 +3200,10 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -3350,9 +3327,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -3365,9 +3340,10 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -3491,9 +3467,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -3506,9 +3480,10 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -3632,9 +3607,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -3647,9 +3620,10 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -3773,9 +3747,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -3788,9 +3760,10 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -3914,9 +3887,7 @@ return simdFloatTypes.every(function(type){
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -3929,9 +3900,10 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -4055,9 +4027,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -4070,9 +4040,10 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -4196,9 +4167,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -4211,9 +4180,10 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -4337,9 +4307,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -4352,9 +4320,10 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -4478,9 +4447,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -4493,9 +4460,10 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -4619,9 +4587,7 @@ return simdFloatTypes.every(function(type){
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -4634,9 +4600,10 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -4760,9 +4727,7 @@ return simdFloatTypes.every(function(type){
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -4775,9 +4740,10 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -4901,9 +4867,7 @@ return simdFloatTypes.every(function(type){
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -4916,9 +4880,10 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -5042,9 +5007,7 @@ return simdFloatTypes.every(function(type){
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -5057,9 +5020,10 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -5183,9 +5147,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -5198,9 +5160,10 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -5324,9 +5287,7 @@ return simdBoolTypes.every(function(type){
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -5339,9 +5300,10 @@ return simdBoolTypes.every(function(type){
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -5465,9 +5427,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -5480,9 +5440,10 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -5606,9 +5567,7 @@ return simdBoolIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -5621,9 +5580,10 @@ return simdBoolIntTypes.every(function(type){
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -5747,9 +5707,7 @@ return simdFloatTypes.every(function(type){
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -5762,9 +5720,10 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -5888,9 +5847,7 @@ return simdFloatTypes.every(function(type){
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -5903,9 +5860,10 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -6029,9 +5987,7 @@ return simdAllTypes.every(function(type){
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -6044,9 +6000,10 @@ return simdAllTypes.every(function(type){
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -6170,9 +6127,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -6185,9 +6140,10 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -6311,9 +6267,7 @@ return simdIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -6326,9 +6280,10 @@ return simdIntTypes.every(function(type){
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -6452,9 +6407,7 @@ return simdIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -6467,9 +6420,10 @@ return simdIntTypes.every(function(type){
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -6593,9 +6547,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -6608,9 +6560,10 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -6734,9 +6687,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -6749,9 +6700,10 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -6875,9 +6827,7 @@ return simdFloatTypes.every(function(type){
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -6890,9 +6840,10 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -7016,9 +6967,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -7031,9 +6980,10 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -7157,9 +7107,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -7172,9 +7120,10 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -7298,9 +7247,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -7313,9 +7260,10 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -7439,9 +7387,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -7454,9 +7400,10 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -7580,9 +7527,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -7595,9 +7540,10 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -7721,9 +7667,7 @@ return simdSmallIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -7736,9 +7680,10 @@ return simdSmallIntTypes.every(function(type){
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -7862,9 +7807,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -7877,9 +7820,10 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -8003,9 +7947,7 @@ return simdBoolIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -8018,9 +7960,10 @@ return simdBoolIntTypes.every(function(type){
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -8144,9 +8087,7 @@ return [&apos;Float32x4&apos;,&apos;Int32x4&apos;,&apos;Int8x16&apos;,&apos;Uint
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -8159,9 +8100,10 @@ return [&apos;Float32x4&apos;,&apos;Int32x4&apos;,&apos;Int8x16&apos;,&apos;Uint
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -8283,9 +8225,7 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -8298,9 +8238,10 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -8412,7 +8353,7 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="no" data-browser="opera_mobile76">No</td>
 <td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
-<tr><th colspan="137" class="separator"></th>
+<tr><th colspan="136" class="separator"></th>
 </tr>
 <tr class="supertest" significance="1"><td id="test-decompilation"><span><a class="anchor" href="#test-decompilation">&#xA7;</a>decompilation</span></td>
 <td class="tally obsolete" data-browser="konq4_13" data-tally="0">0/4</td>
@@ -8421,9 +8362,7 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="tally obsolete" data-browser="ie9" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="0">0/4</td>
@@ -8436,9 +8375,10 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="tally obsolete" data-browser="firefox113" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="0">0/4</td>
 <td class="tally" data-browser="firefox115" data-tally="0">0/4</td>
-<td class="tally" data-browser="firefox116" data-tally="0">0/4</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="0">0/4</td>
+<td class="tally" data-browser="firefox117" data-tally="0">0/4</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="0">0/4</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="0">0/4</td>
@@ -8560,9 +8500,7 @@ return typeof uneval === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -8575,9 +8513,10 @@ return typeof uneval === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -8707,9 +8646,7 @@ return &apos;toSource&apos; in Object.prototype
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -8722,9 +8659,10 @@ return &apos;toSource&apos; in Object.prototype
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -8846,9 +8784,7 @@ return uneval({ toSource: function() { return &quot;pwnd!&quot; } }) === &quot;p
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -8861,9 +8797,10 @@ return uneval({ toSource: function() { return &quot;pwnd!&quot; } }) === &quot;p
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -9071,9 +9008,7 @@ return true;
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -9086,9 +9021,10 @@ return true;
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -9211,9 +9147,7 @@ return eval(&quot;x&quot;, { x: 2 }) === 2;
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -9226,9 +9160,10 @@ return eval(&quot;x&quot;, { x: 2 }) === 2;
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -9340,7 +9275,7 @@ return eval(&quot;x&quot;, { x: 2 }) === 2;
 <td class="no" data-browser="opera_mobile76">No</td>
 <td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
-<tr><th colspan="137" class="separator"></th>
+<tr><th colspan="136" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-function_caller_property"><span><a class="anchor" href="#test-function_caller_property">&#xA7;</a>function &quot;caller&quot; property <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/caller" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return &apos;caller&apos; in function(){};
@@ -9354,9 +9289,7 @@ return 'caller' in function(){};
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -9369,9 +9302,10 @@ return 'caller' in function(){};
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -9499,9 +9433,7 @@ return (function () {}).arity === 0 &&
 <td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -9514,9 +9446,10 @@ return (function () {}).arity === 0 &&
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -9646,9 +9579,7 @@ return f(1, 'boo');
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -9661,9 +9592,10 @@ return f(1, 'boo');
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -9787,9 +9719,7 @@ return typeof Function.prototype.isGenerator === 'function';
 <td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -9802,9 +9732,10 @@ return typeof Function.prototype.isGenerator === 'function';
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -9916,7 +9847,7 @@ return typeof Function.prototype.isGenerator === 'function';
 <td class="no" data-browser="opera_mobile76">No</td>
 <td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
-<tr><th colspan="137" class="separator"></th>
+<tr><th colspan="136" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-class_extends_null"><span><a class="anchor" href="#test-class_extends_null">&#xA7;</a><a href="https://github.com/tc39/ecma262/issues/543">class extends null</a></span><script data-source="
 class C extends null {}
@@ -9929,9 +9860,7 @@ return new C instanceof C;
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="unknown obsolete" data-browser="firefox91">?</td>
 <td class="unknown obsolete" data-browser="firefox102">?</td>
-<td class="unknown obsolete" data-browser="firefox103">?</td>
 <td class="unknown obsolete" data-browser="firefox104">?</td>
 <td class="unknown obsolete" data-browser="firefox105">?</td>
 <td class="unknown obsolete" data-browser="firefox106">?</td>
@@ -9944,9 +9873,10 @@ return new C instanceof C;
 <td class="unknown obsolete" data-browser="firefox113">?</td>
 <td class="unknown obsolete" data-browser="firefox114">?</td>
 <td class="unknown" data-browser="firefox115">?</td>
-<td class="unknown" data-browser="firefox116">?</td>
-<td class="unknown unstable" data-browser="firefox117">?</td>
+<td class="unknown obsolete" data-browser="firefox116">?</td>
+<td class="unknown" data-browser="firefox117">?</td>
 <td class="unknown unstable" data-browser="firefox118">?</td>
+<td class="unknown unstable" data-browser="firefox119">?</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -10072,9 +10002,7 @@ return typeof ({}).__count__ === 'number' &&
 <td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -10087,9 +10015,10 @@ return typeof ({}).__count__ === 'number' &&
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -10213,9 +10142,7 @@ return typeof ({}).__parent__ !== 'undefined';
 <td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -10228,9 +10155,10 @@ return typeof ({}).__parent__ !== 'undefined';
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -10364,9 +10292,7 @@ return executed;
 <td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -10379,9 +10305,10 @@ return executed;
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -10505,9 +10432,7 @@ return typeof Array.slice === 'function' && Array.slice('abc').length === 3;
 <td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -10520,9 +10445,10 @@ return typeof Array.slice === 'function' && Array.slice('abc').length === 3;
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -10646,9 +10572,7 @@ return typeof String.slice === 'function' && String.slice(123, 1) === "23";
 <td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -10661,9 +10585,10 @@ return typeof String.slice === 'function' && String.slice(123, 1) === "23";
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -10775,7 +10700,7 @@ return typeof String.slice === 'function' && String.slice(123, 1) === "23";
 <td class="no" data-browser="opera_mobile76">No</td>
 <td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
-<tr><th colspan="137" class="separator"></th>
+<tr><th colspan="136" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Array_comprehensions_(JS_1.8_style)"><span><a class="anchor" href="#test-Array_comprehensions_(JS_1.8_style)">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Predefined_Core_Objects#Array_comprehensions">Array comprehensions (JS 1.8 style)</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Array_comprehensions#Differences_to_the_older_JS1.7JS1.8_comprehensions" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var obj = { 2: true, &quot;foo&quot;: true, 4: true };
@@ -10789,9 +10714,7 @@ return a instanceof Array &amp;&amp; a[0] === 4 &amp;&amp; a[1] === 8;
 <td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -10804,9 +10727,10 @@ return a instanceof Array &amp;&amp; a[0] === 4 &amp;&amp; a[1] === 8;
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -10928,9 +10852,7 @@ return [for (a of [1, 2, 3]) a * a] + &apos;&apos; === &apos;1,4,9&apos;;
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -10943,9 +10865,10 @@ return [for (a of [1, 2, 3]) a * a] + &apos;&apos; === &apos;1,4,9&apos;;
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -11067,9 +10990,7 @@ return (function(x)x)(1) === 1;
 <td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -11082,9 +11003,10 @@ return (function(x)x)(1) === 1;
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -11206,9 +11128,7 @@ return typeof &lt;foo/&gt; === &quot;xml&quot;;
 <td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -11221,9 +11141,10 @@ return typeof &lt;foo/&gt; === &quot;xml&quot;;
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -11349,9 +11270,7 @@ return str === &quot;foobarbaz&quot;;
 <td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -11364,9 +11283,10 @@ return str === &quot;foobarbaz&quot;;
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -11489,9 +11409,7 @@ return arr[1] === arr;
 <td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -11504,9 +11422,10 @@ return arr[1] === arr;
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -11618,7 +11537,7 @@ return arr[1] === arr;
 <td class="no" data-browser="opera_mobile76">No</td>
 <td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
-<tr><th colspan="137" class="separator"></th>
+<tr><th colspan="136" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Iterator"><span><a class="anchor" href="#test-Iterator">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators">Iterator</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 /* global Iterator */
@@ -11662,9 +11581,7 @@ catch(e) {
 <td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -11677,9 +11594,10 @@ catch(e) {
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -11841,9 +11759,7 @@ catch(e) {
 <td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -11856,9 +11772,10 @@ catch(e) {
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -12019,9 +11936,7 @@ global.test((function () {
 <td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -12034,9 +11949,10 @@ global.test((function () {
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -12160,9 +12076,7 @@ return g.next() === 4 &amp;&amp; g.next() === 8;
 <td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -12175,9 +12089,10 @@ return g.next() === 4 &amp;&amp; g.next() === 8;
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -12306,9 +12221,7 @@ return passed;
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -12321,9 +12234,10 @@ return passed;
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -12435,7 +12349,7 @@ return passed;
 <td class="no" data-browser="opera_mobile76">No</td>
 <td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
-<tr><th colspan="137" class="separator"></th>
+<tr><th colspan="136" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-RegExp_x_flag"><span><a class="anchor" href="#test-RegExp_x_flag">&#xA7;</a>RegExp &quot;x&quot; flag</span><script data-source="function () {
 try {
@@ -12463,9 +12377,7 @@ try {
 <td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -12478,9 +12390,10 @@ try {
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -12602,9 +12515,7 @@ return /\\w/(&quot;x&quot;)[0] === &quot;x&quot;;
 <td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -12617,9 +12528,10 @@ return /\\w/(&quot;x&quot;)[0] === &quot;x&quot;;
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -12742,9 +12654,7 @@ return /(?P&lt;name&gt;a)(?P=name)/.test(&quot;aa&quot;) &amp;&amp;
 <td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -12757,9 +12667,10 @@ return /(?P&lt;name&gt;a)(?P=name)/.test(&quot;aa&quot;) &amp;&amp;
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -12871,7 +12782,7 @@ return /(?P&lt;name&gt;a)(?P=name)/.test(&quot;aa&quot;) &amp;&amp;
 <td class="no" data-browser="opera_mobile76">No</td>
 <td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
-<tr><th colspan="137" class="separator"></th>
+<tr><th colspan="136" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-String.prototype.quote"><span><a class="anchor" href="#test-String.prototype.quote">&#xA7;</a>String.prototype.quote <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/quote" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () { return typeof String.prototype.quote === &apos;function&apos; }">test(
 function () { return typeof String.prototype.quote === 'function' }())</script></td>
@@ -12881,9 +12792,7 @@ function () { return typeof String.prototype.quote === 'function' }())</script><
 <td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -12896,9 +12805,10 @@ function () { return typeof String.prototype.quote === 'function' }())</script><
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -13018,9 +12928,7 @@ function () { return 'foofoo'.replace('foo', 'bar', 'g') === 'barbar' }())</scri
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -13033,9 +12941,10 @@ function () { return 'foofoo'.replace('foo', 'bar', 'g') === 'barbar' }())</scri
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -13147,7 +13056,7 @@ function () { return 'foofoo'.replace('foo', 'bar', 'g') === 'barbar' }())</scri
 <td class="no" data-browser="opera_mobile76">No</td>
 <td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
-<tr><th colspan="137" class="separator"></th>
+<tr><th colspan="136" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Date.prototype.toLocaleFormat"><span><a class="anchor" href="#test-Date.prototype.toLocaleFormat">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleFormat">Date.prototype.toLocaleFormat</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleFormat" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () { return typeof Date.prototype.toLocaleFormat === &apos;function&apos; }">test(
 function () { return typeof Date.prototype.toLocaleFormat === 'function' }())</script></td>
@@ -13157,9 +13066,7 @@ function () { return typeof Date.prototype.toLocaleFormat === 'function' }())</s
 <td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -13172,9 +13079,10 @@ function () { return typeof Date.prototype.toLocaleFormat === 'function' }())</s
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -13304,9 +13212,7 @@ return !brokenOnFirefox && !brokenOnIE10 && !brokenOnChrome;
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -13319,9 +13225,10 @@ return !brokenOnFirefox && !brokenOnIE10 && !brokenOnChrome;
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -13433,7 +13340,7 @@ return !brokenOnFirefox && !brokenOnIE10 && !brokenOnChrome;
 <td class="no" data-browser="opera_mobile76">No</td>
 <td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
-<tr><th colspan="137" class="separator"></th>
+<tr><th colspan="136" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Object.prototype.watch"><span><a class="anchor" href="#test-Object.prototype.watch">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/watch">Object.prototype.watch</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/watch" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () { return typeof Object.prototype.watch === &apos;function&apos; }">test(
 function () { return typeof Object.prototype.watch === 'function' }())</script></td>
@@ -13443,9 +13350,7 @@ function () { return typeof Object.prototype.watch === 'function' }())</script><
 <td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -13458,9 +13363,10 @@ function () { return typeof Object.prototype.watch === 'function' }())</script><
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -13580,9 +13486,7 @@ function () { return typeof Object.prototype.unwatch === 'function' }())</script
 <td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -13595,9 +13499,10 @@ function () { return typeof Object.prototype.unwatch === 'function' }())</script
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -13717,9 +13622,7 @@ function () { return typeof Object.prototype.eval === 'function' }())</script></
 <td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -13732,9 +13635,10 @@ function () { return typeof Object.prototype.eval === 'function' }())</script></
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -13856,9 +13760,7 @@ return typeof Object.observe === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -13871,9 +13773,10 @@ return typeof Object.observe === &apos;function&apos;;
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -13985,7 +13888,7 @@ return typeof Object.observe === &apos;function&apos;;
 <td class="no" data-browser="opera_mobile76">No</td>
 <td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
-<tr><th colspan="137" class="separator"></th>
+<tr><th colspan="136" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-error_stack"><span><a class="anchor" href="#test-error_stack">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack">error &quot;stack&quot;</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 try {
@@ -14007,9 +13910,7 @@ try {
 <td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -14022,9 +13923,10 @@ try {
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome102">Yes</td>
 <td class="yes obsolete" data-browser="chrome103">Yes</td>
@@ -14148,9 +14050,7 @@ return 'lineNumber' in new Error();
 <td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -14163,9 +14063,10 @@ return 'lineNumber' in new Error();
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -14289,9 +14190,7 @@ return 'columnNumber' in new Error();
 <td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -14304,9 +14203,10 @@ return 'columnNumber' in new Error();
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -14430,9 +14330,7 @@ return 'fileName' in new Error();
 <td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="yes obsolete" data-browser="firefox91">Yes</td>
 <td class="yes obsolete" data-browser="firefox102">Yes</td>
-<td class="yes obsolete" data-browser="firefox103">Yes</td>
 <td class="yes obsolete" data-browser="firefox104">Yes</td>
 <td class="yes obsolete" data-browser="firefox105">Yes</td>
 <td class="yes obsolete" data-browser="firefox106">Yes</td>
@@ -14445,9 +14343,10 @@ return 'fileName' in new Error();
 <td class="yes obsolete" data-browser="firefox113">Yes</td>
 <td class="yes obsolete" data-browser="firefox114">Yes</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="yes" data-browser="firefox116">Yes</td>
-<td class="yes unstable" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox116">Yes</td>
+<td class="yes" data-browser="firefox117">Yes</td>
 <td class="yes unstable" data-browser="firefox118">Yes</td>
+<td class="yes unstable" data-browser="firefox119">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -14571,9 +14470,7 @@ return 'description' in new Error();
 <td class="yes obsolete" data-browser="ie9">Yes</td>
 <td class="yes obsolete" data-browser="ie10">Yes</td>
 <td class="yes" data-browser="ie11">Yes</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -14586,9 +14483,10 @@ return 'description' in new Error();
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -14700,7 +14598,7 @@ return 'description' in new Error();
 <td class="no" data-browser="opera_mobile76">No</td>
 <td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
-<tr><th colspan="137" class="separator"></th>
+<tr><th colspan="136" class="separator"></th>
 </tr>
 <tr class="supertest" significance="1"><td id="test-global"><span><a class="anchor" href="#test-global">&#xA7;</a>global</span></td>
 <td class="tally obsolete" data-browser="konq4_13" data-tally="0">0/2</td>
@@ -14709,9 +14607,7 @@ return 'description' in new Error();
 <td class="tally obsolete" data-browser="ie9" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ie10" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="firefox91" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox102" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="firefox103" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox104" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox105" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox106" data-tally="0">0/2</td>
@@ -14724,9 +14620,10 @@ return 'description' in new Error();
 <td class="tally obsolete" data-browser="firefox113" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox114" data-tally="0">0/2</td>
 <td class="tally" data-browser="firefox115" data-tally="0">0/2</td>
-<td class="tally" data-browser="firefox116" data-tally="0">0/2</td>
-<td class="tally unstable" data-browser="firefox117" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="0">0/2</td>
+<td class="tally" data-browser="firefox117" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="firefox118" data-tally="0">0/2</td>
+<td class="tally unstable" data-browser="firefox119" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome102" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome103" data-tally="0">0/2</td>
@@ -14850,9 +14747,7 @@ return typeof global === &apos;object&apos; &amp;&amp; global &amp;&amp; global 
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -14865,9 +14760,10 @@ return typeof global === &apos;object&apos; &amp;&amp; global &amp;&amp; global 
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -14996,9 +14892,7 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -15011,9 +14905,10 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>
@@ -15140,9 +15035,7 @@ return Object.getOwnPropertyNames(P) + &apos;&apos; === &quot;a,a,b,b&quot;;
 <td class="unknown obsolete" data-browser="ie9">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox91">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox103">No</td>
 <td class="no obsolete" data-browser="firefox104">No</td>
 <td class="no obsolete" data-browser="firefox105">No</td>
 <td class="no obsolete" data-browser="firefox106">No</td>
@@ -15155,9 +15048,10 @@ return Object.getOwnPropertyNames(P) + &apos;&apos; === &quot;a,a,b,b&quot;;
 <td class="no obsolete" data-browser="firefox113">No</td>
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no" data-browser="firefox116">No</td>
-<td class="no unstable" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no" data-browser="firefox117">No</td>
 <td class="no unstable" data-browser="firefox118">No</td>
+<td class="no unstable" data-browser="firefox119">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome102">No</td>
 <td class="no obsolete" data-browser="chrome103">No</td>


### PR DESCRIPTION
Firefox 117 was released today.  Fixed the results for RegExp match indices on the 2016+ tab