### PR TITLE
Updates to pr1827

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,11 @@ es*/compilers/*
 .DS_Store
 .ruby-version
 _site/
-.idea/
 
 # Only apps should have lockfiles
 npm-shrinkwrap.json
 package-lock.json
 yarn.lock
+
+// temp file created by runner_support
+test.js

--- a/node.js
+++ b/node.js
@@ -4,7 +4,7 @@ var fs = require('fs');
 var chalk = require('chalk');
 var path = require('path');
 var cheerio = require('cheerio');
-var runner_support = require('./runner_support');
+var createIterableHelper = require('./test-utils/testHelpers').createIterableHelper;
 
 var page = fs.readFileSync(path.join(__dirname, String(process.argv[2] || 'es6').toLowerCase(), 'index.html')).toString().replace(/data-source="[^"]*"/g,'');
 var $ = cheerio.load(page);
@@ -26,7 +26,7 @@ $('#body tbody tr').each(function (index) {
   global.asyncPassed = function asyncPassed() {
     results[index] = true;
   };
-  eval(runner_support.createIterableHelper);
+  eval(createIterableHelper);
 
   results[index] = null;
 

--- a/rhino.js
+++ b/rhino.js
@@ -60,4 +60,6 @@ function rhinoRunner(testFilename) {
     }
 }
 
-runner_support.runTests(rhinoRunner, rhinoKey, 'Rhino');
+runner_support.runTests(rhinoRunner, rhinoKey, 'Rhino', {
+	logCommand: 'print'
+});

--- a/test-utils/testHelpers.js
+++ b/test-utils/testHelpers.js
@@ -1,0 +1,22 @@
+// this file must only contain js code written in ES3 as it's used in tests
+
+exports.createIterableHelper =
+'function __createIterableObject(arr, methods) {\n' +
+'    methods = methods || {};\n' +
+'    if (typeof Symbol !== "function" || !Symbol.iterator)\n' +
+'        return {};\n' +
+'    arr.length++;\n' +
+'    var iterator = {\n' +
+'        next: function() {\n' +
+'            return { value: arr.shift(), done: arr.length <= 0 };\n' +
+'        },\n' +
+'        "return": methods["return"],\n' +
+'        "throw": methods["throw"]\n' +
+'    };\n' +
+'    var iterable = {};\n' +
+'    iterable[Symbol.iterator] = function(){ return iterator; };\n' +
+'    return iterable;\n' +
+'}\n' +
+'if (typeof global !== "undefined") {\n' +
+'    global.__createIterableObject = __createIterableObject;\n' +
+'}\n';


### PR DESCRIPTION
Fixes issues introduced in #1827, namely:
- runner_support.js mixing usage of the `print` and `console.log` commands, neither of which will both work on any environment
- exceptions occurring during running of tests cluttering the stdout

Includes extracting `createIterableHelper` out from runner_support, as it's used by the `node.js` script, which must remain working on older NodeJS versions (and thus should be authored in ES3), while runner_support.js does not have that ES3 requirement  (and thus can use newer syntax)