### PR TITLE
Split the sync/async iterator helpers proposal, update Firefox results

### DIFF
--- a/data-esnext.js
+++ b/data-esnext.js
@@ -387,6 +387,12 @@ exports.tests = [
         ie11: false,
         firefox10: false,
         firefox60: false,
+        firefox116: false,
+        firefox117: {
+          val: 'flagged',
+          note_id: 'ff-iterator-helpers',
+          note_html: 'The feature is only available on Nightly builds, and has to be enabled via <code>javascript.options.experimental.iterator_helpers</code> setting under <code>about:config</code>.'
+        },
         chrome77: false,
         chrome126: true,
         duktape2_0: false,
@@ -411,6 +417,11 @@ exports.tests = [
         ie11: false,
         firefox10: false,
         firefox60: false,
+        firefox116: false,
+        firefox117: {
+          val: 'flagged',
+          note_id: 'ff-iterator-helpers'
+        },
         chrome77: false,
         chrome126: true,
         duktape2_0: false,
@@ -436,6 +447,11 @@ exports.tests = [
         ie11: false,
         firefox10: false,
         firefox60: false,
+        firefox116: false,
+        firefox117: {
+          val: 'flagged',
+          note_id: 'ff-iterator-helpers'
+        },
         chrome77: false,
         chrome126: true,
         duktape2_0: false,
@@ -466,6 +482,11 @@ exports.tests = [
         ie11: false,
         firefox10: false,
         firefox60: false,
+        firefox116: false,
+        firefox117: {
+          val: 'flagged',
+          note_id: 'ff-iterator-helpers'
+        },
         chrome77: false,
         chrome126: true,
         duktape2_0: false,
@@ -509,6 +530,11 @@ exports.tests = [
         ie11: false,
         firefox10: false,
         firefox60: false,
+        firefox116: false,
+        firefox117: {
+          val: 'flagged',
+          note_id: 'ff-iterator-helpers'
+        },
         chrome77: false,
         chrome126: true,
         duktape2_0: false,
@@ -531,6 +557,11 @@ exports.tests = [
         ie11: false,
         firefox10: false,
         firefox60: false,
+        firefox116: false,
+        firefox117: {
+          val: 'flagged',
+          note_id: 'ff-iterator-helpers'
+        },
         chrome77: false,
         chrome126: true,
         duktape2_0: false,
@@ -553,6 +584,11 @@ exports.tests = [
         ie11: false,
         firefox10: false,
         firefox60: false,
+        firefox116: false,
+        firefox117: {
+          val: 'flagged',
+          note_id: 'ff-iterator-helpers'
+        },
         chrome77: false,
         chrome126: true,
         duktape2_0: false,
@@ -575,6 +611,11 @@ exports.tests = [
         ie11: false,
         firefox10: false,
         firefox60: false,
+        firefox116: false,
+        firefox117: {
+          val: 'flagged',
+          note_id: 'ff-iterator-helpers'
+        },
         chrome77: false,
         chrome126: true,
         duktape2_0: false,
@@ -597,6 +638,11 @@ exports.tests = [
         ie11: false,
         firefox10: false,
         firefox60: false,
+        firefox116: false,
+        firefox117: {
+          val: 'flagged',
+          note_id: 'ff-iterator-helpers'
+        },
         chrome77: false,
         chrome126: true,
         duktape2_0: false,
@@ -621,6 +667,11 @@ exports.tests = [
         ie11: false,
         firefox10: false,
         firefox60: false,
+        firefox116: false,
+        firefox117: {
+          val: 'flagged',
+          note_id: 'ff-iterator-helpers'
+        },
         chrome77: false,
         chrome126: true,
         duktape2_0: false,
@@ -643,6 +694,11 @@ exports.tests = [
         ie11: false,
         firefox10: false,
         firefox60: false,
+        firefox116: false,
+        firefox117: {
+          val: 'flagged',
+          note_id: 'ff-iterator-helpers'
+        },
         chrome77: false,
         chrome126: true,
         duktape2_0: false,
@@ -665,6 +721,11 @@ exports.tests = [
         ie11: false,
         firefox10: false,
         firefox60: false,
+        firefox116: false,
+        firefox117: {
+          val: 'flagged',
+          note_id: 'ff-iterator-helpers'
+        },
         chrome77: false,
         chrome126: true,
         duktape2_0: false,
@@ -687,6 +748,11 @@ exports.tests = [
         ie11: false,
         firefox10: false,
         firefox60: false,
+        firefox116: false,
+        firefox117: {
+          val: 'flagged',
+          note_id: 'ff-iterator-helpers'
+        },
         chrome77: false,
         chrome126: true,
         duktape2_0: false,
@@ -709,6 +775,11 @@ exports.tests = [
         ie11: false,
         firefox10: false,
         firefox60: false,
+        firefox116: false,
+        firefox117: {
+          val: 'flagged',
+          note_id: 'ff-iterator-helpers'
+        },
         chrome77: false,
         chrome126: true,
         duktape2_0: false,
@@ -732,6 +803,11 @@ exports.tests = [
         ie11: false,
         firefox10: false,
         firefox60: false,
+        firefox116: false,
+        firefox117: {
+          val: 'flagged',
+          note_id: 'ff-iterator-helpers'
+        },
         chrome77: false,
         chrome126: true,
         duktape2_0: false,
@@ -754,6 +830,11 @@ exports.tests = [
         ie11: false,
         firefox10: false,
         firefox60: false,
+        firefox116: false,
+        firefox117: {
+          val: 'flagged',
+          note_id: 'ff-iterator-helpers'
+        },
         chrome77: false,
         chrome126: true,
         duktape2_0: false,
@@ -763,6 +844,14 @@ exports.tests = [
         rhino1_7_13: false
       }
     },
+  ]
+},
+{
+  name: 'Async Iterator Helpers',
+  category: STAGE2,
+  significance: 'large',
+  spec: 'https://github.com/tc39/proposal-async-iterator-helpers',
+  subtests: [
     {
       name: 'instanceof AsyncIterator',
       exec: function () {/*
@@ -776,6 +865,16 @@ exports.tests = [
         ie11: false,
         firefox10: false,
         firefox60: false,
+        firefox116: false,
+        firefox117: {
+          val: 'flagged',
+          note_id: 'ff-iterator-helpers'
+        },
+        firefox128: {
+          val: 'flagged',
+          note_id: 'ff-async-iterator-helpers',
+          note_html: 'The feature is only available on Nightly builds, and has to be enabled via <code>javascript.options.experimental.async_iterator_helpers</code> setting under <code>about:config</code>.'
+        },
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
@@ -799,6 +898,15 @@ exports.tests = [
         ie11: false,
         firefox10: false,
         firefox60: false,
+        firefox116: false,
+        firefox117: {
+          val: 'flagged',
+          note_id: 'ff-iterator-helpers'
+        },
+        firefox128: {
+          val: 'flagged',
+          note_id: 'ff-async-iterator-helpers'
+        },
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
@@ -927,6 +1035,15 @@ exports.tests = [
         ie11: false,
         firefox10: false,
         firefox60: false,
+        firefox116: false,
+        firefox117: {
+          val: 'flagged',
+          note_id: 'ff-iterator-helpers'
+        },
+        firefox128: {
+          val: 'flagged',
+          note_id: 'ff-async-iterator-helpers'
+        },
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
@@ -956,6 +1073,15 @@ exports.tests = [
         ie11: false,
         firefox10: false,
         firefox60: false,
+        firefox116: false,
+        firefox117: {
+          val: 'flagged',
+          note_id: 'ff-iterator-helpers'
+        },
+        firefox128: {
+          val: 'flagged',
+          note_id: 'ff-async-iterator-helpers'
+        },
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
@@ -979,6 +1105,15 @@ exports.tests = [
         ie11: false,
         firefox10: false,
         firefox60: false,
+        firefox116: false,
+        firefox117: {
+          val: 'flagged',
+          note_id: 'ff-iterator-helpers'
+        },
+        firefox128: {
+          val: 'flagged',
+          note_id: 'ff-async-iterator-helpers'
+        },
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
@@ -1008,6 +1143,15 @@ exports.tests = [
         ie11: false,
         firefox10: false,
         firefox60: false,
+        firefox116: false,
+        firefox117: {
+          val: 'flagged',
+          note_id: 'ff-iterator-helpers'
+        },
+        firefox128: {
+          val: 'flagged',
+          note_id: 'ff-async-iterator-helpers'
+        },
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
@@ -1031,6 +1175,15 @@ exports.tests = [
         ie11: false,
         firefox10: false,
         firefox60: false,
+        firefox116: false,
+        firefox117: {
+          val: 'flagged',
+          note_id: 'ff-iterator-helpers'
+        },
+        firefox128: {
+          val: 'flagged',
+          note_id: 'ff-async-iterator-helpers'
+        },
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
@@ -1060,6 +1213,15 @@ exports.tests = [
         ie11: false,
         firefox10: false,
         firefox60: false,
+        firefox116: false,
+        firefox117: {
+          val: 'flagged',
+          note_id: 'ff-iterator-helpers'
+        },
+        firefox128: {
+          val: 'flagged',
+          note_id: 'ff-async-iterator-helpers'
+        },
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
@@ -1084,6 +1246,15 @@ exports.tests = [
         ie11: false,
         firefox10: false,
         firefox60: false,
+        firefox116: false,
+        firefox117: {
+          val: 'flagged',
+          note_id: 'ff-iterator-helpers'
+        },
+        firefox128: {
+          val: 'flagged',
+          note_id: 'ff-async-iterator-helpers'
+        },
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
@@ -1113,6 +1284,15 @@ exports.tests = [
         ie11: false,
         firefox10: false,
         firefox60: false,
+        firefox116: false,
+        firefox117: {
+          val: 'flagged',
+          note_id: 'ff-iterator-helpers'
+        },
+        firefox128: {
+          val: 'flagged',
+          note_id: 'ff-async-iterator-helpers'
+        },
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
@@ -1136,6 +1316,15 @@ exports.tests = [
         ie11: false,
         firefox10: false,
         firefox60: false,
+        firefox116: false,
+        firefox117: {
+          val: 'flagged',
+          note_id: 'ff-iterator-helpers'
+        },
+        firefox128: {
+          val: 'flagged',
+          note_id: 'ff-async-iterator-helpers'
+        },
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
@@ -1159,6 +1348,15 @@ exports.tests = [
         ie11: false,
         firefox10: false,
         firefox60: false,
+        firefox116: false,
+        firefox117: {
+          val: 'flagged',
+          note_id: 'ff-iterator-helpers'
+        },
+        firefox128: {
+          val: 'flagged',
+          note_id: 'ff-async-iterator-helpers'
+        },
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
@@ -1188,6 +1386,15 @@ exports.tests = [
         ie11: false,
         firefox10: false,
         firefox60: false,
+        firefox116: false,
+        firefox117: {
+          val: 'flagged',
+          note_id: 'ff-iterator-helpers'
+        },
+        firefox128: {
+          val: 'flagged',
+          note_id: 'ff-async-iterator-helpers'
+        },
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
@@ -1211,6 +1418,15 @@ exports.tests = [
         ie11: false,
         firefox10: false,
         firefox60: false,
+        firefox116: false,
+        firefox117: {
+          val: 'flagged',
+          note_id: 'ff-iterator-helpers'
+        },
+        firefox128: {
+          val: 'flagged',
+          note_id: 'ff-async-iterator-helpers'
+        },
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -1067,154 +1067,154 @@ return true;
 <td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Iterator_Helpers"><span><a class="anchor" href="#test-Iterator_Helpers">&#xA7;</a><a href="https://github.com/tc39/proposal-iterator-helpers">Iterator Helpers</a></span></td>
-<td class="tally obsolete" data-browser="tr" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/35</td>
-<td class="tally" data-browser="babel7corejs3" data-tally="1">35/35</td>
-<td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="closure20210808" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="closure20210906" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="closure20211006" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="closure20211107" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="closure20220502" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="closure20220719" data-tally="0">0/35</td>
-<td class="tally" data-browser="closure20230228" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="typescript3_9corejs3" data-tally="1">35/35</td>
-<td class="tally obsolete" data-browser="typescript4_9corejs3" data-tally="1">35/35</td>
-<td class="tally obsolete" data-browser="typescript5_2corejs3" data-tally="1">35/35</td>
-<td class="tally obsolete" data-browser="typescript5_3corejs3" data-tally="1">35/35</td>
-<td class="tally obsolete" data-browser="typescript5_4corejs3" data-tally="1">35/35</td>
-<td class="tally" data-browser="typescript5_5corejs3" data-tally="1">35/35</td>
-<td class="tally obsolete" data-browser="firefox102" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="firefox114" data-tally="0">0/35</td>
-<td class="tally" data-browser="firefox115" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="firefox116" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="firefox117" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="firefox118" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="firefox119" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="firefox120" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="firefox121" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="firefox122" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="firefox123" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="firefox124" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="firefox125" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="firefox126" data-tally="0">0/35</td>
-<td class="tally" data-browser="firefox127" data-tally="0">0/35</td>
-<td class="tally unstable" data-browser="firefox128" data-tally="0">0/35</td>
-<td class="tally unstable" data-browser="firefox129" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="chrome115" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="chrome116" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="chrome117" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="chrome118" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="chrome119" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="chrome120" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="chrome121" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="chrome122" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="chrome123" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="chrome124" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="chrome125" data-tally="0">0/35</td>
-<td class="tally" data-browser="chrome126" data-tally="0.45714285714285713" style="background-color:hsl(54,65%,50%)">16/35</td>
-<td class="tally unstable" data-browser="chrome127" data-tally="0.45714285714285713" style="background-color:hsl(54,65%,50%)">16/35</td>
-<td class="tally obsolete" data-browser="edge18" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="edge115" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="edge116" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="edge117" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="edge118" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="edge119" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="edge120" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="edge121" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="edge122" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="edge123" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="edge124" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="edge125" data-tally="0">0/35</td>
-<td class="tally" data-browser="edge126" data-tally="0.45714285714285713" style="background-color:hsl(54,65%,50%)">16/35</td>
-<td class="tally unstable" data-browser="edge127" data-tally="0.45714285714285713" style="background-color:hsl(54,65%,50%)">16/35</td>
-<td class="tally obsolete" data-browser="safari15_6" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="safari16_6" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="safari17" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="safari17_1" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="safari17_2" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="safari17_3" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="safari17_4" data-tally="0">0/35</td>
-<td class="tally" data-browser="safari17_5" data-tally="0">0/35</td>
-<td class="tally unstable" data-browser="safaritp" data-tally="0">0/35</td>
-<td class="tally unstable" data-browser="webkit" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="opera88" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="opera89" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="opera90" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="opera91" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="opera92" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="opera93" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="opera94" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="opera95" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="opera96" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="opera97" data-tally="0">0/35</td>
-<td class="tally" data-browser="opera98" data-tally="0">0/35</td>
-<td class="tally unstable" data-browser="opera99" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="rhino1_7_15" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="node0_4" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="node0_6" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="node0_8" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="node0_10" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="node0_12" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="node14_6" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="node16_0" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="node16_9" data-tally="0">0/35</td>
-<td class="tally" data-browser="node16_11" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="node17_0" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="node17_2" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="node18_0" data-tally="0">0/35</td>
-<td class="tally" data-browser="node18_3" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="node19_0" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="node19_2" data-tally="0">0/35</td>
-<td class="tally" data-browser="node20_0" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="node21_0" data-tally="0">0/35</td>
-<td class="tally" data-browser="node22_0" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="duktape2_6" data-tally="0">0/35</td>
-<td class="tally" data-browser="duktape2_7" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="graalvm19" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="graalvm19_3_6" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="graalvm20" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="graalvm20_1" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="graalvm20_3" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="graalvm20_3_1" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="graalvm21" data-tally="0">0/35</td>
-<td class="tally" data-browser="graalvm21_3_3" data-tally="0">0/35</td>
-<td class="tally" data-browser="graalvm22_2" data-tally="0">0/35</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="deno1_33" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="deno1_34" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="deno1_35" data-tally="0">0/35</td>
-<td class="tally" data-browser="deno1_36" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="android4_4" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="ios12_2" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="ios13_4" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="ios14_5" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="ios16" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="ios16_1" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="ios16_2" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="ios16_3" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="ios16_4" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="ios16_5" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="ios16_6" data-tally="0">0/35</td>
-<td class="tally" data-browser="ios17" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="samsung19" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="samsung20" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="samsung21" data-tally="0">0/35</td>
-<td class="tally" data-browser="samsung22" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="opera_mobile72" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="opera_mobile73" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="opera_mobile74" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="opera_mobile75" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="opera_mobile76" data-tally="0">0/35</td>
-<td class="tally" data-browser="opera_mobile77" data-tally="0">0/35</td>
-<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/35</td>
+<td class="tally obsolete" data-browser="tr" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/17</td>
+<td class="tally" data-browser="babel7corejs3" data-tally="1">17/17</td>
+<td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="closure20210808" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="closure20210906" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="closure20211006" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="closure20211107" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="closure20220502" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="closure20220719" data-tally="0">0/17</td>
+<td class="tally" data-browser="closure20230228" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="typescript3_9corejs3" data-tally="1">17/17</td>
+<td class="tally obsolete" data-browser="typescript4_9corejs3" data-tally="1">17/17</td>
+<td class="tally obsolete" data-browser="typescript5_2corejs3" data-tally="1">17/17</td>
+<td class="tally obsolete" data-browser="typescript5_3corejs3" data-tally="1">17/17</td>
+<td class="tally obsolete" data-browser="typescript5_4corejs3" data-tally="1">17/17</td>
+<td class="tally" data-browser="typescript5_5corejs3" data-tally="1">17/17</td>
+<td class="tally obsolete" data-browser="firefox102" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="firefox114" data-tally="0">0/17</td>
+<td class="tally" data-browser="firefox115" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="firefox117" data-tally="0" data-flagged-tally="0.9411764705882353">0/17</td>
+<td class="tally obsolete" data-browser="firefox118" data-tally="0" data-flagged-tally="0.9411764705882353">0/17</td>
+<td class="tally obsolete" data-browser="firefox119" data-tally="0" data-flagged-tally="0.9411764705882353">0/17</td>
+<td class="tally obsolete" data-browser="firefox120" data-tally="0" data-flagged-tally="0.9411764705882353">0/17</td>
+<td class="tally obsolete" data-browser="firefox121" data-tally="0" data-flagged-tally="0.9411764705882353">0/17</td>
+<td class="tally obsolete" data-browser="firefox122" data-tally="0" data-flagged-tally="0.9411764705882353">0/17</td>
+<td class="tally obsolete" data-browser="firefox123" data-tally="0" data-flagged-tally="0.9411764705882353">0/17</td>
+<td class="tally obsolete" data-browser="firefox124" data-tally="0" data-flagged-tally="0.9411764705882353">0/17</td>
+<td class="tally obsolete" data-browser="firefox125" data-tally="0" data-flagged-tally="0.9411764705882353">0/17</td>
+<td class="tally obsolete" data-browser="firefox126" data-tally="0" data-flagged-tally="0.9411764705882353">0/17</td>
+<td class="tally" data-browser="firefox127" data-tally="0" data-flagged-tally="0.9411764705882353">0/17</td>
+<td class="tally unstable" data-browser="firefox128" data-tally="0" data-flagged-tally="0.9411764705882353">0/17</td>
+<td class="tally unstable" data-browser="firefox129" data-tally="0" data-flagged-tally="0.9411764705882353">0/17</td>
+<td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="chrome115" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="chrome116" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="chrome117" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="chrome118" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="chrome119" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="chrome120" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="chrome121" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="chrome122" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="chrome123" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="chrome124" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="chrome125" data-tally="0">0/17</td>
+<td class="tally" data-browser="chrome126" data-tally="0.9411764705882353" style="background-color:hsl(112,44%,50%)">16/17</td>
+<td class="tally unstable" data-browser="chrome127" data-tally="0.9411764705882353" style="background-color:hsl(112,44%,50%)">16/17</td>
+<td class="tally obsolete" data-browser="edge18" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="edge115" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="edge116" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="edge117" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="edge118" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="edge119" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="edge120" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="edge121" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="edge122" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="edge123" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="edge124" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="edge125" data-tally="0">0/17</td>
+<td class="tally" data-browser="edge126" data-tally="0.9411764705882353" style="background-color:hsl(112,44%,50%)">16/17</td>
+<td class="tally unstable" data-browser="edge127" data-tally="0.9411764705882353" style="background-color:hsl(112,44%,50%)">16/17</td>
+<td class="tally obsolete" data-browser="safari15_6" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="safari16_6" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="safari17" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="safari17_1" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="safari17_2" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="safari17_3" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="safari17_4" data-tally="0">0/17</td>
+<td class="tally" data-browser="safari17_5" data-tally="0">0/17</td>
+<td class="tally unstable" data-browser="safaritp" data-tally="0">0/17</td>
+<td class="tally unstable" data-browser="webkit" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="opera88" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="opera89" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="opera90" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="opera91" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="opera92" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="opera93" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="opera94" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="opera95" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="opera96" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="opera97" data-tally="0">0/17</td>
+<td class="tally" data-browser="opera98" data-tally="0">0/17</td>
+<td class="tally unstable" data-browser="opera99" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="rhino1_7_15" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="node0_4" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="node0_6" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="node0_8" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="node0_10" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="node0_12" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="node14_6" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="node16_0" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="node16_9" data-tally="0">0/17</td>
+<td class="tally" data-browser="node16_11" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="node17_0" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="node17_2" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="node18_0" data-tally="0">0/17</td>
+<td class="tally" data-browser="node18_3" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="node19_0" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="node19_2" data-tally="0">0/17</td>
+<td class="tally" data-browser="node20_0" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="node21_0" data-tally="0">0/17</td>
+<td class="tally" data-browser="node22_0" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="duktape2_6" data-tally="0">0/17</td>
+<td class="tally" data-browser="duktape2_7" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="graalvm19" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="graalvm19_3_6" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="graalvm20" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="graalvm20_1" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="graalvm20_3" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="graalvm20_3_1" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="graalvm21" data-tally="0">0/17</td>
+<td class="tally" data-browser="graalvm21_3_3" data-tally="0">0/17</td>
+<td class="tally" data-browser="graalvm22_2" data-tally="0">0/17</td>
+<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="deno1_33" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="deno1_34" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="deno1_35" data-tally="0">0/17</td>
+<td class="tally" data-browser="deno1_36" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="android4_4" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="ios12_2" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="ios13_4" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="ios14_5" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="ios16" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="ios16_1" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="ios16_2" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="ios16_3" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="ios16_4" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="ios16_5" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="ios16_6" data-tally="0">0/17</td>
+<td class="tally" data-browser="ios17" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="samsung19" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="samsung20" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="samsung21" data-tally="0">0/17</td>
+<td class="tally" data-browser="samsung22" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="opera_mobile72" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="opera_mobile73" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="opera_mobile74" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="opera_mobile75" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="opera_mobile76" data-tally="0">0/17</td>
+<td class="tally" data-browser="opera_mobile77" data-tally="0">0/17</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/17</td>
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_instanceof_Iterator"><td><span><a class="anchor" href="#test-Iterator_Helpers_instanceof_Iterator">&#xA7;</a>instanceof Iterator</span><script data-source="
 return [1, 2, 3].values() instanceof Iterator;
@@ -1243,19 +1243,19 @@ return [1, 2, 3].values() instanceof Iterator;
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
 <td class="no obsolete" data-browser="firefox116">No</td>
-<td class="no obsolete" data-browser="firefox117">No</td>
-<td class="no obsolete" data-browser="firefox118">No</td>
-<td class="no obsolete" data-browser="firefox119">No</td>
-<td class="no obsolete" data-browser="firefox120">No</td>
-<td class="no obsolete" data-browser="firefox121">No</td>
-<td class="no obsolete" data-browser="firefox122">No</td>
-<td class="no obsolete" data-browser="firefox123">No</td>
-<td class="no obsolete" data-browser="firefox124">No</td>
-<td class="no obsolete" data-browser="firefox125">No</td>
-<td class="no obsolete" data-browser="firefox126">No</td>
-<td class="no" data-browser="firefox127">No</td>
-<td class="no unstable" data-browser="firefox128">No</td>
-<td class="no unstable" data-browser="firefox129">No</td>
+<td class="no flagged obsolete" data-browser="firefox117">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox118">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox119">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox120">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox121">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox122">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox123">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox124">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox125">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox126">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged" data-browser="firefox127">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox128">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox129">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome115">No</td>
 <td class="no obsolete" data-browser="chrome116">No</td>
@@ -1398,19 +1398,19 @@ return instance[Symbol.iterator]() === instance;
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
 <td class="no obsolete" data-browser="firefox116">No</td>
-<td class="no obsolete" data-browser="firefox117">No</td>
-<td class="no obsolete" data-browser="firefox118">No</td>
-<td class="no obsolete" data-browser="firefox119">No</td>
-<td class="no obsolete" data-browser="firefox120">No</td>
-<td class="no obsolete" data-browser="firefox121">No</td>
-<td class="no obsolete" data-browser="firefox122">No</td>
-<td class="no obsolete" data-browser="firefox123">No</td>
-<td class="no obsolete" data-browser="firefox124">No</td>
-<td class="no obsolete" data-browser="firefox125">No</td>
-<td class="no obsolete" data-browser="firefox126">No</td>
-<td class="no" data-browser="firefox127">No</td>
-<td class="no unstable" data-browser="firefox128">No</td>
-<td class="no unstable" data-browser="firefox129">No</td>
+<td class="no flagged obsolete" data-browser="firefox117">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox118">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox119">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox120">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox121">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox122">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox123">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox124">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox125">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox126">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged" data-browser="firefox127">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox128">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox129">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome115">No</td>
 <td class="no obsolete" data-browser="chrome116">No</td>
@@ -1554,19 +1554,19 @@ return &apos;next&apos; in iterator
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
 <td class="no obsolete" data-browser="firefox116">No</td>
-<td class="no obsolete" data-browser="firefox117">No</td>
-<td class="no obsolete" data-browser="firefox118">No</td>
-<td class="no obsolete" data-browser="firefox119">No</td>
-<td class="no obsolete" data-browser="firefox120">No</td>
-<td class="no obsolete" data-browser="firefox121">No</td>
-<td class="no obsolete" data-browser="firefox122">No</td>
-<td class="no obsolete" data-browser="firefox123">No</td>
-<td class="no obsolete" data-browser="firefox124">No</td>
-<td class="no obsolete" data-browser="firefox125">No</td>
-<td class="no obsolete" data-browser="firefox126">No</td>
-<td class="no" data-browser="firefox127">No</td>
-<td class="no unstable" data-browser="firefox128">No</td>
-<td class="no unstable" data-browser="firefox129">No</td>
+<td class="no flagged obsolete" data-browser="firefox117">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox118">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox119">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox120">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox121">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox122">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox123">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox124">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox125">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox126">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged" data-browser="firefox127">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox128">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox129">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome115">No</td>
 <td class="no obsolete" data-browser="chrome116">No</td>
@@ -1715,19 +1715,19 @@ return &apos;next&apos; in iterator
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
 <td class="no obsolete" data-browser="firefox116">No</td>
-<td class="no obsolete" data-browser="firefox117">No</td>
-<td class="no obsolete" data-browser="firefox118">No</td>
-<td class="no obsolete" data-browser="firefox119">No</td>
-<td class="no obsolete" data-browser="firefox120">No</td>
-<td class="no obsolete" data-browser="firefox121">No</td>
-<td class="no obsolete" data-browser="firefox122">No</td>
-<td class="no obsolete" data-browser="firefox123">No</td>
-<td class="no obsolete" data-browser="firefox124">No</td>
-<td class="no obsolete" data-browser="firefox125">No</td>
-<td class="no obsolete" data-browser="firefox126">No</td>
-<td class="no" data-browser="firefox127">No</td>
-<td class="no unstable" data-browser="firefox128">No</td>
-<td class="no unstable" data-browser="firefox129">No</td>
+<td class="no flagged obsolete" data-browser="firefox117">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox118">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox119">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox120">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox121">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox122">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox123">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox124">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox125">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox126">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged" data-browser="firefox127">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox128">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox129">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome115">No</td>
 <td class="no obsolete" data-browser="chrome116">No</td>
@@ -2021,19 +2021,19 @@ return Array.from([1, 2, 3].values().drop(1)).join() === &apos;2,3&apos;;
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
 <td class="no obsolete" data-browser="firefox116">No</td>
-<td class="no obsolete" data-browser="firefox117">No</td>
-<td class="no obsolete" data-browser="firefox118">No</td>
-<td class="no obsolete" data-browser="firefox119">No</td>
-<td class="no obsolete" data-browser="firefox120">No</td>
-<td class="no obsolete" data-browser="firefox121">No</td>
-<td class="no obsolete" data-browser="firefox122">No</td>
-<td class="no obsolete" data-browser="firefox123">No</td>
-<td class="no obsolete" data-browser="firefox124">No</td>
-<td class="no obsolete" data-browser="firefox125">No</td>
-<td class="no obsolete" data-browser="firefox126">No</td>
-<td class="no" data-browser="firefox127">No</td>
-<td class="no unstable" data-browser="firefox128">No</td>
-<td class="no unstable" data-browser="firefox129">No</td>
+<td class="no flagged obsolete" data-browser="firefox117">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox118">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox119">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox120">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox121">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox122">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox123">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox124">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox125">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox126">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged" data-browser="firefox127">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox128">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox129">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome115">No</td>
 <td class="no obsolete" data-browser="chrome116">No</td>
@@ -2174,19 +2174,19 @@ return [1, 2, 3].values().every(it =&gt; typeof it === &apos;number&apos;);
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
 <td class="no obsolete" data-browser="firefox116">No</td>
-<td class="no obsolete" data-browser="firefox117">No</td>
-<td class="no obsolete" data-browser="firefox118">No</td>
-<td class="no obsolete" data-browser="firefox119">No</td>
-<td class="no obsolete" data-browser="firefox120">No</td>
-<td class="no obsolete" data-browser="firefox121">No</td>
-<td class="no obsolete" data-browser="firefox122">No</td>
-<td class="no obsolete" data-browser="firefox123">No</td>
-<td class="no obsolete" data-browser="firefox124">No</td>
-<td class="no obsolete" data-browser="firefox125">No</td>
-<td class="no obsolete" data-browser="firefox126">No</td>
-<td class="no" data-browser="firefox127">No</td>
-<td class="no unstable" data-browser="firefox128">No</td>
-<td class="no unstable" data-browser="firefox129">No</td>
+<td class="no flagged obsolete" data-browser="firefox117">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox118">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox119">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox120">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox121">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox122">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox123">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox124">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox125">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox126">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged" data-browser="firefox127">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox128">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox129">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome115">No</td>
 <td class="no obsolete" data-browser="chrome116">No</td>
@@ -2327,19 +2327,19 @@ return Array.from([1, 2, 3].values().filter(it =&gt; it % 2)).join() === &apos;1
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
 <td class="no obsolete" data-browser="firefox116">No</td>
-<td class="no obsolete" data-browser="firefox117">No</td>
-<td class="no obsolete" data-browser="firefox118">No</td>
-<td class="no obsolete" data-browser="firefox119">No</td>
-<td class="no obsolete" data-browser="firefox120">No</td>
-<td class="no obsolete" data-browser="firefox121">No</td>
-<td class="no obsolete" data-browser="firefox122">No</td>
-<td class="no obsolete" data-browser="firefox123">No</td>
-<td class="no obsolete" data-browser="firefox124">No</td>
-<td class="no obsolete" data-browser="firefox125">No</td>
-<td class="no obsolete" data-browser="firefox126">No</td>
-<td class="no" data-browser="firefox127">No</td>
-<td class="no unstable" data-browser="firefox128">No</td>
-<td class="no unstable" data-browser="firefox129">No</td>
+<td class="no flagged obsolete" data-browser="firefox117">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox118">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox119">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox120">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox121">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox122">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox123">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox124">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox125">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox126">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged" data-browser="firefox127">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox128">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox129">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome115">No</td>
 <td class="no obsolete" data-browser="chrome116">No</td>
@@ -2480,19 +2480,19 @@ return [1, 2, 3].values().find(it =&gt; it % 2) === 1;
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
 <td class="no obsolete" data-browser="firefox116">No</td>
-<td class="no obsolete" data-browser="firefox117">No</td>
-<td class="no obsolete" data-browser="firefox118">No</td>
-<td class="no obsolete" data-browser="firefox119">No</td>
-<td class="no obsolete" data-browser="firefox120">No</td>
-<td class="no obsolete" data-browser="firefox121">No</td>
-<td class="no obsolete" data-browser="firefox122">No</td>
-<td class="no obsolete" data-browser="firefox123">No</td>
-<td class="no obsolete" data-browser="firefox124">No</td>
-<td class="no obsolete" data-browser="firefox125">No</td>
-<td class="no obsolete" data-browser="firefox126">No</td>
-<td class="no" data-browser="firefox127">No</td>
-<td class="no unstable" data-browser="firefox128">No</td>
-<td class="no unstable" data-browser="firefox129">No</td>
+<td class="no flagged obsolete" data-browser="firefox117">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox118">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox119">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox120">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox121">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox122">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox123">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox124">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox125">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox126">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged" data-browser="firefox127">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox128">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox129">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome115">No</td>
 <td class="no obsolete" data-browser="chrome116">No</td>
@@ -2633,19 +2633,19 @@ return Array.from([1, 2, 3].values().flatMap(it =&gt; [it, 0])).join() === &apos
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
 <td class="no obsolete" data-browser="firefox116">No</td>
-<td class="no obsolete" data-browser="firefox117">No</td>
-<td class="no obsolete" data-browser="firefox118">No</td>
-<td class="no obsolete" data-browser="firefox119">No</td>
-<td class="no obsolete" data-browser="firefox120">No</td>
-<td class="no obsolete" data-browser="firefox121">No</td>
-<td class="no obsolete" data-browser="firefox122">No</td>
-<td class="no obsolete" data-browser="firefox123">No</td>
-<td class="no obsolete" data-browser="firefox124">No</td>
-<td class="no obsolete" data-browser="firefox125">No</td>
-<td class="no obsolete" data-browser="firefox126">No</td>
-<td class="no" data-browser="firefox127">No</td>
-<td class="no unstable" data-browser="firefox128">No</td>
-<td class="no unstable" data-browser="firefox129">No</td>
+<td class="no flagged obsolete" data-browser="firefox117">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox118">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox119">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox120">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox121">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox122">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox123">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox124">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox125">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox126">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged" data-browser="firefox127">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox128">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox129">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome115">No</td>
 <td class="no obsolete" data-browser="chrome116">No</td>
@@ -2788,19 +2788,19 @@ return result === &apos;123&apos;;
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
 <td class="no obsolete" data-browser="firefox116">No</td>
-<td class="no obsolete" data-browser="firefox117">No</td>
-<td class="no obsolete" data-browser="firefox118">No</td>
-<td class="no obsolete" data-browser="firefox119">No</td>
-<td class="no obsolete" data-browser="firefox120">No</td>
-<td class="no obsolete" data-browser="firefox121">No</td>
-<td class="no obsolete" data-browser="firefox122">No</td>
-<td class="no obsolete" data-browser="firefox123">No</td>
-<td class="no obsolete" data-browser="firefox124">No</td>
-<td class="no obsolete" data-browser="firefox125">No</td>
-<td class="no obsolete" data-browser="firefox126">No</td>
-<td class="no" data-browser="firefox127">No</td>
-<td class="no unstable" data-browser="firefox128">No</td>
-<td class="no unstable" data-browser="firefox129">No</td>
+<td class="no flagged obsolete" data-browser="firefox117">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox118">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox119">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox120">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox121">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox122">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox123">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox124">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox125">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox126">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged" data-browser="firefox127">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox128">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox129">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome115">No</td>
 <td class="no obsolete" data-browser="chrome116">No</td>
@@ -2941,19 +2941,19 @@ return Array.from([1, 2, 3].values().map(it =&gt; it * it)).join() === &apos;1,4
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
 <td class="no obsolete" data-browser="firefox116">No</td>
-<td class="no obsolete" data-browser="firefox117">No</td>
-<td class="no obsolete" data-browser="firefox118">No</td>
-<td class="no obsolete" data-browser="firefox119">No</td>
-<td class="no obsolete" data-browser="firefox120">No</td>
-<td class="no obsolete" data-browser="firefox121">No</td>
-<td class="no obsolete" data-browser="firefox122">No</td>
-<td class="no obsolete" data-browser="firefox123">No</td>
-<td class="no obsolete" data-browser="firefox124">No</td>
-<td class="no obsolete" data-browser="firefox125">No</td>
-<td class="no obsolete" data-browser="firefox126">No</td>
-<td class="no" data-browser="firefox127">No</td>
-<td class="no unstable" data-browser="firefox128">No</td>
-<td class="no unstable" data-browser="firefox129">No</td>
+<td class="no flagged obsolete" data-browser="firefox117">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox118">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox119">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox120">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox121">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox122">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox123">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox124">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox125">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox126">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged" data-browser="firefox127">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox128">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox129">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome115">No</td>
 <td class="no obsolete" data-browser="chrome116">No</td>
@@ -3094,19 +3094,19 @@ return [1, 2, 3].values().reduce((a, b) =&gt; a + b) === 6;
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
 <td class="no obsolete" data-browser="firefox116">No</td>
-<td class="no obsolete" data-browser="firefox117">No</td>
-<td class="no obsolete" data-browser="firefox118">No</td>
-<td class="no obsolete" data-browser="firefox119">No</td>
-<td class="no obsolete" data-browser="firefox120">No</td>
-<td class="no obsolete" data-browser="firefox121">No</td>
-<td class="no obsolete" data-browser="firefox122">No</td>
-<td class="no obsolete" data-browser="firefox123">No</td>
-<td class="no obsolete" data-browser="firefox124">No</td>
-<td class="no obsolete" data-browser="firefox125">No</td>
-<td class="no obsolete" data-browser="firefox126">No</td>
-<td class="no" data-browser="firefox127">No</td>
-<td class="no unstable" data-browser="firefox128">No</td>
-<td class="no unstable" data-browser="firefox129">No</td>
+<td class="no flagged obsolete" data-browser="firefox117">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox118">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox119">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox120">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox121">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox122">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox123">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox124">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox125">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox126">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged" data-browser="firefox127">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox128">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox129">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome115">No</td>
 <td class="no obsolete" data-browser="chrome116">No</td>
@@ -3247,19 +3247,19 @@ return [1, 2, 3].values().some(it =&gt; typeof it === &apos;number&apos;);
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
 <td class="no obsolete" data-browser="firefox116">No</td>
-<td class="no obsolete" data-browser="firefox117">No</td>
-<td class="no obsolete" data-browser="firefox118">No</td>
-<td class="no obsolete" data-browser="firefox119">No</td>
-<td class="no obsolete" data-browser="firefox120">No</td>
-<td class="no obsolete" data-browser="firefox121">No</td>
-<td class="no obsolete" data-browser="firefox122">No</td>
-<td class="no obsolete" data-browser="firefox123">No</td>
-<td class="no obsolete" data-browser="firefox124">No</td>
-<td class="no obsolete" data-browser="firefox125">No</td>
-<td class="no obsolete" data-browser="firefox126">No</td>
-<td class="no" data-browser="firefox127">No</td>
-<td class="no unstable" data-browser="firefox128">No</td>
-<td class="no unstable" data-browser="firefox129">No</td>
+<td class="no flagged obsolete" data-browser="firefox117">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox118">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox119">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox120">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox121">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox122">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox123">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox124">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox125">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox126">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged" data-browser="firefox127">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox128">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox129">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome115">No</td>
 <td class="no obsolete" data-browser="chrome116">No</td>
@@ -3400,19 +3400,19 @@ return Array.from([1, 2, 3].values().take(2)).join() === &apos;1,2&apos;;
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
 <td class="no obsolete" data-browser="firefox116">No</td>
-<td class="no obsolete" data-browser="firefox117">No</td>
-<td class="no obsolete" data-browser="firefox118">No</td>
-<td class="no obsolete" data-browser="firefox119">No</td>
-<td class="no obsolete" data-browser="firefox120">No</td>
-<td class="no obsolete" data-browser="firefox121">No</td>
-<td class="no obsolete" data-browser="firefox122">No</td>
-<td class="no obsolete" data-browser="firefox123">No</td>
-<td class="no obsolete" data-browser="firefox124">No</td>
-<td class="no obsolete" data-browser="firefox125">No</td>
-<td class="no obsolete" data-browser="firefox126">No</td>
-<td class="no" data-browser="firefox127">No</td>
-<td class="no unstable" data-browser="firefox128">No</td>
-<td class="no unstable" data-browser="firefox129">No</td>
+<td class="no flagged obsolete" data-browser="firefox117">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox118">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox119">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox120">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox121">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox122">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox123">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox124">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox125">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox126">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged" data-browser="firefox127">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox128">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox129">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome115">No</td>
 <td class="no obsolete" data-browser="chrome116">No</td>
@@ -3554,19 +3554,19 @@ return Array.isArray(array) &amp;&amp; array.join() === &apos;1,2,3&apos;;
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
 <td class="no obsolete" data-browser="firefox116">No</td>
-<td class="no obsolete" data-browser="firefox117">No</td>
-<td class="no obsolete" data-browser="firefox118">No</td>
-<td class="no obsolete" data-browser="firefox119">No</td>
-<td class="no obsolete" data-browser="firefox120">No</td>
-<td class="no obsolete" data-browser="firefox121">No</td>
-<td class="no obsolete" data-browser="firefox122">No</td>
-<td class="no obsolete" data-browser="firefox123">No</td>
-<td class="no obsolete" data-browser="firefox124">No</td>
-<td class="no obsolete" data-browser="firefox125">No</td>
-<td class="no obsolete" data-browser="firefox126">No</td>
-<td class="no" data-browser="firefox127">No</td>
-<td class="no unstable" data-browser="firefox128">No</td>
-<td class="no unstable" data-browser="firefox129">No</td>
+<td class="no flagged obsolete" data-browser="firefox117">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox118">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox119">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox120">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox121">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox122">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox123">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox124">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox125">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox126">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged" data-browser="firefox127">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox128">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox129">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome115">No</td>
 <td class="no obsolete" data-browser="chrome116">No</td>
@@ -3707,19 +3707,19 @@ return Iterator.prototype[Symbol.toStringTag] === &apos;Iterator&apos;;
 <td class="no obsolete" data-browser="firefox114">No</td>
 <td class="no" data-browser="firefox115">No</td>
 <td class="no obsolete" data-browser="firefox116">No</td>
-<td class="no obsolete" data-browser="firefox117">No</td>
-<td class="no obsolete" data-browser="firefox118">No</td>
-<td class="no obsolete" data-browser="firefox119">No</td>
-<td class="no obsolete" data-browser="firefox120">No</td>
-<td class="no obsolete" data-browser="firefox121">No</td>
-<td class="no obsolete" data-browser="firefox122">No</td>
-<td class="no obsolete" data-browser="firefox123">No</td>
-<td class="no obsolete" data-browser="firefox124">No</td>
-<td class="no obsolete" data-browser="firefox125">No</td>
-<td class="no obsolete" data-browser="firefox126">No</td>
-<td class="no" data-browser="firefox127">No</td>
-<td class="no unstable" data-browser="firefox128">No</td>
-<td class="no unstable" data-browser="firefox129">No</td>
+<td class="no flagged obsolete" data-browser="firefox117">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox118">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox119">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox120">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox121">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox122">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox123">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox124">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox125">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox126">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged" data-browser="firefox127">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox128">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox129">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="no obsolete" data-browser="chrome115">No</td>
 <td class="no obsolete" data-browser="chrome116">No</td>
@@ -3833,2859 +3833,6 @@ return Iterator.prototype[Symbol.toStringTag] === &apos;Iterator&apos;;
 <td class="no" data-browser="opera_mobile77">No</td>
 <td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
-<tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_instanceof_AsyncIterator"><td><span><a class="anchor" href="#test-Iterator_Helpers_instanceof_AsyncIterator">&#xA7;</a>instanceof AsyncIterator</span><script data-source="
-return (async function*() {})() instanceof AsyncIterator;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("23");try{return Function("asyncTestPassed","\nreturn (async function*() {})() instanceof AsyncIterator;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("23");return Function("asyncTestPassed","'use strict';"+"\nreturn (async function*() {})() instanceof AsyncIterator;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
-</script></td>
-<td class="unknown obsolete" data-browser="tr">?</td>
-<td class="no obsolete" data-browser="babel6corejs2">No</td>
-<td class="no obsolete" data-browser="babel7corejs2">No</td>
-<td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200927">?</td>
-<td class="unknown obsolete" data-browser="closure20210808">?</td>
-<td class="unknown obsolete" data-browser="closure20210906">?</td>
-<td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown obsolete" data-browser="closure20220502">?</td>
-<td class="unknown obsolete" data-browser="closure20220719">?</td>
-<td class="unknown" data-browser="closure20230228">?</td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes" data-browser="typescript5_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox114">No</td>
-<td class="no" data-browser="firefox115">No</td>
-<td class="no obsolete" data-browser="firefox116">No</td>
-<td class="no obsolete" data-browser="firefox117">No</td>
-<td class="no obsolete" data-browser="firefox118">No</td>
-<td class="no obsolete" data-browser="firefox119">No</td>
-<td class="no obsolete" data-browser="firefox120">No</td>
-<td class="no obsolete" data-browser="firefox121">No</td>
-<td class="no obsolete" data-browser="firefox122">No</td>
-<td class="no obsolete" data-browser="firefox123">No</td>
-<td class="no obsolete" data-browser="firefox124">No</td>
-<td class="no obsolete" data-browser="firefox125">No</td>
-<td class="no obsolete" data-browser="firefox126">No</td>
-<td class="no" data-browser="firefox127">No</td>
-<td class="no unstable" data-browser="firefox128">No</td>
-<td class="no unstable" data-browser="firefox129">No</td>
-<td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome115">No</td>
-<td class="no obsolete" data-browser="chrome116">No</td>
-<td class="no obsolete" data-browser="chrome117">No</td>
-<td class="no obsolete" data-browser="chrome118">No</td>
-<td class="no obsolete" data-browser="chrome119">No</td>
-<td class="no obsolete" data-browser="chrome120">No</td>
-<td class="no obsolete" data-browser="chrome121">No</td>
-<td class="no obsolete" data-browser="chrome122">No</td>
-<td class="no obsolete" data-browser="chrome123">No</td>
-<td class="no obsolete" data-browser="chrome124">No</td>
-<td class="no obsolete" data-browser="chrome125">No</td>
-<td class="no" data-browser="chrome126">No</td>
-<td class="no unstable" data-browser="chrome127">No</td>
-<td class="no obsolete" data-browser="edge18">No</td>
-<td class="no obsolete" data-browser="edge115">No</td>
-<td class="no obsolete" data-browser="edge116">No</td>
-<td class="no obsolete" data-browser="edge117">No</td>
-<td class="no obsolete" data-browser="edge118">No</td>
-<td class="no obsolete" data-browser="edge119">No</td>
-<td class="no obsolete" data-browser="edge120">No</td>
-<td class="no obsolete" data-browser="edge121">No</td>
-<td class="no obsolete" data-browser="edge122">No</td>
-<td class="no obsolete" data-browser="edge123">No</td>
-<td class="no obsolete" data-browser="edge124">No</td>
-<td class="no obsolete" data-browser="edge125">No</td>
-<td class="no" data-browser="edge126">No</td>
-<td class="no unstable" data-browser="edge127">No</td>
-<td class="unknown obsolete" data-browser="safari15_6">?</td>
-<td class="unknown obsolete" data-browser="safari16_6">?</td>
-<td class="unknown obsolete" data-browser="safari17">?</td>
-<td class="unknown obsolete" data-browser="safari17_1">?</td>
-<td class="unknown obsolete" data-browser="safari17_2">?</td>
-<td class="unknown obsolete" data-browser="safari17_3">?</td>
-<td class="unknown obsolete" data-browser="safari17_4">?</td>
-<td class="unknown" data-browser="safari17_5">?</td>
-<td class="unknown unstable" data-browser="safaritp">?</td>
-<td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera88">No</td>
-<td class="no obsolete" data-browser="opera89">No</td>
-<td class="no obsolete" data-browser="opera90">No</td>
-<td class="no obsolete" data-browser="opera91">No</td>
-<td class="no obsolete" data-browser="opera92">No</td>
-<td class="no obsolete" data-browser="opera93">No</td>
-<td class="no obsolete" data-browser="opera94">No</td>
-<td class="no obsolete" data-browser="opera95">No</td>
-<td class="no obsolete" data-browser="opera96">No</td>
-<td class="no obsolete" data-browser="opera97">No</td>
-<td class="no" data-browser="opera98">No</td>
-<td class="no unstable" data-browser="opera99">No</td>
-<td class="no obsolete" data-browser="rhino1_7_13">No</td>
-<td class="no obsolete" data-browser="rhino1_7_14">No</td>
-<td class="no obsolete" data-browser="rhino1_7_15">No</td>
-<td class="unknown obsolete" data-browser="phantom2_1">?</td>
-<td class="unknown obsolete" data-browser="node0_4">?</td>
-<td class="unknown obsolete" data-browser="node0_6">?</td>
-<td class="unknown obsolete" data-browser="node0_8">?</td>
-<td class="unknown obsolete" data-browser="node0_10">?</td>
-<td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node14_6">No</td>
-<td class="no obsolete" data-browser="node16_0">No</td>
-<td class="no obsolete" data-browser="node16_9">No</td>
-<td class="no" data-browser="node16_11">No</td>
-<td class="no obsolete" data-browser="node17_0">No</td>
-<td class="no obsolete" data-browser="node17_2">No</td>
-<td class="no obsolete" data-browser="node18_0">No</td>
-<td class="no" data-browser="node18_3">No</td>
-<td class="no obsolete" data-browser="node19_0">No</td>
-<td class="no obsolete" data-browser="node19_2">No</td>
-<td class="no" data-browser="node20_0">No</td>
-<td class="no obsolete" data-browser="node21_0">No</td>
-<td class="no" data-browser="node22_0">No</td>
-<td class="no obsolete" data-browser="duktape2_6">No</td>
-<td class="no" data-browser="duktape2_7">No</td>
-<td class="unknown obsolete" data-browser="graalvm19">?</td>
-<td class="unknown obsolete" data-browser="graalvm19_3_6">?</td>
-<td class="unknown obsolete" data-browser="graalvm20">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_1">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_3">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_3_1">?</td>
-<td class="unknown obsolete" data-browser="graalvm21">?</td>
-<td class="no" data-browser="graalvm21_3_3">No</td>
-<td class="no" data-browser="graalvm22_2">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
-<td class="no obsolete" data-browser="deno1_33">No</td>
-<td class="no obsolete" data-browser="deno1_34">No</td>
-<td class="no obsolete" data-browser="deno1_35">No</td>
-<td class="no" data-browser="deno1_36">No</td>
-<td class="unknown obsolete" data-browser="android4_4">?</td>
-<td class="unknown obsolete" data-browser="android4_4_3">?</td>
-<td class="unknown obsolete" data-browser="ios12_2">?</td>
-<td class="unknown obsolete" data-browser="ios13_4">?</td>
-<td class="unknown obsolete" data-browser="ios14_5">?</td>
-<td class="unknown obsolete" data-browser="ios16">?</td>
-<td class="unknown obsolete" data-browser="ios16_1">?</td>
-<td class="unknown obsolete" data-browser="ios16_2">?</td>
-<td class="unknown obsolete" data-browser="ios16_3">?</td>
-<td class="unknown obsolete" data-browser="ios16_4">?</td>
-<td class="unknown obsolete" data-browser="ios16_5">?</td>
-<td class="unknown obsolete" data-browser="ios16_6">?</td>
-<td class="unknown" data-browser="ios17">?</td>
-<td class="no obsolete" data-browser="samsung19">No</td>
-<td class="no obsolete" data-browser="samsung20">No</td>
-<td class="no obsolete" data-browser="samsung21">No</td>
-<td class="no" data-browser="samsung22">No</td>
-<td class="no obsolete" data-browser="opera_mobile72">No</td>
-<td class="no obsolete" data-browser="opera_mobile73">No</td>
-<td class="no obsolete" data-browser="opera_mobile74">No</td>
-<td class="no obsolete" data-browser="opera_mobile75">No</td>
-<td class="no obsolete" data-browser="opera_mobile76">No</td>
-<td class="no" data-browser="opera_mobile77">No</td>
-<td class="no" data-browser="reactnative0_70_3">No</td>
-</tr>
-<tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_extends_AsyncIterator"><td><span><a class="anchor" href="#test-Iterator_Helpers_extends_AsyncIterator">&#xA7;</a>extends AsyncIterator</span><script data-source="
-class Class extends AsyncIterator { }
-const instance = new Class();
-return instance[Symbol.asyncIterator]() === instance;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("24");try{return Function("asyncTestPassed","\nclass Class extends AsyncIterator { }\nconst instance = new Class();\nreturn instance[Symbol.asyncIterator]() === instance;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("24");return Function("asyncTestPassed","'use strict';"+"\nclass Class extends AsyncIterator { }\nconst instance = new Class();\nreturn instance[Symbol.asyncIterator]() === instance;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
-</script></td>
-<td class="unknown obsolete" data-browser="tr">?</td>
-<td class="no obsolete" data-browser="babel6corejs2">No</td>
-<td class="no obsolete" data-browser="babel7corejs2">No</td>
-<td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200927">?</td>
-<td class="unknown obsolete" data-browser="closure20210808">?</td>
-<td class="unknown obsolete" data-browser="closure20210906">?</td>
-<td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown obsolete" data-browser="closure20220502">?</td>
-<td class="unknown obsolete" data-browser="closure20220719">?</td>
-<td class="unknown" data-browser="closure20230228">?</td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes" data-browser="typescript5_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox114">No</td>
-<td class="no" data-browser="firefox115">No</td>
-<td class="no obsolete" data-browser="firefox116">No</td>
-<td class="no obsolete" data-browser="firefox117">No</td>
-<td class="no obsolete" data-browser="firefox118">No</td>
-<td class="no obsolete" data-browser="firefox119">No</td>
-<td class="no obsolete" data-browser="firefox120">No</td>
-<td class="no obsolete" data-browser="firefox121">No</td>
-<td class="no obsolete" data-browser="firefox122">No</td>
-<td class="no obsolete" data-browser="firefox123">No</td>
-<td class="no obsolete" data-browser="firefox124">No</td>
-<td class="no obsolete" data-browser="firefox125">No</td>
-<td class="no obsolete" data-browser="firefox126">No</td>
-<td class="no" data-browser="firefox127">No</td>
-<td class="no unstable" data-browser="firefox128">No</td>
-<td class="no unstable" data-browser="firefox129">No</td>
-<td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome115">No</td>
-<td class="no obsolete" data-browser="chrome116">No</td>
-<td class="no obsolete" data-browser="chrome117">No</td>
-<td class="no obsolete" data-browser="chrome118">No</td>
-<td class="no obsolete" data-browser="chrome119">No</td>
-<td class="no obsolete" data-browser="chrome120">No</td>
-<td class="no obsolete" data-browser="chrome121">No</td>
-<td class="no obsolete" data-browser="chrome122">No</td>
-<td class="no obsolete" data-browser="chrome123">No</td>
-<td class="no obsolete" data-browser="chrome124">No</td>
-<td class="no obsolete" data-browser="chrome125">No</td>
-<td class="no" data-browser="chrome126">No</td>
-<td class="no unstable" data-browser="chrome127">No</td>
-<td class="no obsolete" data-browser="edge18">No</td>
-<td class="no obsolete" data-browser="edge115">No</td>
-<td class="no obsolete" data-browser="edge116">No</td>
-<td class="no obsolete" data-browser="edge117">No</td>
-<td class="no obsolete" data-browser="edge118">No</td>
-<td class="no obsolete" data-browser="edge119">No</td>
-<td class="no obsolete" data-browser="edge120">No</td>
-<td class="no obsolete" data-browser="edge121">No</td>
-<td class="no obsolete" data-browser="edge122">No</td>
-<td class="no obsolete" data-browser="edge123">No</td>
-<td class="no obsolete" data-browser="edge124">No</td>
-<td class="no obsolete" data-browser="edge125">No</td>
-<td class="no" data-browser="edge126">No</td>
-<td class="no unstable" data-browser="edge127">No</td>
-<td class="unknown obsolete" data-browser="safari15_6">?</td>
-<td class="unknown obsolete" data-browser="safari16_6">?</td>
-<td class="unknown obsolete" data-browser="safari17">?</td>
-<td class="unknown obsolete" data-browser="safari17_1">?</td>
-<td class="unknown obsolete" data-browser="safari17_2">?</td>
-<td class="unknown obsolete" data-browser="safari17_3">?</td>
-<td class="unknown obsolete" data-browser="safari17_4">?</td>
-<td class="unknown" data-browser="safari17_5">?</td>
-<td class="unknown unstable" data-browser="safaritp">?</td>
-<td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera88">No</td>
-<td class="no obsolete" data-browser="opera89">No</td>
-<td class="no obsolete" data-browser="opera90">No</td>
-<td class="no obsolete" data-browser="opera91">No</td>
-<td class="no obsolete" data-browser="opera92">No</td>
-<td class="no obsolete" data-browser="opera93">No</td>
-<td class="no obsolete" data-browser="opera94">No</td>
-<td class="no obsolete" data-browser="opera95">No</td>
-<td class="no obsolete" data-browser="opera96">No</td>
-<td class="no obsolete" data-browser="opera97">No</td>
-<td class="no" data-browser="opera98">No</td>
-<td class="no unstable" data-browser="opera99">No</td>
-<td class="no obsolete" data-browser="rhino1_7_13">No</td>
-<td class="no obsolete" data-browser="rhino1_7_14">No</td>
-<td class="no obsolete" data-browser="rhino1_7_15">No</td>
-<td class="unknown obsolete" data-browser="phantom2_1">?</td>
-<td class="unknown obsolete" data-browser="node0_4">?</td>
-<td class="unknown obsolete" data-browser="node0_6">?</td>
-<td class="unknown obsolete" data-browser="node0_8">?</td>
-<td class="unknown obsolete" data-browser="node0_10">?</td>
-<td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node14_6">No</td>
-<td class="no obsolete" data-browser="node16_0">No</td>
-<td class="no obsolete" data-browser="node16_9">No</td>
-<td class="no" data-browser="node16_11">No</td>
-<td class="no obsolete" data-browser="node17_0">No</td>
-<td class="no obsolete" data-browser="node17_2">No</td>
-<td class="no obsolete" data-browser="node18_0">No</td>
-<td class="no" data-browser="node18_3">No</td>
-<td class="no obsolete" data-browser="node19_0">No</td>
-<td class="no obsolete" data-browser="node19_2">No</td>
-<td class="no" data-browser="node20_0">No</td>
-<td class="no obsolete" data-browser="node21_0">No</td>
-<td class="no" data-browser="node22_0">No</td>
-<td class="no obsolete" data-browser="duktape2_6">No</td>
-<td class="no" data-browser="duktape2_7">No</td>
-<td class="unknown obsolete" data-browser="graalvm19">?</td>
-<td class="unknown obsolete" data-browser="graalvm19_3_6">?</td>
-<td class="unknown obsolete" data-browser="graalvm20">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_1">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_3">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_3_1">?</td>
-<td class="unknown obsolete" data-browser="graalvm21">?</td>
-<td class="no" data-browser="graalvm21_3_3">No</td>
-<td class="no" data-browser="graalvm22_2">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
-<td class="no obsolete" data-browser="deno1_33">No</td>
-<td class="no obsolete" data-browser="deno1_34">No</td>
-<td class="no obsolete" data-browser="deno1_35">No</td>
-<td class="no" data-browser="deno1_36">No</td>
-<td class="unknown obsolete" data-browser="android4_4">?</td>
-<td class="unknown obsolete" data-browser="android4_4_3">?</td>
-<td class="unknown obsolete" data-browser="ios12_2">?</td>
-<td class="unknown obsolete" data-browser="ios13_4">?</td>
-<td class="unknown obsolete" data-browser="ios14_5">?</td>
-<td class="unknown obsolete" data-browser="ios16">?</td>
-<td class="unknown obsolete" data-browser="ios16_1">?</td>
-<td class="unknown obsolete" data-browser="ios16_2">?</td>
-<td class="unknown obsolete" data-browser="ios16_3">?</td>
-<td class="unknown obsolete" data-browser="ios16_4">?</td>
-<td class="unknown obsolete" data-browser="ios16_5">?</td>
-<td class="unknown obsolete" data-browser="ios16_6">?</td>
-<td class="unknown" data-browser="ios17">?</td>
-<td class="no obsolete" data-browser="samsung19">No</td>
-<td class="no obsolete" data-browser="samsung20">No</td>
-<td class="no obsolete" data-browser="samsung21">No</td>
-<td class="no" data-browser="samsung22">No</td>
-<td class="no obsolete" data-browser="opera_mobile72">No</td>
-<td class="no obsolete" data-browser="opera_mobile73">No</td>
-<td class="no obsolete" data-browser="opera_mobile74">No</td>
-<td class="no obsolete" data-browser="opera_mobile75">No</td>
-<td class="no obsolete" data-browser="opera_mobile76">No</td>
-<td class="no" data-browser="opera_mobile77">No</td>
-<td class="no" data-browser="reactnative0_70_3">No</td>
-</tr>
-<tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_AsyncIterator.from,_async_iterable"><td><span><a class="anchor" href="#test-Iterator_Helpers_AsyncIterator.from,_async_iterable">&#xA7;</a>AsyncIterator.from, async iterable</span><script data-source="
-async function toArray(iterator) {
-  const result = [];
-  for await (const it of iterator) result.push(it);
-  return result;
-}
-
-const iterator = AsyncIterator.from(async function*() { yield * [1, 2, 3] }());
-
-if (!(&apos;next&apos; in iterator) || !(iterator instanceof AsyncIterator)) return false;
-
-toArray(iterator).then(it =&gt; {
-  if (it.join() === &apos;1,2,3&apos;) asyncTestPassed();
-});
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("25");try{return Function("asyncTestPassed","\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\nconst iterator = AsyncIterator.from(async function*() { yield * [1, 2, 3] }());\n\nif (!('next' in iterator) || !(iterator instanceof AsyncIterator)) return false;\n\ntoArray(iterator).then(it => {\n  if (it.join() === '1,2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("25");return Function("asyncTestPassed","'use strict';"+"\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\nconst iterator = AsyncIterator.from(async function*() { yield * [1, 2, 3] }());\n\nif (!('next' in iterator) || !(iterator instanceof AsyncIterator)) return false;\n\ntoArray(iterator).then(it => {\n  if (it.join() === '1,2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
-</script></td>
-<td class="unknown obsolete" data-browser="tr">?</td>
-<td class="no obsolete" data-browser="babel6corejs2">No</td>
-<td class="no obsolete" data-browser="babel7corejs2">No</td>
-<td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200927">?</td>
-<td class="unknown obsolete" data-browser="closure20210808">?</td>
-<td class="unknown obsolete" data-browser="closure20210906">?</td>
-<td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown obsolete" data-browser="closure20220502">?</td>
-<td class="unknown obsolete" data-browser="closure20220719">?</td>
-<td class="unknown" data-browser="closure20230228">?</td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes" data-browser="typescript5_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox114">No</td>
-<td class="no" data-browser="firefox115">No</td>
-<td class="no obsolete" data-browser="firefox116">No</td>
-<td class="no obsolete" data-browser="firefox117">No</td>
-<td class="no obsolete" data-browser="firefox118">No</td>
-<td class="no obsolete" data-browser="firefox119">No</td>
-<td class="no obsolete" data-browser="firefox120">No</td>
-<td class="no obsolete" data-browser="firefox121">No</td>
-<td class="no obsolete" data-browser="firefox122">No</td>
-<td class="no obsolete" data-browser="firefox123">No</td>
-<td class="no obsolete" data-browser="firefox124">No</td>
-<td class="no obsolete" data-browser="firefox125">No</td>
-<td class="no obsolete" data-browser="firefox126">No</td>
-<td class="no" data-browser="firefox127">No</td>
-<td class="no unstable" data-browser="firefox128">No</td>
-<td class="no unstable" data-browser="firefox129">No</td>
-<td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome115">No</td>
-<td class="no obsolete" data-browser="chrome116">No</td>
-<td class="no obsolete" data-browser="chrome117">No</td>
-<td class="no obsolete" data-browser="chrome118">No</td>
-<td class="no obsolete" data-browser="chrome119">No</td>
-<td class="no obsolete" data-browser="chrome120">No</td>
-<td class="no obsolete" data-browser="chrome121">No</td>
-<td class="no obsolete" data-browser="chrome122">No</td>
-<td class="no obsolete" data-browser="chrome123">No</td>
-<td class="no obsolete" data-browser="chrome124">No</td>
-<td class="no obsolete" data-browser="chrome125">No</td>
-<td class="no" data-browser="chrome126">No</td>
-<td class="no unstable" data-browser="chrome127">No</td>
-<td class="no obsolete" data-browser="edge18">No</td>
-<td class="no obsolete" data-browser="edge115">No</td>
-<td class="no obsolete" data-browser="edge116">No</td>
-<td class="no obsolete" data-browser="edge117">No</td>
-<td class="no obsolete" data-browser="edge118">No</td>
-<td class="no obsolete" data-browser="edge119">No</td>
-<td class="no obsolete" data-browser="edge120">No</td>
-<td class="no obsolete" data-browser="edge121">No</td>
-<td class="no obsolete" data-browser="edge122">No</td>
-<td class="no obsolete" data-browser="edge123">No</td>
-<td class="no obsolete" data-browser="edge124">No</td>
-<td class="no obsolete" data-browser="edge125">No</td>
-<td class="no" data-browser="edge126">No</td>
-<td class="no unstable" data-browser="edge127">No</td>
-<td class="unknown obsolete" data-browser="safari15_6">?</td>
-<td class="unknown obsolete" data-browser="safari16_6">?</td>
-<td class="unknown obsolete" data-browser="safari17">?</td>
-<td class="unknown obsolete" data-browser="safari17_1">?</td>
-<td class="unknown obsolete" data-browser="safari17_2">?</td>
-<td class="unknown obsolete" data-browser="safari17_3">?</td>
-<td class="unknown obsolete" data-browser="safari17_4">?</td>
-<td class="unknown" data-browser="safari17_5">?</td>
-<td class="unknown unstable" data-browser="safaritp">?</td>
-<td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera88">No</td>
-<td class="no obsolete" data-browser="opera89">No</td>
-<td class="no obsolete" data-browser="opera90">No</td>
-<td class="no obsolete" data-browser="opera91">No</td>
-<td class="no obsolete" data-browser="opera92">No</td>
-<td class="no obsolete" data-browser="opera93">No</td>
-<td class="no obsolete" data-browser="opera94">No</td>
-<td class="no obsolete" data-browser="opera95">No</td>
-<td class="no obsolete" data-browser="opera96">No</td>
-<td class="no obsolete" data-browser="opera97">No</td>
-<td class="no" data-browser="opera98">No</td>
-<td class="no unstable" data-browser="opera99">No</td>
-<td class="no obsolete" data-browser="rhino1_7_13">No</td>
-<td class="no obsolete" data-browser="rhino1_7_14">No</td>
-<td class="no obsolete" data-browser="rhino1_7_15">No</td>
-<td class="unknown obsolete" data-browser="phantom2_1">?</td>
-<td class="unknown obsolete" data-browser="node0_4">?</td>
-<td class="unknown obsolete" data-browser="node0_6">?</td>
-<td class="unknown obsolete" data-browser="node0_8">?</td>
-<td class="unknown obsolete" data-browser="node0_10">?</td>
-<td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node14_6">No</td>
-<td class="no obsolete" data-browser="node16_0">No</td>
-<td class="no obsolete" data-browser="node16_9">No</td>
-<td class="no" data-browser="node16_11">No</td>
-<td class="no obsolete" data-browser="node17_0">No</td>
-<td class="no obsolete" data-browser="node17_2">No</td>
-<td class="no obsolete" data-browser="node18_0">No</td>
-<td class="no" data-browser="node18_3">No</td>
-<td class="no obsolete" data-browser="node19_0">No</td>
-<td class="no obsolete" data-browser="node19_2">No</td>
-<td class="no" data-browser="node20_0">No</td>
-<td class="no obsolete" data-browser="node21_0">No</td>
-<td class="no" data-browser="node22_0">No</td>
-<td class="no obsolete" data-browser="duktape2_6">No</td>
-<td class="no" data-browser="duktape2_7">No</td>
-<td class="unknown obsolete" data-browser="graalvm19">?</td>
-<td class="unknown obsolete" data-browser="graalvm19_3_6">?</td>
-<td class="unknown obsolete" data-browser="graalvm20">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_1">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_3">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_3_1">?</td>
-<td class="unknown obsolete" data-browser="graalvm21">?</td>
-<td class="no" data-browser="graalvm21_3_3">No</td>
-<td class="no" data-browser="graalvm22_2">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
-<td class="no obsolete" data-browser="deno1_33">No</td>
-<td class="no obsolete" data-browser="deno1_34">No</td>
-<td class="no obsolete" data-browser="deno1_35">No</td>
-<td class="no" data-browser="deno1_36">No</td>
-<td class="unknown obsolete" data-browser="android4_4">?</td>
-<td class="unknown obsolete" data-browser="android4_4_3">?</td>
-<td class="unknown obsolete" data-browser="ios12_2">?</td>
-<td class="unknown obsolete" data-browser="ios13_4">?</td>
-<td class="unknown obsolete" data-browser="ios14_5">?</td>
-<td class="unknown obsolete" data-browser="ios16">?</td>
-<td class="unknown obsolete" data-browser="ios16_1">?</td>
-<td class="unknown obsolete" data-browser="ios16_2">?</td>
-<td class="unknown obsolete" data-browser="ios16_3">?</td>
-<td class="unknown obsolete" data-browser="ios16_4">?</td>
-<td class="unknown obsolete" data-browser="ios16_5">?</td>
-<td class="unknown obsolete" data-browser="ios16_6">?</td>
-<td class="unknown" data-browser="ios17">?</td>
-<td class="no obsolete" data-browser="samsung19">No</td>
-<td class="no obsolete" data-browser="samsung20">No</td>
-<td class="no obsolete" data-browser="samsung21">No</td>
-<td class="no" data-browser="samsung22">No</td>
-<td class="no obsolete" data-browser="opera_mobile72">No</td>
-<td class="no obsolete" data-browser="opera_mobile73">No</td>
-<td class="no obsolete" data-browser="opera_mobile74">No</td>
-<td class="no obsolete" data-browser="opera_mobile75">No</td>
-<td class="no obsolete" data-browser="opera_mobile76">No</td>
-<td class="no" data-browser="opera_mobile77">No</td>
-<td class="no" data-browser="reactnative0_70_3">No</td>
-</tr>
-<tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_AsyncIterator.from,_iterable"><td><span><a class="anchor" href="#test-Iterator_Helpers_AsyncIterator.from,_iterable">&#xA7;</a>AsyncIterator.from, iterable</span><script data-source="
-async function toArray(iterator) {
-  const result = [];
-  for await (const it of iterator) result.push(it);
-  return result;
-}
-
-const iterator = AsyncIterator.from([1, 2, 3]);
-
-if (!(&apos;next&apos; in iterator) || !(iterator instanceof AsyncIterator)) return false;
-
-toArray(iterator).then(it =&gt; {
-  if (it.join() === &apos;1,2,3&apos;) asyncTestPassed();
-});
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("26");try{return Function("asyncTestPassed","\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\nconst iterator = AsyncIterator.from([1, 2, 3]);\n\nif (!('next' in iterator) || !(iterator instanceof AsyncIterator)) return false;\n\ntoArray(iterator).then(it => {\n  if (it.join() === '1,2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("26");return Function("asyncTestPassed","'use strict';"+"\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\nconst iterator = AsyncIterator.from([1, 2, 3]);\n\nif (!('next' in iterator) || !(iterator instanceof AsyncIterator)) return false;\n\ntoArray(iterator).then(it => {\n  if (it.join() === '1,2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
-</script></td>
-<td class="unknown obsolete" data-browser="tr">?</td>
-<td class="no obsolete" data-browser="babel6corejs2">No</td>
-<td class="no obsolete" data-browser="babel7corejs2">No</td>
-<td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200927">?</td>
-<td class="unknown obsolete" data-browser="closure20210808">?</td>
-<td class="unknown obsolete" data-browser="closure20210906">?</td>
-<td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown obsolete" data-browser="closure20220502">?</td>
-<td class="unknown obsolete" data-browser="closure20220719">?</td>
-<td class="unknown" data-browser="closure20230228">?</td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes" data-browser="typescript5_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox114">No</td>
-<td class="no" data-browser="firefox115">No</td>
-<td class="no obsolete" data-browser="firefox116">No</td>
-<td class="no obsolete" data-browser="firefox117">No</td>
-<td class="no obsolete" data-browser="firefox118">No</td>
-<td class="no obsolete" data-browser="firefox119">No</td>
-<td class="no obsolete" data-browser="firefox120">No</td>
-<td class="no obsolete" data-browser="firefox121">No</td>
-<td class="no obsolete" data-browser="firefox122">No</td>
-<td class="no obsolete" data-browser="firefox123">No</td>
-<td class="no obsolete" data-browser="firefox124">No</td>
-<td class="no obsolete" data-browser="firefox125">No</td>
-<td class="no obsolete" data-browser="firefox126">No</td>
-<td class="no" data-browser="firefox127">No</td>
-<td class="no unstable" data-browser="firefox128">No</td>
-<td class="no unstable" data-browser="firefox129">No</td>
-<td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome115">No</td>
-<td class="no obsolete" data-browser="chrome116">No</td>
-<td class="no obsolete" data-browser="chrome117">No</td>
-<td class="no obsolete" data-browser="chrome118">No</td>
-<td class="no obsolete" data-browser="chrome119">No</td>
-<td class="no obsolete" data-browser="chrome120">No</td>
-<td class="no obsolete" data-browser="chrome121">No</td>
-<td class="no obsolete" data-browser="chrome122">No</td>
-<td class="no obsolete" data-browser="chrome123">No</td>
-<td class="no obsolete" data-browser="chrome124">No</td>
-<td class="no obsolete" data-browser="chrome125">No</td>
-<td class="no" data-browser="chrome126">No</td>
-<td class="no unstable" data-browser="chrome127">No</td>
-<td class="no obsolete" data-browser="edge18">No</td>
-<td class="no obsolete" data-browser="edge115">No</td>
-<td class="no obsolete" data-browser="edge116">No</td>
-<td class="no obsolete" data-browser="edge117">No</td>
-<td class="no obsolete" data-browser="edge118">No</td>
-<td class="no obsolete" data-browser="edge119">No</td>
-<td class="no obsolete" data-browser="edge120">No</td>
-<td class="no obsolete" data-browser="edge121">No</td>
-<td class="no obsolete" data-browser="edge122">No</td>
-<td class="no obsolete" data-browser="edge123">No</td>
-<td class="no obsolete" data-browser="edge124">No</td>
-<td class="no obsolete" data-browser="edge125">No</td>
-<td class="no" data-browser="edge126">No</td>
-<td class="no unstable" data-browser="edge127">No</td>
-<td class="unknown obsolete" data-browser="safari15_6">?</td>
-<td class="unknown obsolete" data-browser="safari16_6">?</td>
-<td class="unknown obsolete" data-browser="safari17">?</td>
-<td class="unknown obsolete" data-browser="safari17_1">?</td>
-<td class="unknown obsolete" data-browser="safari17_2">?</td>
-<td class="unknown obsolete" data-browser="safari17_3">?</td>
-<td class="unknown obsolete" data-browser="safari17_4">?</td>
-<td class="unknown" data-browser="safari17_5">?</td>
-<td class="unknown unstable" data-browser="safaritp">?</td>
-<td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera88">No</td>
-<td class="no obsolete" data-browser="opera89">No</td>
-<td class="no obsolete" data-browser="opera90">No</td>
-<td class="no obsolete" data-browser="opera91">No</td>
-<td class="no obsolete" data-browser="opera92">No</td>
-<td class="no obsolete" data-browser="opera93">No</td>
-<td class="no obsolete" data-browser="opera94">No</td>
-<td class="no obsolete" data-browser="opera95">No</td>
-<td class="no obsolete" data-browser="opera96">No</td>
-<td class="no obsolete" data-browser="opera97">No</td>
-<td class="no" data-browser="opera98">No</td>
-<td class="no unstable" data-browser="opera99">No</td>
-<td class="no obsolete" data-browser="rhino1_7_13">No</td>
-<td class="no obsolete" data-browser="rhino1_7_14">No</td>
-<td class="no obsolete" data-browser="rhino1_7_15">No</td>
-<td class="unknown obsolete" data-browser="phantom2_1">?</td>
-<td class="unknown obsolete" data-browser="node0_4">?</td>
-<td class="unknown obsolete" data-browser="node0_6">?</td>
-<td class="unknown obsolete" data-browser="node0_8">?</td>
-<td class="unknown obsolete" data-browser="node0_10">?</td>
-<td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node14_6">No</td>
-<td class="no obsolete" data-browser="node16_0">No</td>
-<td class="no obsolete" data-browser="node16_9">No</td>
-<td class="no" data-browser="node16_11">No</td>
-<td class="no obsolete" data-browser="node17_0">No</td>
-<td class="no obsolete" data-browser="node17_2">No</td>
-<td class="no obsolete" data-browser="node18_0">No</td>
-<td class="no" data-browser="node18_3">No</td>
-<td class="no obsolete" data-browser="node19_0">No</td>
-<td class="no obsolete" data-browser="node19_2">No</td>
-<td class="no" data-browser="node20_0">No</td>
-<td class="no obsolete" data-browser="node21_0">No</td>
-<td class="no" data-browser="node22_0">No</td>
-<td class="no obsolete" data-browser="duktape2_6">No</td>
-<td class="no" data-browser="duktape2_7">No</td>
-<td class="unknown obsolete" data-browser="graalvm19">?</td>
-<td class="unknown obsolete" data-browser="graalvm19_3_6">?</td>
-<td class="unknown obsolete" data-browser="graalvm20">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_1">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_3">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_3_1">?</td>
-<td class="unknown obsolete" data-browser="graalvm21">?</td>
-<td class="no" data-browser="graalvm21_3_3">No</td>
-<td class="no" data-browser="graalvm22_2">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
-<td class="no obsolete" data-browser="deno1_33">No</td>
-<td class="no obsolete" data-browser="deno1_34">No</td>
-<td class="no obsolete" data-browser="deno1_35">No</td>
-<td class="no" data-browser="deno1_36">No</td>
-<td class="unknown obsolete" data-browser="android4_4">?</td>
-<td class="unknown obsolete" data-browser="android4_4_3">?</td>
-<td class="unknown obsolete" data-browser="ios12_2">?</td>
-<td class="unknown obsolete" data-browser="ios13_4">?</td>
-<td class="unknown obsolete" data-browser="ios14_5">?</td>
-<td class="unknown obsolete" data-browser="ios16">?</td>
-<td class="unknown obsolete" data-browser="ios16_1">?</td>
-<td class="unknown obsolete" data-browser="ios16_2">?</td>
-<td class="unknown obsolete" data-browser="ios16_3">?</td>
-<td class="unknown obsolete" data-browser="ios16_4">?</td>
-<td class="unknown obsolete" data-browser="ios16_5">?</td>
-<td class="unknown obsolete" data-browser="ios16_6">?</td>
-<td class="unknown" data-browser="ios17">?</td>
-<td class="no obsolete" data-browser="samsung19">No</td>
-<td class="no obsolete" data-browser="samsung20">No</td>
-<td class="no obsolete" data-browser="samsung21">No</td>
-<td class="no" data-browser="samsung22">No</td>
-<td class="no obsolete" data-browser="opera_mobile72">No</td>
-<td class="no obsolete" data-browser="opera_mobile73">No</td>
-<td class="no obsolete" data-browser="opera_mobile74">No</td>
-<td class="no obsolete" data-browser="opera_mobile75">No</td>
-<td class="no obsolete" data-browser="opera_mobile76">No</td>
-<td class="no" data-browser="opera_mobile77">No</td>
-<td class="no" data-browser="reactnative0_70_3">No</td>
-</tr>
-<tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_AsyncIterator.from,_iterator"><td><span><a class="anchor" href="#test-Iterator_Helpers_AsyncIterator.from,_iterator">&#xA7;</a>AsyncIterator.from, iterator</span><script data-source="
-async function toArray(iterator) {
-  const result = [];
-  for await (const it of iterator) result.push(it);
-  return result;
-}
-
-const iterator = AsyncIterator.from([1, 2, 3].values());
-
-if (!(&apos;next&apos; in iterator) || !(iterator instanceof AsyncIterator)) return false;
-
-toArray(iterator).then(it =&gt; {
-  if (it.join() === &apos;1,2,3&apos;) asyncTestPassed();
-});
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("27");try{return Function("asyncTestPassed","\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\nconst iterator = AsyncIterator.from([1, 2, 3].values());\n\nif (!('next' in iterator) || !(iterator instanceof AsyncIterator)) return false;\n\ntoArray(iterator).then(it => {\n  if (it.join() === '1,2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("27");return Function("asyncTestPassed","'use strict';"+"\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\nconst iterator = AsyncIterator.from([1, 2, 3].values());\n\nif (!('next' in iterator) || !(iterator instanceof AsyncIterator)) return false;\n\ntoArray(iterator).then(it => {\n  if (it.join() === '1,2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
-</script></td>
-<td class="unknown obsolete" data-browser="tr">?</td>
-<td class="no obsolete" data-browser="babel6corejs2">No</td>
-<td class="no obsolete" data-browser="babel7corejs2">No</td>
-<td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200927">?</td>
-<td class="unknown obsolete" data-browser="closure20210808">?</td>
-<td class="unknown obsolete" data-browser="closure20210906">?</td>
-<td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown obsolete" data-browser="closure20220502">?</td>
-<td class="unknown obsolete" data-browser="closure20220719">?</td>
-<td class="unknown" data-browser="closure20230228">?</td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes" data-browser="typescript5_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox114">No</td>
-<td class="no" data-browser="firefox115">No</td>
-<td class="no obsolete" data-browser="firefox116">No</td>
-<td class="no obsolete" data-browser="firefox117">No</td>
-<td class="no obsolete" data-browser="firefox118">No</td>
-<td class="no obsolete" data-browser="firefox119">No</td>
-<td class="no obsolete" data-browser="firefox120">No</td>
-<td class="no obsolete" data-browser="firefox121">No</td>
-<td class="no obsolete" data-browser="firefox122">No</td>
-<td class="no obsolete" data-browser="firefox123">No</td>
-<td class="no obsolete" data-browser="firefox124">No</td>
-<td class="no obsolete" data-browser="firefox125">No</td>
-<td class="no obsolete" data-browser="firefox126">No</td>
-<td class="no" data-browser="firefox127">No</td>
-<td class="no unstable" data-browser="firefox128">No</td>
-<td class="no unstable" data-browser="firefox129">No</td>
-<td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome115">No</td>
-<td class="no obsolete" data-browser="chrome116">No</td>
-<td class="no obsolete" data-browser="chrome117">No</td>
-<td class="no obsolete" data-browser="chrome118">No</td>
-<td class="no obsolete" data-browser="chrome119">No</td>
-<td class="no obsolete" data-browser="chrome120">No</td>
-<td class="no obsolete" data-browser="chrome121">No</td>
-<td class="no obsolete" data-browser="chrome122">No</td>
-<td class="no obsolete" data-browser="chrome123">No</td>
-<td class="no obsolete" data-browser="chrome124">No</td>
-<td class="no obsolete" data-browser="chrome125">No</td>
-<td class="no" data-browser="chrome126">No</td>
-<td class="no unstable" data-browser="chrome127">No</td>
-<td class="no obsolete" data-browser="edge18">No</td>
-<td class="no obsolete" data-browser="edge115">No</td>
-<td class="no obsolete" data-browser="edge116">No</td>
-<td class="no obsolete" data-browser="edge117">No</td>
-<td class="no obsolete" data-browser="edge118">No</td>
-<td class="no obsolete" data-browser="edge119">No</td>
-<td class="no obsolete" data-browser="edge120">No</td>
-<td class="no obsolete" data-browser="edge121">No</td>
-<td class="no obsolete" data-browser="edge122">No</td>
-<td class="no obsolete" data-browser="edge123">No</td>
-<td class="no obsolete" data-browser="edge124">No</td>
-<td class="no obsolete" data-browser="edge125">No</td>
-<td class="no" data-browser="edge126">No</td>
-<td class="no unstable" data-browser="edge127">No</td>
-<td class="unknown obsolete" data-browser="safari15_6">?</td>
-<td class="unknown obsolete" data-browser="safari16_6">?</td>
-<td class="unknown obsolete" data-browser="safari17">?</td>
-<td class="unknown obsolete" data-browser="safari17_1">?</td>
-<td class="unknown obsolete" data-browser="safari17_2">?</td>
-<td class="unknown obsolete" data-browser="safari17_3">?</td>
-<td class="unknown obsolete" data-browser="safari17_4">?</td>
-<td class="unknown" data-browser="safari17_5">?</td>
-<td class="unknown unstable" data-browser="safaritp">?</td>
-<td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera88">No</td>
-<td class="no obsolete" data-browser="opera89">No</td>
-<td class="no obsolete" data-browser="opera90">No</td>
-<td class="no obsolete" data-browser="opera91">No</td>
-<td class="no obsolete" data-browser="opera92">No</td>
-<td class="no obsolete" data-browser="opera93">No</td>
-<td class="no obsolete" data-browser="opera94">No</td>
-<td class="no obsolete" data-browser="opera95">No</td>
-<td class="no obsolete" data-browser="opera96">No</td>
-<td class="no obsolete" data-browser="opera97">No</td>
-<td class="no" data-browser="opera98">No</td>
-<td class="no unstable" data-browser="opera99">No</td>
-<td class="no obsolete" data-browser="rhino1_7_13">No</td>
-<td class="no obsolete" data-browser="rhino1_7_14">No</td>
-<td class="no obsolete" data-browser="rhino1_7_15">No</td>
-<td class="unknown obsolete" data-browser="phantom2_1">?</td>
-<td class="unknown obsolete" data-browser="node0_4">?</td>
-<td class="unknown obsolete" data-browser="node0_6">?</td>
-<td class="unknown obsolete" data-browser="node0_8">?</td>
-<td class="unknown obsolete" data-browser="node0_10">?</td>
-<td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node14_6">No</td>
-<td class="no obsolete" data-browser="node16_0">No</td>
-<td class="no obsolete" data-browser="node16_9">No</td>
-<td class="no" data-browser="node16_11">No</td>
-<td class="no obsolete" data-browser="node17_0">No</td>
-<td class="no obsolete" data-browser="node17_2">No</td>
-<td class="no obsolete" data-browser="node18_0">No</td>
-<td class="no" data-browser="node18_3">No</td>
-<td class="no obsolete" data-browser="node19_0">No</td>
-<td class="no obsolete" data-browser="node19_2">No</td>
-<td class="no" data-browser="node20_0">No</td>
-<td class="no obsolete" data-browser="node21_0">No</td>
-<td class="no" data-browser="node22_0">No</td>
-<td class="no obsolete" data-browser="duktape2_6">No</td>
-<td class="no" data-browser="duktape2_7">No</td>
-<td class="unknown obsolete" data-browser="graalvm19">?</td>
-<td class="unknown obsolete" data-browser="graalvm19_3_6">?</td>
-<td class="unknown obsolete" data-browser="graalvm20">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_1">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_3">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_3_1">?</td>
-<td class="unknown obsolete" data-browser="graalvm21">?</td>
-<td class="no" data-browser="graalvm21_3_3">No</td>
-<td class="no" data-browser="graalvm22_2">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
-<td class="no obsolete" data-browser="deno1_33">No</td>
-<td class="no obsolete" data-browser="deno1_34">No</td>
-<td class="no obsolete" data-browser="deno1_35">No</td>
-<td class="no" data-browser="deno1_36">No</td>
-<td class="unknown obsolete" data-browser="android4_4">?</td>
-<td class="unknown obsolete" data-browser="android4_4_3">?</td>
-<td class="unknown obsolete" data-browser="ios12_2">?</td>
-<td class="unknown obsolete" data-browser="ios13_4">?</td>
-<td class="unknown obsolete" data-browser="ios14_5">?</td>
-<td class="unknown obsolete" data-browser="ios16">?</td>
-<td class="unknown obsolete" data-browser="ios16_1">?</td>
-<td class="unknown obsolete" data-browser="ios16_2">?</td>
-<td class="unknown obsolete" data-browser="ios16_3">?</td>
-<td class="unknown obsolete" data-browser="ios16_4">?</td>
-<td class="unknown obsolete" data-browser="ios16_5">?</td>
-<td class="unknown obsolete" data-browser="ios16_6">?</td>
-<td class="unknown" data-browser="ios17">?</td>
-<td class="no obsolete" data-browser="samsung19">No</td>
-<td class="no obsolete" data-browser="samsung20">No</td>
-<td class="no obsolete" data-browser="samsung21">No</td>
-<td class="no" data-browser="samsung22">No</td>
-<td class="no obsolete" data-browser="opera_mobile72">No</td>
-<td class="no obsolete" data-browser="opera_mobile73">No</td>
-<td class="no obsolete" data-browser="opera_mobile74">No</td>
-<td class="no obsolete" data-browser="opera_mobile75">No</td>
-<td class="no obsolete" data-browser="opera_mobile76">No</td>
-<td class="no" data-browser="opera_mobile77">No</td>
-<td class="no" data-browser="reactnative0_70_3">No</td>
-</tr>
-<tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_AsyncIterator.prototype.asIndexedPairs"><td><span><a class="anchor" href="#test-Iterator_Helpers_AsyncIterator.prototype.asIndexedPairs">&#xA7;</a>AsyncIterator.prototype.asIndexedPairs</span><script data-source="
-async function toArray(iterator) {
-  const result = [];
-  for await (const it of iterator) result.push(it);
-  return result;
-}
-
-toArray((async function*() { yield * [1, 2, 3] })().asIndexedPairs()).then(it =&gt; {
-  if (it.join() === &apos;0,1,1,2,2,3&apos;) asyncTestPassed();
-});
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("28");try{return Function("asyncTestPassed","\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray((async function*() { yield * [1, 2, 3] })().asIndexedPairs()).then(it => {\n  if (it.join() === '0,1,1,2,2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("28");return Function("asyncTestPassed","'use strict';"+"\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray((async function*() { yield * [1, 2, 3] })().asIndexedPairs()).then(it => {\n  if (it.join() === '0,1,1,2,2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
-</script></td>
-<td class="unknown obsolete" data-browser="tr">?</td>
-<td class="no obsolete" data-browser="babel6corejs2">No</td>
-<td class="no obsolete" data-browser="babel7corejs2">No</td>
-<td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200927">?</td>
-<td class="unknown obsolete" data-browser="closure20210808">?</td>
-<td class="unknown obsolete" data-browser="closure20210906">?</td>
-<td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown obsolete" data-browser="closure20220502">?</td>
-<td class="unknown obsolete" data-browser="closure20220719">?</td>
-<td class="unknown" data-browser="closure20230228">?</td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes" data-browser="typescript5_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox114">No</td>
-<td class="no" data-browser="firefox115">No</td>
-<td class="no obsolete" data-browser="firefox116">No</td>
-<td class="no obsolete" data-browser="firefox117">No</td>
-<td class="no obsolete" data-browser="firefox118">No</td>
-<td class="no obsolete" data-browser="firefox119">No</td>
-<td class="no obsolete" data-browser="firefox120">No</td>
-<td class="no obsolete" data-browser="firefox121">No</td>
-<td class="no obsolete" data-browser="firefox122">No</td>
-<td class="no obsolete" data-browser="firefox123">No</td>
-<td class="no obsolete" data-browser="firefox124">No</td>
-<td class="no obsolete" data-browser="firefox125">No</td>
-<td class="no obsolete" data-browser="firefox126">No</td>
-<td class="no" data-browser="firefox127">No</td>
-<td class="no unstable" data-browser="firefox128">No</td>
-<td class="no unstable" data-browser="firefox129">No</td>
-<td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome115">No</td>
-<td class="no obsolete" data-browser="chrome116">No</td>
-<td class="no obsolete" data-browser="chrome117">No</td>
-<td class="no obsolete" data-browser="chrome118">No</td>
-<td class="no obsolete" data-browser="chrome119">No</td>
-<td class="no obsolete" data-browser="chrome120">No</td>
-<td class="no obsolete" data-browser="chrome121">No</td>
-<td class="no obsolete" data-browser="chrome122">No</td>
-<td class="no obsolete" data-browser="chrome123">No</td>
-<td class="no obsolete" data-browser="chrome124">No</td>
-<td class="no obsolete" data-browser="chrome125">No</td>
-<td class="no" data-browser="chrome126">No</td>
-<td class="no unstable" data-browser="chrome127">No</td>
-<td class="no obsolete" data-browser="edge18">No</td>
-<td class="no obsolete" data-browser="edge115">No</td>
-<td class="no obsolete" data-browser="edge116">No</td>
-<td class="no obsolete" data-browser="edge117">No</td>
-<td class="no obsolete" data-browser="edge118">No</td>
-<td class="no obsolete" data-browser="edge119">No</td>
-<td class="no obsolete" data-browser="edge120">No</td>
-<td class="no obsolete" data-browser="edge121">No</td>
-<td class="no obsolete" data-browser="edge122">No</td>
-<td class="no obsolete" data-browser="edge123">No</td>
-<td class="no obsolete" data-browser="edge124">No</td>
-<td class="no obsolete" data-browser="edge125">No</td>
-<td class="no" data-browser="edge126">No</td>
-<td class="no unstable" data-browser="edge127">No</td>
-<td class="unknown obsolete" data-browser="safari15_6">?</td>
-<td class="unknown obsolete" data-browser="safari16_6">?</td>
-<td class="unknown obsolete" data-browser="safari17">?</td>
-<td class="unknown obsolete" data-browser="safari17_1">?</td>
-<td class="unknown obsolete" data-browser="safari17_2">?</td>
-<td class="unknown obsolete" data-browser="safari17_3">?</td>
-<td class="unknown obsolete" data-browser="safari17_4">?</td>
-<td class="unknown" data-browser="safari17_5">?</td>
-<td class="unknown unstable" data-browser="safaritp">?</td>
-<td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera88">No</td>
-<td class="no obsolete" data-browser="opera89">No</td>
-<td class="no obsolete" data-browser="opera90">No</td>
-<td class="no obsolete" data-browser="opera91">No</td>
-<td class="no obsolete" data-browser="opera92">No</td>
-<td class="no obsolete" data-browser="opera93">No</td>
-<td class="no obsolete" data-browser="opera94">No</td>
-<td class="no obsolete" data-browser="opera95">No</td>
-<td class="no obsolete" data-browser="opera96">No</td>
-<td class="no obsolete" data-browser="opera97">No</td>
-<td class="no" data-browser="opera98">No</td>
-<td class="no unstable" data-browser="opera99">No</td>
-<td class="no obsolete" data-browser="rhino1_7_13">No</td>
-<td class="no obsolete" data-browser="rhino1_7_14">No</td>
-<td class="no obsolete" data-browser="rhino1_7_15">No</td>
-<td class="unknown obsolete" data-browser="phantom2_1">?</td>
-<td class="unknown obsolete" data-browser="node0_4">?</td>
-<td class="unknown obsolete" data-browser="node0_6">?</td>
-<td class="unknown obsolete" data-browser="node0_8">?</td>
-<td class="unknown obsolete" data-browser="node0_10">?</td>
-<td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node14_6">No</td>
-<td class="no obsolete" data-browser="node16_0">No</td>
-<td class="no obsolete" data-browser="node16_9">No</td>
-<td class="no" data-browser="node16_11">No</td>
-<td class="no obsolete" data-browser="node17_0">No</td>
-<td class="no obsolete" data-browser="node17_2">No</td>
-<td class="no obsolete" data-browser="node18_0">No</td>
-<td class="no" data-browser="node18_3">No</td>
-<td class="no obsolete" data-browser="node19_0">No</td>
-<td class="no obsolete" data-browser="node19_2">No</td>
-<td class="no" data-browser="node20_0">No</td>
-<td class="no obsolete" data-browser="node21_0">No</td>
-<td class="no" data-browser="node22_0">No</td>
-<td class="no obsolete" data-browser="duktape2_6">No</td>
-<td class="no" data-browser="duktape2_7">No</td>
-<td class="unknown obsolete" data-browser="graalvm19">?</td>
-<td class="unknown obsolete" data-browser="graalvm19_3_6">?</td>
-<td class="unknown obsolete" data-browser="graalvm20">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_1">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_3">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_3_1">?</td>
-<td class="unknown obsolete" data-browser="graalvm21">?</td>
-<td class="no" data-browser="graalvm21_3_3">No</td>
-<td class="no" data-browser="graalvm22_2">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
-<td class="no obsolete" data-browser="deno1_33">No</td>
-<td class="no obsolete" data-browser="deno1_34">No</td>
-<td class="no obsolete" data-browser="deno1_35">No</td>
-<td class="no" data-browser="deno1_36">No</td>
-<td class="unknown obsolete" data-browser="android4_4">?</td>
-<td class="unknown obsolete" data-browser="android4_4_3">?</td>
-<td class="unknown obsolete" data-browser="ios12_2">?</td>
-<td class="unknown obsolete" data-browser="ios13_4">?</td>
-<td class="unknown obsolete" data-browser="ios14_5">?</td>
-<td class="unknown obsolete" data-browser="ios16">?</td>
-<td class="unknown obsolete" data-browser="ios16_1">?</td>
-<td class="unknown obsolete" data-browser="ios16_2">?</td>
-<td class="unknown obsolete" data-browser="ios16_3">?</td>
-<td class="unknown obsolete" data-browser="ios16_4">?</td>
-<td class="unknown obsolete" data-browser="ios16_5">?</td>
-<td class="unknown obsolete" data-browser="ios16_6">?</td>
-<td class="unknown" data-browser="ios17">?</td>
-<td class="no obsolete" data-browser="samsung19">No</td>
-<td class="no obsolete" data-browser="samsung20">No</td>
-<td class="no obsolete" data-browser="samsung21">No</td>
-<td class="no" data-browser="samsung22">No</td>
-<td class="no obsolete" data-browser="opera_mobile72">No</td>
-<td class="no obsolete" data-browser="opera_mobile73">No</td>
-<td class="no obsolete" data-browser="opera_mobile74">No</td>
-<td class="no obsolete" data-browser="opera_mobile75">No</td>
-<td class="no obsolete" data-browser="opera_mobile76">No</td>
-<td class="no" data-browser="opera_mobile77">No</td>
-<td class="no" data-browser="reactnative0_70_3">No</td>
-</tr>
-<tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_AsyncIterator.prototype.drop"><td><span><a class="anchor" href="#test-Iterator_Helpers_AsyncIterator.prototype.drop">&#xA7;</a>AsyncIterator.prototype.drop</span><script data-source="
-async function toArray(iterator) {
-  const result = [];
-  for await (const it of iterator) result.push(it);
-  return result;
-}
-
-toArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it =&gt; {
-  if (it.join() === &apos;2,3&apos;) asyncTestPassed();
-});
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("29");try{return Function("asyncTestPassed","\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it => {\n  if (it.join() === '2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("29");return Function("asyncTestPassed","'use strict';"+"\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it => {\n  if (it.join() === '2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
-</script></td>
-<td class="unknown obsolete" data-browser="tr">?</td>
-<td class="no obsolete" data-browser="babel6corejs2">No</td>
-<td class="no obsolete" data-browser="babel7corejs2">No</td>
-<td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200927">?</td>
-<td class="unknown obsolete" data-browser="closure20210808">?</td>
-<td class="unknown obsolete" data-browser="closure20210906">?</td>
-<td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown obsolete" data-browser="closure20220502">?</td>
-<td class="unknown obsolete" data-browser="closure20220719">?</td>
-<td class="unknown" data-browser="closure20230228">?</td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes" data-browser="typescript5_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox114">No</td>
-<td class="no" data-browser="firefox115">No</td>
-<td class="no obsolete" data-browser="firefox116">No</td>
-<td class="no obsolete" data-browser="firefox117">No</td>
-<td class="no obsolete" data-browser="firefox118">No</td>
-<td class="no obsolete" data-browser="firefox119">No</td>
-<td class="no obsolete" data-browser="firefox120">No</td>
-<td class="no obsolete" data-browser="firefox121">No</td>
-<td class="no obsolete" data-browser="firefox122">No</td>
-<td class="no obsolete" data-browser="firefox123">No</td>
-<td class="no obsolete" data-browser="firefox124">No</td>
-<td class="no obsolete" data-browser="firefox125">No</td>
-<td class="no obsolete" data-browser="firefox126">No</td>
-<td class="no" data-browser="firefox127">No</td>
-<td class="no unstable" data-browser="firefox128">No</td>
-<td class="no unstable" data-browser="firefox129">No</td>
-<td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome115">No</td>
-<td class="no obsolete" data-browser="chrome116">No</td>
-<td class="no obsolete" data-browser="chrome117">No</td>
-<td class="no obsolete" data-browser="chrome118">No</td>
-<td class="no obsolete" data-browser="chrome119">No</td>
-<td class="no obsolete" data-browser="chrome120">No</td>
-<td class="no obsolete" data-browser="chrome121">No</td>
-<td class="no obsolete" data-browser="chrome122">No</td>
-<td class="no obsolete" data-browser="chrome123">No</td>
-<td class="no obsolete" data-browser="chrome124">No</td>
-<td class="no obsolete" data-browser="chrome125">No</td>
-<td class="no" data-browser="chrome126">No</td>
-<td class="no unstable" data-browser="chrome127">No</td>
-<td class="no obsolete" data-browser="edge18">No</td>
-<td class="no obsolete" data-browser="edge115">No</td>
-<td class="no obsolete" data-browser="edge116">No</td>
-<td class="no obsolete" data-browser="edge117">No</td>
-<td class="no obsolete" data-browser="edge118">No</td>
-<td class="no obsolete" data-browser="edge119">No</td>
-<td class="no obsolete" data-browser="edge120">No</td>
-<td class="no obsolete" data-browser="edge121">No</td>
-<td class="no obsolete" data-browser="edge122">No</td>
-<td class="no obsolete" data-browser="edge123">No</td>
-<td class="no obsolete" data-browser="edge124">No</td>
-<td class="no obsolete" data-browser="edge125">No</td>
-<td class="no" data-browser="edge126">No</td>
-<td class="no unstable" data-browser="edge127">No</td>
-<td class="unknown obsolete" data-browser="safari15_6">?</td>
-<td class="unknown obsolete" data-browser="safari16_6">?</td>
-<td class="unknown obsolete" data-browser="safari17">?</td>
-<td class="unknown obsolete" data-browser="safari17_1">?</td>
-<td class="unknown obsolete" data-browser="safari17_2">?</td>
-<td class="unknown obsolete" data-browser="safari17_3">?</td>
-<td class="unknown obsolete" data-browser="safari17_4">?</td>
-<td class="unknown" data-browser="safari17_5">?</td>
-<td class="unknown unstable" data-browser="safaritp">?</td>
-<td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera88">No</td>
-<td class="no obsolete" data-browser="opera89">No</td>
-<td class="no obsolete" data-browser="opera90">No</td>
-<td class="no obsolete" data-browser="opera91">No</td>
-<td class="no obsolete" data-browser="opera92">No</td>
-<td class="no obsolete" data-browser="opera93">No</td>
-<td class="no obsolete" data-browser="opera94">No</td>
-<td class="no obsolete" data-browser="opera95">No</td>
-<td class="no obsolete" data-browser="opera96">No</td>
-<td class="no obsolete" data-browser="opera97">No</td>
-<td class="no" data-browser="opera98">No</td>
-<td class="no unstable" data-browser="opera99">No</td>
-<td class="no obsolete" data-browser="rhino1_7_13">No</td>
-<td class="no obsolete" data-browser="rhino1_7_14">No</td>
-<td class="no obsolete" data-browser="rhino1_7_15">No</td>
-<td class="unknown obsolete" data-browser="phantom2_1">?</td>
-<td class="unknown obsolete" data-browser="node0_4">?</td>
-<td class="unknown obsolete" data-browser="node0_6">?</td>
-<td class="unknown obsolete" data-browser="node0_8">?</td>
-<td class="unknown obsolete" data-browser="node0_10">?</td>
-<td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node14_6">No</td>
-<td class="no obsolete" data-browser="node16_0">No</td>
-<td class="no obsolete" data-browser="node16_9">No</td>
-<td class="no" data-browser="node16_11">No</td>
-<td class="no obsolete" data-browser="node17_0">No</td>
-<td class="no obsolete" data-browser="node17_2">No</td>
-<td class="no obsolete" data-browser="node18_0">No</td>
-<td class="no" data-browser="node18_3">No</td>
-<td class="no obsolete" data-browser="node19_0">No</td>
-<td class="no obsolete" data-browser="node19_2">No</td>
-<td class="no" data-browser="node20_0">No</td>
-<td class="no obsolete" data-browser="node21_0">No</td>
-<td class="no" data-browser="node22_0">No</td>
-<td class="no obsolete" data-browser="duktape2_6">No</td>
-<td class="no" data-browser="duktape2_7">No</td>
-<td class="unknown obsolete" data-browser="graalvm19">?</td>
-<td class="unknown obsolete" data-browser="graalvm19_3_6">?</td>
-<td class="unknown obsolete" data-browser="graalvm20">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_1">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_3">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_3_1">?</td>
-<td class="unknown obsolete" data-browser="graalvm21">?</td>
-<td class="no" data-browser="graalvm21_3_3">No</td>
-<td class="no" data-browser="graalvm22_2">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
-<td class="no obsolete" data-browser="deno1_33">No</td>
-<td class="no obsolete" data-browser="deno1_34">No</td>
-<td class="no obsolete" data-browser="deno1_35">No</td>
-<td class="no" data-browser="deno1_36">No</td>
-<td class="unknown obsolete" data-browser="android4_4">?</td>
-<td class="unknown obsolete" data-browser="android4_4_3">?</td>
-<td class="unknown obsolete" data-browser="ios12_2">?</td>
-<td class="unknown obsolete" data-browser="ios13_4">?</td>
-<td class="unknown obsolete" data-browser="ios14_5">?</td>
-<td class="unknown obsolete" data-browser="ios16">?</td>
-<td class="unknown obsolete" data-browser="ios16_1">?</td>
-<td class="unknown obsolete" data-browser="ios16_2">?</td>
-<td class="unknown obsolete" data-browser="ios16_3">?</td>
-<td class="unknown obsolete" data-browser="ios16_4">?</td>
-<td class="unknown obsolete" data-browser="ios16_5">?</td>
-<td class="unknown obsolete" data-browser="ios16_6">?</td>
-<td class="unknown" data-browser="ios17">?</td>
-<td class="no obsolete" data-browser="samsung19">No</td>
-<td class="no obsolete" data-browser="samsung20">No</td>
-<td class="no obsolete" data-browser="samsung21">No</td>
-<td class="no" data-browser="samsung22">No</td>
-<td class="no obsolete" data-browser="opera_mobile72">No</td>
-<td class="no obsolete" data-browser="opera_mobile73">No</td>
-<td class="no obsolete" data-browser="opera_mobile74">No</td>
-<td class="no obsolete" data-browser="opera_mobile75">No</td>
-<td class="no obsolete" data-browser="opera_mobile76">No</td>
-<td class="no" data-browser="opera_mobile77">No</td>
-<td class="no" data-browser="reactnative0_70_3">No</td>
-</tr>
-<tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_AsyncIterator.prototype.every"><td><span><a class="anchor" href="#test-Iterator_Helpers_AsyncIterator.prototype.every">&#xA7;</a>AsyncIterator.prototype.every</span><script data-source="
-(async function*() { yield * [1, 2, 3] })().every(it =&gt; typeof it === &apos;number&apos;).then(it =&gt; {
-  if (it === true) asyncTestPassed();
-});
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("30");try{return Function("asyncTestPassed","\n(async function*() { yield * [1, 2, 3] })().every(it => typeof it === 'number').then(it => {\n  if (it === true) asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("30");return Function("asyncTestPassed","'use strict';"+"\n(async function*() { yield * [1, 2, 3] })().every(it => typeof it === 'number').then(it => {\n  if (it === true) asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
-</script></td>
-<td class="unknown obsolete" data-browser="tr">?</td>
-<td class="no obsolete" data-browser="babel6corejs2">No</td>
-<td class="no obsolete" data-browser="babel7corejs2">No</td>
-<td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200927">?</td>
-<td class="unknown obsolete" data-browser="closure20210808">?</td>
-<td class="unknown obsolete" data-browser="closure20210906">?</td>
-<td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown obsolete" data-browser="closure20220502">?</td>
-<td class="unknown obsolete" data-browser="closure20220719">?</td>
-<td class="unknown" data-browser="closure20230228">?</td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes" data-browser="typescript5_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox114">No</td>
-<td class="no" data-browser="firefox115">No</td>
-<td class="no obsolete" data-browser="firefox116">No</td>
-<td class="no obsolete" data-browser="firefox117">No</td>
-<td class="no obsolete" data-browser="firefox118">No</td>
-<td class="no obsolete" data-browser="firefox119">No</td>
-<td class="no obsolete" data-browser="firefox120">No</td>
-<td class="no obsolete" data-browser="firefox121">No</td>
-<td class="no obsolete" data-browser="firefox122">No</td>
-<td class="no obsolete" data-browser="firefox123">No</td>
-<td class="no obsolete" data-browser="firefox124">No</td>
-<td class="no obsolete" data-browser="firefox125">No</td>
-<td class="no obsolete" data-browser="firefox126">No</td>
-<td class="no" data-browser="firefox127">No</td>
-<td class="no unstable" data-browser="firefox128">No</td>
-<td class="no unstable" data-browser="firefox129">No</td>
-<td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome115">No</td>
-<td class="no obsolete" data-browser="chrome116">No</td>
-<td class="no obsolete" data-browser="chrome117">No</td>
-<td class="no obsolete" data-browser="chrome118">No</td>
-<td class="no obsolete" data-browser="chrome119">No</td>
-<td class="no obsolete" data-browser="chrome120">No</td>
-<td class="no obsolete" data-browser="chrome121">No</td>
-<td class="no obsolete" data-browser="chrome122">No</td>
-<td class="no obsolete" data-browser="chrome123">No</td>
-<td class="no obsolete" data-browser="chrome124">No</td>
-<td class="no obsolete" data-browser="chrome125">No</td>
-<td class="no" data-browser="chrome126">No</td>
-<td class="no unstable" data-browser="chrome127">No</td>
-<td class="no obsolete" data-browser="edge18">No</td>
-<td class="no obsolete" data-browser="edge115">No</td>
-<td class="no obsolete" data-browser="edge116">No</td>
-<td class="no obsolete" data-browser="edge117">No</td>
-<td class="no obsolete" data-browser="edge118">No</td>
-<td class="no obsolete" data-browser="edge119">No</td>
-<td class="no obsolete" data-browser="edge120">No</td>
-<td class="no obsolete" data-browser="edge121">No</td>
-<td class="no obsolete" data-browser="edge122">No</td>
-<td class="no obsolete" data-browser="edge123">No</td>
-<td class="no obsolete" data-browser="edge124">No</td>
-<td class="no obsolete" data-browser="edge125">No</td>
-<td class="no" data-browser="edge126">No</td>
-<td class="no unstable" data-browser="edge127">No</td>
-<td class="unknown obsolete" data-browser="safari15_6">?</td>
-<td class="unknown obsolete" data-browser="safari16_6">?</td>
-<td class="unknown obsolete" data-browser="safari17">?</td>
-<td class="unknown obsolete" data-browser="safari17_1">?</td>
-<td class="unknown obsolete" data-browser="safari17_2">?</td>
-<td class="unknown obsolete" data-browser="safari17_3">?</td>
-<td class="unknown obsolete" data-browser="safari17_4">?</td>
-<td class="unknown" data-browser="safari17_5">?</td>
-<td class="unknown unstable" data-browser="safaritp">?</td>
-<td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera88">No</td>
-<td class="no obsolete" data-browser="opera89">No</td>
-<td class="no obsolete" data-browser="opera90">No</td>
-<td class="no obsolete" data-browser="opera91">No</td>
-<td class="no obsolete" data-browser="opera92">No</td>
-<td class="no obsolete" data-browser="opera93">No</td>
-<td class="no obsolete" data-browser="opera94">No</td>
-<td class="no obsolete" data-browser="opera95">No</td>
-<td class="no obsolete" data-browser="opera96">No</td>
-<td class="no obsolete" data-browser="opera97">No</td>
-<td class="no" data-browser="opera98">No</td>
-<td class="no unstable" data-browser="opera99">No</td>
-<td class="no obsolete" data-browser="rhino1_7_13">No</td>
-<td class="no obsolete" data-browser="rhino1_7_14">No</td>
-<td class="no obsolete" data-browser="rhino1_7_15">No</td>
-<td class="unknown obsolete" data-browser="phantom2_1">?</td>
-<td class="unknown obsolete" data-browser="node0_4">?</td>
-<td class="unknown obsolete" data-browser="node0_6">?</td>
-<td class="unknown obsolete" data-browser="node0_8">?</td>
-<td class="unknown obsolete" data-browser="node0_10">?</td>
-<td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node14_6">No</td>
-<td class="no obsolete" data-browser="node16_0">No</td>
-<td class="no obsolete" data-browser="node16_9">No</td>
-<td class="no" data-browser="node16_11">No</td>
-<td class="no obsolete" data-browser="node17_0">No</td>
-<td class="no obsolete" data-browser="node17_2">No</td>
-<td class="no obsolete" data-browser="node18_0">No</td>
-<td class="no" data-browser="node18_3">No</td>
-<td class="no obsolete" data-browser="node19_0">No</td>
-<td class="no obsolete" data-browser="node19_2">No</td>
-<td class="no" data-browser="node20_0">No</td>
-<td class="no obsolete" data-browser="node21_0">No</td>
-<td class="no" data-browser="node22_0">No</td>
-<td class="no obsolete" data-browser="duktape2_6">No</td>
-<td class="no" data-browser="duktape2_7">No</td>
-<td class="unknown obsolete" data-browser="graalvm19">?</td>
-<td class="unknown obsolete" data-browser="graalvm19_3_6">?</td>
-<td class="unknown obsolete" data-browser="graalvm20">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_1">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_3">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_3_1">?</td>
-<td class="unknown obsolete" data-browser="graalvm21">?</td>
-<td class="no" data-browser="graalvm21_3_3">No</td>
-<td class="no" data-browser="graalvm22_2">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
-<td class="no obsolete" data-browser="deno1_33">No</td>
-<td class="no obsolete" data-browser="deno1_34">No</td>
-<td class="no obsolete" data-browser="deno1_35">No</td>
-<td class="no" data-browser="deno1_36">No</td>
-<td class="unknown obsolete" data-browser="android4_4">?</td>
-<td class="unknown obsolete" data-browser="android4_4_3">?</td>
-<td class="unknown obsolete" data-browser="ios12_2">?</td>
-<td class="unknown obsolete" data-browser="ios13_4">?</td>
-<td class="unknown obsolete" data-browser="ios14_5">?</td>
-<td class="unknown obsolete" data-browser="ios16">?</td>
-<td class="unknown obsolete" data-browser="ios16_1">?</td>
-<td class="unknown obsolete" data-browser="ios16_2">?</td>
-<td class="unknown obsolete" data-browser="ios16_3">?</td>
-<td class="unknown obsolete" data-browser="ios16_4">?</td>
-<td class="unknown obsolete" data-browser="ios16_5">?</td>
-<td class="unknown obsolete" data-browser="ios16_6">?</td>
-<td class="unknown" data-browser="ios17">?</td>
-<td class="no obsolete" data-browser="samsung19">No</td>
-<td class="no obsolete" data-browser="samsung20">No</td>
-<td class="no obsolete" data-browser="samsung21">No</td>
-<td class="no" data-browser="samsung22">No</td>
-<td class="no obsolete" data-browser="opera_mobile72">No</td>
-<td class="no obsolete" data-browser="opera_mobile73">No</td>
-<td class="no obsolete" data-browser="opera_mobile74">No</td>
-<td class="no obsolete" data-browser="opera_mobile75">No</td>
-<td class="no obsolete" data-browser="opera_mobile76">No</td>
-<td class="no" data-browser="opera_mobile77">No</td>
-<td class="no" data-browser="reactnative0_70_3">No</td>
-</tr>
-<tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_AsyncIterator.prototype.filter"><td><span><a class="anchor" href="#test-Iterator_Helpers_AsyncIterator.prototype.filter">&#xA7;</a>AsyncIterator.prototype.filter</span><script data-source="
-async function toArray(iterator) {
-  const result = [];
-  for await (const it of iterator) result.push(it);
-  return result;
-}
-
-toArray(async function*() { yield * [1, 2, 3] }().filter(it =&gt; it % 2)).then(it =&gt; {
-  if (it.join() === &apos;1,3&apos;) asyncTestPassed();
-});
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("31");try{return Function("asyncTestPassed","\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray(async function*() { yield * [1, 2, 3] }().filter(it => it % 2)).then(it => {\n  if (it.join() === '1,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("31");return Function("asyncTestPassed","'use strict';"+"\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray(async function*() { yield * [1, 2, 3] }().filter(it => it % 2)).then(it => {\n  if (it.join() === '1,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
-</script></td>
-<td class="unknown obsolete" data-browser="tr">?</td>
-<td class="no obsolete" data-browser="babel6corejs2">No</td>
-<td class="no obsolete" data-browser="babel7corejs2">No</td>
-<td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200927">?</td>
-<td class="unknown obsolete" data-browser="closure20210808">?</td>
-<td class="unknown obsolete" data-browser="closure20210906">?</td>
-<td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown obsolete" data-browser="closure20220502">?</td>
-<td class="unknown obsolete" data-browser="closure20220719">?</td>
-<td class="unknown" data-browser="closure20230228">?</td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes" data-browser="typescript5_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox114">No</td>
-<td class="no" data-browser="firefox115">No</td>
-<td class="no obsolete" data-browser="firefox116">No</td>
-<td class="no obsolete" data-browser="firefox117">No</td>
-<td class="no obsolete" data-browser="firefox118">No</td>
-<td class="no obsolete" data-browser="firefox119">No</td>
-<td class="no obsolete" data-browser="firefox120">No</td>
-<td class="no obsolete" data-browser="firefox121">No</td>
-<td class="no obsolete" data-browser="firefox122">No</td>
-<td class="no obsolete" data-browser="firefox123">No</td>
-<td class="no obsolete" data-browser="firefox124">No</td>
-<td class="no obsolete" data-browser="firefox125">No</td>
-<td class="no obsolete" data-browser="firefox126">No</td>
-<td class="no" data-browser="firefox127">No</td>
-<td class="no unstable" data-browser="firefox128">No</td>
-<td class="no unstable" data-browser="firefox129">No</td>
-<td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome115">No</td>
-<td class="no obsolete" data-browser="chrome116">No</td>
-<td class="no obsolete" data-browser="chrome117">No</td>
-<td class="no obsolete" data-browser="chrome118">No</td>
-<td class="no obsolete" data-browser="chrome119">No</td>
-<td class="no obsolete" data-browser="chrome120">No</td>
-<td class="no obsolete" data-browser="chrome121">No</td>
-<td class="no obsolete" data-browser="chrome122">No</td>
-<td class="no obsolete" data-browser="chrome123">No</td>
-<td class="no obsolete" data-browser="chrome124">No</td>
-<td class="no obsolete" data-browser="chrome125">No</td>
-<td class="no" data-browser="chrome126">No</td>
-<td class="no unstable" data-browser="chrome127">No</td>
-<td class="no obsolete" data-browser="edge18">No</td>
-<td class="no obsolete" data-browser="edge115">No</td>
-<td class="no obsolete" data-browser="edge116">No</td>
-<td class="no obsolete" data-browser="edge117">No</td>
-<td class="no obsolete" data-browser="edge118">No</td>
-<td class="no obsolete" data-browser="edge119">No</td>
-<td class="no obsolete" data-browser="edge120">No</td>
-<td class="no obsolete" data-browser="edge121">No</td>
-<td class="no obsolete" data-browser="edge122">No</td>
-<td class="no obsolete" data-browser="edge123">No</td>
-<td class="no obsolete" data-browser="edge124">No</td>
-<td class="no obsolete" data-browser="edge125">No</td>
-<td class="no" data-browser="edge126">No</td>
-<td class="no unstable" data-browser="edge127">No</td>
-<td class="unknown obsolete" data-browser="safari15_6">?</td>
-<td class="unknown obsolete" data-browser="safari16_6">?</td>
-<td class="unknown obsolete" data-browser="safari17">?</td>
-<td class="unknown obsolete" data-browser="safari17_1">?</td>
-<td class="unknown obsolete" data-browser="safari17_2">?</td>
-<td class="unknown obsolete" data-browser="safari17_3">?</td>
-<td class="unknown obsolete" data-browser="safari17_4">?</td>
-<td class="unknown" data-browser="safari17_5">?</td>
-<td class="unknown unstable" data-browser="safaritp">?</td>
-<td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera88">No</td>
-<td class="no obsolete" data-browser="opera89">No</td>
-<td class="no obsolete" data-browser="opera90">No</td>
-<td class="no obsolete" data-browser="opera91">No</td>
-<td class="no obsolete" data-browser="opera92">No</td>
-<td class="no obsolete" data-browser="opera93">No</td>
-<td class="no obsolete" data-browser="opera94">No</td>
-<td class="no obsolete" data-browser="opera95">No</td>
-<td class="no obsolete" data-browser="opera96">No</td>
-<td class="no obsolete" data-browser="opera97">No</td>
-<td class="no" data-browser="opera98">No</td>
-<td class="no unstable" data-browser="opera99">No</td>
-<td class="no obsolete" data-browser="rhino1_7_13">No</td>
-<td class="no obsolete" data-browser="rhino1_7_14">No</td>
-<td class="no obsolete" data-browser="rhino1_7_15">No</td>
-<td class="unknown obsolete" data-browser="phantom2_1">?</td>
-<td class="unknown obsolete" data-browser="node0_4">?</td>
-<td class="unknown obsolete" data-browser="node0_6">?</td>
-<td class="unknown obsolete" data-browser="node0_8">?</td>
-<td class="unknown obsolete" data-browser="node0_10">?</td>
-<td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node14_6">No</td>
-<td class="no obsolete" data-browser="node16_0">No</td>
-<td class="no obsolete" data-browser="node16_9">No</td>
-<td class="no" data-browser="node16_11">No</td>
-<td class="no obsolete" data-browser="node17_0">No</td>
-<td class="no obsolete" data-browser="node17_2">No</td>
-<td class="no obsolete" data-browser="node18_0">No</td>
-<td class="no" data-browser="node18_3">No</td>
-<td class="no obsolete" data-browser="node19_0">No</td>
-<td class="no obsolete" data-browser="node19_2">No</td>
-<td class="no" data-browser="node20_0">No</td>
-<td class="no obsolete" data-browser="node21_0">No</td>
-<td class="no" data-browser="node22_0">No</td>
-<td class="no obsolete" data-browser="duktape2_6">No</td>
-<td class="no" data-browser="duktape2_7">No</td>
-<td class="unknown obsolete" data-browser="graalvm19">?</td>
-<td class="unknown obsolete" data-browser="graalvm19_3_6">?</td>
-<td class="unknown obsolete" data-browser="graalvm20">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_1">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_3">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_3_1">?</td>
-<td class="unknown obsolete" data-browser="graalvm21">?</td>
-<td class="no" data-browser="graalvm21_3_3">No</td>
-<td class="no" data-browser="graalvm22_2">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
-<td class="no obsolete" data-browser="deno1_33">No</td>
-<td class="no obsolete" data-browser="deno1_34">No</td>
-<td class="no obsolete" data-browser="deno1_35">No</td>
-<td class="no" data-browser="deno1_36">No</td>
-<td class="unknown obsolete" data-browser="android4_4">?</td>
-<td class="unknown obsolete" data-browser="android4_4_3">?</td>
-<td class="unknown obsolete" data-browser="ios12_2">?</td>
-<td class="unknown obsolete" data-browser="ios13_4">?</td>
-<td class="unknown obsolete" data-browser="ios14_5">?</td>
-<td class="unknown obsolete" data-browser="ios16">?</td>
-<td class="unknown obsolete" data-browser="ios16_1">?</td>
-<td class="unknown obsolete" data-browser="ios16_2">?</td>
-<td class="unknown obsolete" data-browser="ios16_3">?</td>
-<td class="unknown obsolete" data-browser="ios16_4">?</td>
-<td class="unknown obsolete" data-browser="ios16_5">?</td>
-<td class="unknown obsolete" data-browser="ios16_6">?</td>
-<td class="unknown" data-browser="ios17">?</td>
-<td class="no obsolete" data-browser="samsung19">No</td>
-<td class="no obsolete" data-browser="samsung20">No</td>
-<td class="no obsolete" data-browser="samsung21">No</td>
-<td class="no" data-browser="samsung22">No</td>
-<td class="no obsolete" data-browser="opera_mobile72">No</td>
-<td class="no obsolete" data-browser="opera_mobile73">No</td>
-<td class="no obsolete" data-browser="opera_mobile74">No</td>
-<td class="no obsolete" data-browser="opera_mobile75">No</td>
-<td class="no obsolete" data-browser="opera_mobile76">No</td>
-<td class="no" data-browser="opera_mobile77">No</td>
-<td class="no" data-browser="reactnative0_70_3">No</td>
-</tr>
-<tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_AsyncIterator.prototype.find"><td><span><a class="anchor" href="#test-Iterator_Helpers_AsyncIterator.prototype.find">&#xA7;</a>AsyncIterator.prototype.find</span><script data-source="
-(async function*() { yield * [1, 2, 3] })().find(it =&gt; it % 2).then(it =&gt; {
-  if (it === 1) asyncTestPassed();
-});
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("32");try{return Function("asyncTestPassed","\n(async function*() { yield * [1, 2, 3] })().find(it => it % 2).then(it => {\n  if (it === 1) asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("32");return Function("asyncTestPassed","'use strict';"+"\n(async function*() { yield * [1, 2, 3] })().find(it => it % 2).then(it => {\n  if (it === 1) asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
-</script></td>
-<td class="unknown obsolete" data-browser="tr">?</td>
-<td class="no obsolete" data-browser="babel6corejs2">No</td>
-<td class="no obsolete" data-browser="babel7corejs2">No</td>
-<td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200927">?</td>
-<td class="unknown obsolete" data-browser="closure20210808">?</td>
-<td class="unknown obsolete" data-browser="closure20210906">?</td>
-<td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown obsolete" data-browser="closure20220502">?</td>
-<td class="unknown obsolete" data-browser="closure20220719">?</td>
-<td class="unknown" data-browser="closure20230228">?</td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes" data-browser="typescript5_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox114">No</td>
-<td class="no" data-browser="firefox115">No</td>
-<td class="no obsolete" data-browser="firefox116">No</td>
-<td class="no obsolete" data-browser="firefox117">No</td>
-<td class="no obsolete" data-browser="firefox118">No</td>
-<td class="no obsolete" data-browser="firefox119">No</td>
-<td class="no obsolete" data-browser="firefox120">No</td>
-<td class="no obsolete" data-browser="firefox121">No</td>
-<td class="no obsolete" data-browser="firefox122">No</td>
-<td class="no obsolete" data-browser="firefox123">No</td>
-<td class="no obsolete" data-browser="firefox124">No</td>
-<td class="no obsolete" data-browser="firefox125">No</td>
-<td class="no obsolete" data-browser="firefox126">No</td>
-<td class="no" data-browser="firefox127">No</td>
-<td class="no unstable" data-browser="firefox128">No</td>
-<td class="no unstable" data-browser="firefox129">No</td>
-<td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome115">No</td>
-<td class="no obsolete" data-browser="chrome116">No</td>
-<td class="no obsolete" data-browser="chrome117">No</td>
-<td class="no obsolete" data-browser="chrome118">No</td>
-<td class="no obsolete" data-browser="chrome119">No</td>
-<td class="no obsolete" data-browser="chrome120">No</td>
-<td class="no obsolete" data-browser="chrome121">No</td>
-<td class="no obsolete" data-browser="chrome122">No</td>
-<td class="no obsolete" data-browser="chrome123">No</td>
-<td class="no obsolete" data-browser="chrome124">No</td>
-<td class="no obsolete" data-browser="chrome125">No</td>
-<td class="no" data-browser="chrome126">No</td>
-<td class="no unstable" data-browser="chrome127">No</td>
-<td class="no obsolete" data-browser="edge18">No</td>
-<td class="no obsolete" data-browser="edge115">No</td>
-<td class="no obsolete" data-browser="edge116">No</td>
-<td class="no obsolete" data-browser="edge117">No</td>
-<td class="no obsolete" data-browser="edge118">No</td>
-<td class="no obsolete" data-browser="edge119">No</td>
-<td class="no obsolete" data-browser="edge120">No</td>
-<td class="no obsolete" data-browser="edge121">No</td>
-<td class="no obsolete" data-browser="edge122">No</td>
-<td class="no obsolete" data-browser="edge123">No</td>
-<td class="no obsolete" data-browser="edge124">No</td>
-<td class="no obsolete" data-browser="edge125">No</td>
-<td class="no" data-browser="edge126">No</td>
-<td class="no unstable" data-browser="edge127">No</td>
-<td class="unknown obsolete" data-browser="safari15_6">?</td>
-<td class="unknown obsolete" data-browser="safari16_6">?</td>
-<td class="unknown obsolete" data-browser="safari17">?</td>
-<td class="unknown obsolete" data-browser="safari17_1">?</td>
-<td class="unknown obsolete" data-browser="safari17_2">?</td>
-<td class="unknown obsolete" data-browser="safari17_3">?</td>
-<td class="unknown obsolete" data-browser="safari17_4">?</td>
-<td class="unknown" data-browser="safari17_5">?</td>
-<td class="unknown unstable" data-browser="safaritp">?</td>
-<td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera88">No</td>
-<td class="no obsolete" data-browser="opera89">No</td>
-<td class="no obsolete" data-browser="opera90">No</td>
-<td class="no obsolete" data-browser="opera91">No</td>
-<td class="no obsolete" data-browser="opera92">No</td>
-<td class="no obsolete" data-browser="opera93">No</td>
-<td class="no obsolete" data-browser="opera94">No</td>
-<td class="no obsolete" data-browser="opera95">No</td>
-<td class="no obsolete" data-browser="opera96">No</td>
-<td class="no obsolete" data-browser="opera97">No</td>
-<td class="no" data-browser="opera98">No</td>
-<td class="no unstable" data-browser="opera99">No</td>
-<td class="no obsolete" data-browser="rhino1_7_13">No</td>
-<td class="no obsolete" data-browser="rhino1_7_14">No</td>
-<td class="no obsolete" data-browser="rhino1_7_15">No</td>
-<td class="unknown obsolete" data-browser="phantom2_1">?</td>
-<td class="unknown obsolete" data-browser="node0_4">?</td>
-<td class="unknown obsolete" data-browser="node0_6">?</td>
-<td class="unknown obsolete" data-browser="node0_8">?</td>
-<td class="unknown obsolete" data-browser="node0_10">?</td>
-<td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node14_6">No</td>
-<td class="no obsolete" data-browser="node16_0">No</td>
-<td class="no obsolete" data-browser="node16_9">No</td>
-<td class="no" data-browser="node16_11">No</td>
-<td class="no obsolete" data-browser="node17_0">No</td>
-<td class="no obsolete" data-browser="node17_2">No</td>
-<td class="no obsolete" data-browser="node18_0">No</td>
-<td class="no" data-browser="node18_3">No</td>
-<td class="no obsolete" data-browser="node19_0">No</td>
-<td class="no obsolete" data-browser="node19_2">No</td>
-<td class="no" data-browser="node20_0">No</td>
-<td class="no obsolete" data-browser="node21_0">No</td>
-<td class="no" data-browser="node22_0">No</td>
-<td class="no obsolete" data-browser="duktape2_6">No</td>
-<td class="no" data-browser="duktape2_7">No</td>
-<td class="unknown obsolete" data-browser="graalvm19">?</td>
-<td class="unknown obsolete" data-browser="graalvm19_3_6">?</td>
-<td class="unknown obsolete" data-browser="graalvm20">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_1">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_3">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_3_1">?</td>
-<td class="unknown obsolete" data-browser="graalvm21">?</td>
-<td class="no" data-browser="graalvm21_3_3">No</td>
-<td class="no" data-browser="graalvm22_2">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
-<td class="no obsolete" data-browser="deno1_33">No</td>
-<td class="no obsolete" data-browser="deno1_34">No</td>
-<td class="no obsolete" data-browser="deno1_35">No</td>
-<td class="no" data-browser="deno1_36">No</td>
-<td class="unknown obsolete" data-browser="android4_4">?</td>
-<td class="unknown obsolete" data-browser="android4_4_3">?</td>
-<td class="unknown obsolete" data-browser="ios12_2">?</td>
-<td class="unknown obsolete" data-browser="ios13_4">?</td>
-<td class="unknown obsolete" data-browser="ios14_5">?</td>
-<td class="unknown obsolete" data-browser="ios16">?</td>
-<td class="unknown obsolete" data-browser="ios16_1">?</td>
-<td class="unknown obsolete" data-browser="ios16_2">?</td>
-<td class="unknown obsolete" data-browser="ios16_3">?</td>
-<td class="unknown obsolete" data-browser="ios16_4">?</td>
-<td class="unknown obsolete" data-browser="ios16_5">?</td>
-<td class="unknown obsolete" data-browser="ios16_6">?</td>
-<td class="unknown" data-browser="ios17">?</td>
-<td class="no obsolete" data-browser="samsung19">No</td>
-<td class="no obsolete" data-browser="samsung20">No</td>
-<td class="no obsolete" data-browser="samsung21">No</td>
-<td class="no" data-browser="samsung22">No</td>
-<td class="no obsolete" data-browser="opera_mobile72">No</td>
-<td class="no obsolete" data-browser="opera_mobile73">No</td>
-<td class="no obsolete" data-browser="opera_mobile74">No</td>
-<td class="no obsolete" data-browser="opera_mobile75">No</td>
-<td class="no obsolete" data-browser="opera_mobile76">No</td>
-<td class="no" data-browser="opera_mobile77">No</td>
-<td class="no" data-browser="reactnative0_70_3">No</td>
-</tr>
-<tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_AsyncIterator.prototype.flatMap"><td><span><a class="anchor" href="#test-Iterator_Helpers_AsyncIterator.prototype.flatMap">&#xA7;</a>AsyncIterator.prototype.flatMap</span><script data-source="
-async function toArray(iterator) {
-  const result = [];
-  for await (const it of iterator) result.push(it);
-  return result;
-}
-
-toArray(async function*() { yield * [1, 2, 3] }().flatMap(it =&gt; [it, 0])).then(it =&gt; {
-  if (it.join() === &apos;1,0,2,0,3,0&apos;) asyncTestPassed();
-});
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("33");try{return Function("asyncTestPassed","\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray(async function*() { yield * [1, 2, 3] }().flatMap(it => [it, 0])).then(it => {\n  if (it.join() === '1,0,2,0,3,0') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("33");return Function("asyncTestPassed","'use strict';"+"\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray(async function*() { yield * [1, 2, 3] }().flatMap(it => [it, 0])).then(it => {\n  if (it.join() === '1,0,2,0,3,0') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
-</script></td>
-<td class="unknown obsolete" data-browser="tr">?</td>
-<td class="no obsolete" data-browser="babel6corejs2">No</td>
-<td class="no obsolete" data-browser="babel7corejs2">No</td>
-<td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200927">?</td>
-<td class="unknown obsolete" data-browser="closure20210808">?</td>
-<td class="unknown obsolete" data-browser="closure20210906">?</td>
-<td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown obsolete" data-browser="closure20220502">?</td>
-<td class="unknown obsolete" data-browser="closure20220719">?</td>
-<td class="unknown" data-browser="closure20230228">?</td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes" data-browser="typescript5_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox114">No</td>
-<td class="no" data-browser="firefox115">No</td>
-<td class="no obsolete" data-browser="firefox116">No</td>
-<td class="no obsolete" data-browser="firefox117">No</td>
-<td class="no obsolete" data-browser="firefox118">No</td>
-<td class="no obsolete" data-browser="firefox119">No</td>
-<td class="no obsolete" data-browser="firefox120">No</td>
-<td class="no obsolete" data-browser="firefox121">No</td>
-<td class="no obsolete" data-browser="firefox122">No</td>
-<td class="no obsolete" data-browser="firefox123">No</td>
-<td class="no obsolete" data-browser="firefox124">No</td>
-<td class="no obsolete" data-browser="firefox125">No</td>
-<td class="no obsolete" data-browser="firefox126">No</td>
-<td class="no" data-browser="firefox127">No</td>
-<td class="no unstable" data-browser="firefox128">No</td>
-<td class="no unstable" data-browser="firefox129">No</td>
-<td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome115">No</td>
-<td class="no obsolete" data-browser="chrome116">No</td>
-<td class="no obsolete" data-browser="chrome117">No</td>
-<td class="no obsolete" data-browser="chrome118">No</td>
-<td class="no obsolete" data-browser="chrome119">No</td>
-<td class="no obsolete" data-browser="chrome120">No</td>
-<td class="no obsolete" data-browser="chrome121">No</td>
-<td class="no obsolete" data-browser="chrome122">No</td>
-<td class="no obsolete" data-browser="chrome123">No</td>
-<td class="no obsolete" data-browser="chrome124">No</td>
-<td class="no obsolete" data-browser="chrome125">No</td>
-<td class="no" data-browser="chrome126">No</td>
-<td class="no unstable" data-browser="chrome127">No</td>
-<td class="no obsolete" data-browser="edge18">No</td>
-<td class="no obsolete" data-browser="edge115">No</td>
-<td class="no obsolete" data-browser="edge116">No</td>
-<td class="no obsolete" data-browser="edge117">No</td>
-<td class="no obsolete" data-browser="edge118">No</td>
-<td class="no obsolete" data-browser="edge119">No</td>
-<td class="no obsolete" data-browser="edge120">No</td>
-<td class="no obsolete" data-browser="edge121">No</td>
-<td class="no obsolete" data-browser="edge122">No</td>
-<td class="no obsolete" data-browser="edge123">No</td>
-<td class="no obsolete" data-browser="edge124">No</td>
-<td class="no obsolete" data-browser="edge125">No</td>
-<td class="no" data-browser="edge126">No</td>
-<td class="no unstable" data-browser="edge127">No</td>
-<td class="unknown obsolete" data-browser="safari15_6">?</td>
-<td class="unknown obsolete" data-browser="safari16_6">?</td>
-<td class="unknown obsolete" data-browser="safari17">?</td>
-<td class="unknown obsolete" data-browser="safari17_1">?</td>
-<td class="unknown obsolete" data-browser="safari17_2">?</td>
-<td class="unknown obsolete" data-browser="safari17_3">?</td>
-<td class="unknown obsolete" data-browser="safari17_4">?</td>
-<td class="unknown" data-browser="safari17_5">?</td>
-<td class="unknown unstable" data-browser="safaritp">?</td>
-<td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera88">No</td>
-<td class="no obsolete" data-browser="opera89">No</td>
-<td class="no obsolete" data-browser="opera90">No</td>
-<td class="no obsolete" data-browser="opera91">No</td>
-<td class="no obsolete" data-browser="opera92">No</td>
-<td class="no obsolete" data-browser="opera93">No</td>
-<td class="no obsolete" data-browser="opera94">No</td>
-<td class="no obsolete" data-browser="opera95">No</td>
-<td class="no obsolete" data-browser="opera96">No</td>
-<td class="no obsolete" data-browser="opera97">No</td>
-<td class="no" data-browser="opera98">No</td>
-<td class="no unstable" data-browser="opera99">No</td>
-<td class="no obsolete" data-browser="rhino1_7_13">No</td>
-<td class="no obsolete" data-browser="rhino1_7_14">No</td>
-<td class="no obsolete" data-browser="rhino1_7_15">No</td>
-<td class="unknown obsolete" data-browser="phantom2_1">?</td>
-<td class="unknown obsolete" data-browser="node0_4">?</td>
-<td class="unknown obsolete" data-browser="node0_6">?</td>
-<td class="unknown obsolete" data-browser="node0_8">?</td>
-<td class="unknown obsolete" data-browser="node0_10">?</td>
-<td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node14_6">No</td>
-<td class="no obsolete" data-browser="node16_0">No</td>
-<td class="no obsolete" data-browser="node16_9">No</td>
-<td class="no" data-browser="node16_11">No</td>
-<td class="no obsolete" data-browser="node17_0">No</td>
-<td class="no obsolete" data-browser="node17_2">No</td>
-<td class="no obsolete" data-browser="node18_0">No</td>
-<td class="no" data-browser="node18_3">No</td>
-<td class="no obsolete" data-browser="node19_0">No</td>
-<td class="no obsolete" data-browser="node19_2">No</td>
-<td class="no" data-browser="node20_0">No</td>
-<td class="no obsolete" data-browser="node21_0">No</td>
-<td class="no" data-browser="node22_0">No</td>
-<td class="no obsolete" data-browser="duktape2_6">No</td>
-<td class="no" data-browser="duktape2_7">No</td>
-<td class="unknown obsolete" data-browser="graalvm19">?</td>
-<td class="unknown obsolete" data-browser="graalvm19_3_6">?</td>
-<td class="unknown obsolete" data-browser="graalvm20">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_1">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_3">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_3_1">?</td>
-<td class="unknown obsolete" data-browser="graalvm21">?</td>
-<td class="no" data-browser="graalvm21_3_3">No</td>
-<td class="no" data-browser="graalvm22_2">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
-<td class="no obsolete" data-browser="deno1_33">No</td>
-<td class="no obsolete" data-browser="deno1_34">No</td>
-<td class="no obsolete" data-browser="deno1_35">No</td>
-<td class="no" data-browser="deno1_36">No</td>
-<td class="unknown obsolete" data-browser="android4_4">?</td>
-<td class="unknown obsolete" data-browser="android4_4_3">?</td>
-<td class="unknown obsolete" data-browser="ios12_2">?</td>
-<td class="unknown obsolete" data-browser="ios13_4">?</td>
-<td class="unknown obsolete" data-browser="ios14_5">?</td>
-<td class="unknown obsolete" data-browser="ios16">?</td>
-<td class="unknown obsolete" data-browser="ios16_1">?</td>
-<td class="unknown obsolete" data-browser="ios16_2">?</td>
-<td class="unknown obsolete" data-browser="ios16_3">?</td>
-<td class="unknown obsolete" data-browser="ios16_4">?</td>
-<td class="unknown obsolete" data-browser="ios16_5">?</td>
-<td class="unknown obsolete" data-browser="ios16_6">?</td>
-<td class="unknown" data-browser="ios17">?</td>
-<td class="no obsolete" data-browser="samsung19">No</td>
-<td class="no obsolete" data-browser="samsung20">No</td>
-<td class="no obsolete" data-browser="samsung21">No</td>
-<td class="no" data-browser="samsung22">No</td>
-<td class="no obsolete" data-browser="opera_mobile72">No</td>
-<td class="no obsolete" data-browser="opera_mobile73">No</td>
-<td class="no obsolete" data-browser="opera_mobile74">No</td>
-<td class="no obsolete" data-browser="opera_mobile75">No</td>
-<td class="no obsolete" data-browser="opera_mobile76">No</td>
-<td class="no" data-browser="opera_mobile77">No</td>
-<td class="no" data-browser="reactnative0_70_3">No</td>
-</tr>
-<tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_AsyncIterator.prototype.forEach"><td><span><a class="anchor" href="#test-Iterator_Helpers_AsyncIterator.prototype.forEach">&#xA7;</a>AsyncIterator.prototype.forEach</span><script data-source="
-let result = &apos;&apos;;
-(async function*() { yield * [1, 2, 3] })().forEach(it =&gt; result += it).then(() =&gt; {
-  if (result === &apos;123&apos;) asyncTestPassed();
-});
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("34");try{return Function("asyncTestPassed","\nlet result = '';\n(async function*() { yield * [1, 2, 3] })().forEach(it => result += it).then(() => {\n  if (result === '123') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("34");return Function("asyncTestPassed","'use strict';"+"\nlet result = '';\n(async function*() { yield * [1, 2, 3] })().forEach(it => result += it).then(() => {\n  if (result === '123') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
-</script></td>
-<td class="unknown obsolete" data-browser="tr">?</td>
-<td class="no obsolete" data-browser="babel6corejs2">No</td>
-<td class="no obsolete" data-browser="babel7corejs2">No</td>
-<td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200927">?</td>
-<td class="unknown obsolete" data-browser="closure20210808">?</td>
-<td class="unknown obsolete" data-browser="closure20210906">?</td>
-<td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown obsolete" data-browser="closure20220502">?</td>
-<td class="unknown obsolete" data-browser="closure20220719">?</td>
-<td class="unknown" data-browser="closure20230228">?</td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes" data-browser="typescript5_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox114">No</td>
-<td class="no" data-browser="firefox115">No</td>
-<td class="no obsolete" data-browser="firefox116">No</td>
-<td class="no obsolete" data-browser="firefox117">No</td>
-<td class="no obsolete" data-browser="firefox118">No</td>
-<td class="no obsolete" data-browser="firefox119">No</td>
-<td class="no obsolete" data-browser="firefox120">No</td>
-<td class="no obsolete" data-browser="firefox121">No</td>
-<td class="no obsolete" data-browser="firefox122">No</td>
-<td class="no obsolete" data-browser="firefox123">No</td>
-<td class="no obsolete" data-browser="firefox124">No</td>
-<td class="no obsolete" data-browser="firefox125">No</td>
-<td class="no obsolete" data-browser="firefox126">No</td>
-<td class="no" data-browser="firefox127">No</td>
-<td class="no unstable" data-browser="firefox128">No</td>
-<td class="no unstable" data-browser="firefox129">No</td>
-<td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome115">No</td>
-<td class="no obsolete" data-browser="chrome116">No</td>
-<td class="no obsolete" data-browser="chrome117">No</td>
-<td class="no obsolete" data-browser="chrome118">No</td>
-<td class="no obsolete" data-browser="chrome119">No</td>
-<td class="no obsolete" data-browser="chrome120">No</td>
-<td class="no obsolete" data-browser="chrome121">No</td>
-<td class="no obsolete" data-browser="chrome122">No</td>
-<td class="no obsolete" data-browser="chrome123">No</td>
-<td class="no obsolete" data-browser="chrome124">No</td>
-<td class="no obsolete" data-browser="chrome125">No</td>
-<td class="no" data-browser="chrome126">No</td>
-<td class="no unstable" data-browser="chrome127">No</td>
-<td class="no obsolete" data-browser="edge18">No</td>
-<td class="no obsolete" data-browser="edge115">No</td>
-<td class="no obsolete" data-browser="edge116">No</td>
-<td class="no obsolete" data-browser="edge117">No</td>
-<td class="no obsolete" data-browser="edge118">No</td>
-<td class="no obsolete" data-browser="edge119">No</td>
-<td class="no obsolete" data-browser="edge120">No</td>
-<td class="no obsolete" data-browser="edge121">No</td>
-<td class="no obsolete" data-browser="edge122">No</td>
-<td class="no obsolete" data-browser="edge123">No</td>
-<td class="no obsolete" data-browser="edge124">No</td>
-<td class="no obsolete" data-browser="edge125">No</td>
-<td class="no" data-browser="edge126">No</td>
-<td class="no unstable" data-browser="edge127">No</td>
-<td class="unknown obsolete" data-browser="safari15_6">?</td>
-<td class="unknown obsolete" data-browser="safari16_6">?</td>
-<td class="unknown obsolete" data-browser="safari17">?</td>
-<td class="unknown obsolete" data-browser="safari17_1">?</td>
-<td class="unknown obsolete" data-browser="safari17_2">?</td>
-<td class="unknown obsolete" data-browser="safari17_3">?</td>
-<td class="unknown obsolete" data-browser="safari17_4">?</td>
-<td class="unknown" data-browser="safari17_5">?</td>
-<td class="unknown unstable" data-browser="safaritp">?</td>
-<td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera88">No</td>
-<td class="no obsolete" data-browser="opera89">No</td>
-<td class="no obsolete" data-browser="opera90">No</td>
-<td class="no obsolete" data-browser="opera91">No</td>
-<td class="no obsolete" data-browser="opera92">No</td>
-<td class="no obsolete" data-browser="opera93">No</td>
-<td class="no obsolete" data-browser="opera94">No</td>
-<td class="no obsolete" data-browser="opera95">No</td>
-<td class="no obsolete" data-browser="opera96">No</td>
-<td class="no obsolete" data-browser="opera97">No</td>
-<td class="no" data-browser="opera98">No</td>
-<td class="no unstable" data-browser="opera99">No</td>
-<td class="no obsolete" data-browser="rhino1_7_13">No</td>
-<td class="no obsolete" data-browser="rhino1_7_14">No</td>
-<td class="no obsolete" data-browser="rhino1_7_15">No</td>
-<td class="unknown obsolete" data-browser="phantom2_1">?</td>
-<td class="unknown obsolete" data-browser="node0_4">?</td>
-<td class="unknown obsolete" data-browser="node0_6">?</td>
-<td class="unknown obsolete" data-browser="node0_8">?</td>
-<td class="unknown obsolete" data-browser="node0_10">?</td>
-<td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node14_6">No</td>
-<td class="no obsolete" data-browser="node16_0">No</td>
-<td class="no obsolete" data-browser="node16_9">No</td>
-<td class="no" data-browser="node16_11">No</td>
-<td class="no obsolete" data-browser="node17_0">No</td>
-<td class="no obsolete" data-browser="node17_2">No</td>
-<td class="no obsolete" data-browser="node18_0">No</td>
-<td class="no" data-browser="node18_3">No</td>
-<td class="no obsolete" data-browser="node19_0">No</td>
-<td class="no obsolete" data-browser="node19_2">No</td>
-<td class="no" data-browser="node20_0">No</td>
-<td class="no obsolete" data-browser="node21_0">No</td>
-<td class="no" data-browser="node22_0">No</td>
-<td class="no obsolete" data-browser="duktape2_6">No</td>
-<td class="no" data-browser="duktape2_7">No</td>
-<td class="unknown obsolete" data-browser="graalvm19">?</td>
-<td class="unknown obsolete" data-browser="graalvm19_3_6">?</td>
-<td class="unknown obsolete" data-browser="graalvm20">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_1">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_3">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_3_1">?</td>
-<td class="unknown obsolete" data-browser="graalvm21">?</td>
-<td class="no" data-browser="graalvm21_3_3">No</td>
-<td class="no" data-browser="graalvm22_2">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
-<td class="no obsolete" data-browser="deno1_33">No</td>
-<td class="no obsolete" data-browser="deno1_34">No</td>
-<td class="no obsolete" data-browser="deno1_35">No</td>
-<td class="no" data-browser="deno1_36">No</td>
-<td class="unknown obsolete" data-browser="android4_4">?</td>
-<td class="unknown obsolete" data-browser="android4_4_3">?</td>
-<td class="unknown obsolete" data-browser="ios12_2">?</td>
-<td class="unknown obsolete" data-browser="ios13_4">?</td>
-<td class="unknown obsolete" data-browser="ios14_5">?</td>
-<td class="unknown obsolete" data-browser="ios16">?</td>
-<td class="unknown obsolete" data-browser="ios16_1">?</td>
-<td class="unknown obsolete" data-browser="ios16_2">?</td>
-<td class="unknown obsolete" data-browser="ios16_3">?</td>
-<td class="unknown obsolete" data-browser="ios16_4">?</td>
-<td class="unknown obsolete" data-browser="ios16_5">?</td>
-<td class="unknown obsolete" data-browser="ios16_6">?</td>
-<td class="unknown" data-browser="ios17">?</td>
-<td class="no obsolete" data-browser="samsung19">No</td>
-<td class="no obsolete" data-browser="samsung20">No</td>
-<td class="no obsolete" data-browser="samsung21">No</td>
-<td class="no" data-browser="samsung22">No</td>
-<td class="no obsolete" data-browser="opera_mobile72">No</td>
-<td class="no obsolete" data-browser="opera_mobile73">No</td>
-<td class="no obsolete" data-browser="opera_mobile74">No</td>
-<td class="no obsolete" data-browser="opera_mobile75">No</td>
-<td class="no obsolete" data-browser="opera_mobile76">No</td>
-<td class="no" data-browser="opera_mobile77">No</td>
-<td class="no" data-browser="reactnative0_70_3">No</td>
-</tr>
-<tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_AsyncIterator.prototype.map"><td><span><a class="anchor" href="#test-Iterator_Helpers_AsyncIterator.prototype.map">&#xA7;</a>AsyncIterator.prototype.map</span><script data-source="
-async function toArray(iterator) {
-  const result = [];
-  for await (const it of iterator) result.push(it);
-  return result;
-}
-
-toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it =&gt; {
-  if (it.join() === &apos;1,4,9&apos;) asyncTestPassed();
-});
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("35");try{return Function("asyncTestPassed","\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray(async function*() { yield * [1, 2, 3] }().map(it => it * it)).then(it => {\n  if (it.join() === '1,4,9') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("35");return Function("asyncTestPassed","'use strict';"+"\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray(async function*() { yield * [1, 2, 3] }().map(it => it * it)).then(it => {\n  if (it.join() === '1,4,9') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
-</script></td>
-<td class="unknown obsolete" data-browser="tr">?</td>
-<td class="no obsolete" data-browser="babel6corejs2">No</td>
-<td class="no obsolete" data-browser="babel7corejs2">No</td>
-<td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200927">?</td>
-<td class="unknown obsolete" data-browser="closure20210808">?</td>
-<td class="unknown obsolete" data-browser="closure20210906">?</td>
-<td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown obsolete" data-browser="closure20220502">?</td>
-<td class="unknown obsolete" data-browser="closure20220719">?</td>
-<td class="unknown" data-browser="closure20230228">?</td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes" data-browser="typescript5_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox114">No</td>
-<td class="no" data-browser="firefox115">No</td>
-<td class="no obsolete" data-browser="firefox116">No</td>
-<td class="no obsolete" data-browser="firefox117">No</td>
-<td class="no obsolete" data-browser="firefox118">No</td>
-<td class="no obsolete" data-browser="firefox119">No</td>
-<td class="no obsolete" data-browser="firefox120">No</td>
-<td class="no obsolete" data-browser="firefox121">No</td>
-<td class="no obsolete" data-browser="firefox122">No</td>
-<td class="no obsolete" data-browser="firefox123">No</td>
-<td class="no obsolete" data-browser="firefox124">No</td>
-<td class="no obsolete" data-browser="firefox125">No</td>
-<td class="no obsolete" data-browser="firefox126">No</td>
-<td class="no" data-browser="firefox127">No</td>
-<td class="no unstable" data-browser="firefox128">No</td>
-<td class="no unstable" data-browser="firefox129">No</td>
-<td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome115">No</td>
-<td class="no obsolete" data-browser="chrome116">No</td>
-<td class="no obsolete" data-browser="chrome117">No</td>
-<td class="no obsolete" data-browser="chrome118">No</td>
-<td class="no obsolete" data-browser="chrome119">No</td>
-<td class="no obsolete" data-browser="chrome120">No</td>
-<td class="no obsolete" data-browser="chrome121">No</td>
-<td class="no obsolete" data-browser="chrome122">No</td>
-<td class="no obsolete" data-browser="chrome123">No</td>
-<td class="no obsolete" data-browser="chrome124">No</td>
-<td class="no obsolete" data-browser="chrome125">No</td>
-<td class="no" data-browser="chrome126">No</td>
-<td class="no unstable" data-browser="chrome127">No</td>
-<td class="no obsolete" data-browser="edge18">No</td>
-<td class="no obsolete" data-browser="edge115">No</td>
-<td class="no obsolete" data-browser="edge116">No</td>
-<td class="no obsolete" data-browser="edge117">No</td>
-<td class="no obsolete" data-browser="edge118">No</td>
-<td class="no obsolete" data-browser="edge119">No</td>
-<td class="no obsolete" data-browser="edge120">No</td>
-<td class="no obsolete" data-browser="edge121">No</td>
-<td class="no obsolete" data-browser="edge122">No</td>
-<td class="no obsolete" data-browser="edge123">No</td>
-<td class="no obsolete" data-browser="edge124">No</td>
-<td class="no obsolete" data-browser="edge125">No</td>
-<td class="no" data-browser="edge126">No</td>
-<td class="no unstable" data-browser="edge127">No</td>
-<td class="unknown obsolete" data-browser="safari15_6">?</td>
-<td class="unknown obsolete" data-browser="safari16_6">?</td>
-<td class="unknown obsolete" data-browser="safari17">?</td>
-<td class="unknown obsolete" data-browser="safari17_1">?</td>
-<td class="unknown obsolete" data-browser="safari17_2">?</td>
-<td class="unknown obsolete" data-browser="safari17_3">?</td>
-<td class="unknown obsolete" data-browser="safari17_4">?</td>
-<td class="unknown" data-browser="safari17_5">?</td>
-<td class="unknown unstable" data-browser="safaritp">?</td>
-<td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera88">No</td>
-<td class="no obsolete" data-browser="opera89">No</td>
-<td class="no obsolete" data-browser="opera90">No</td>
-<td class="no obsolete" data-browser="opera91">No</td>
-<td class="no obsolete" data-browser="opera92">No</td>
-<td class="no obsolete" data-browser="opera93">No</td>
-<td class="no obsolete" data-browser="opera94">No</td>
-<td class="no obsolete" data-browser="opera95">No</td>
-<td class="no obsolete" data-browser="opera96">No</td>
-<td class="no obsolete" data-browser="opera97">No</td>
-<td class="no" data-browser="opera98">No</td>
-<td class="no unstable" data-browser="opera99">No</td>
-<td class="no obsolete" data-browser="rhino1_7_13">No</td>
-<td class="no obsolete" data-browser="rhino1_7_14">No</td>
-<td class="no obsolete" data-browser="rhino1_7_15">No</td>
-<td class="unknown obsolete" data-browser="phantom2_1">?</td>
-<td class="unknown obsolete" data-browser="node0_4">?</td>
-<td class="unknown obsolete" data-browser="node0_6">?</td>
-<td class="unknown obsolete" data-browser="node0_8">?</td>
-<td class="unknown obsolete" data-browser="node0_10">?</td>
-<td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node14_6">No</td>
-<td class="no obsolete" data-browser="node16_0">No</td>
-<td class="no obsolete" data-browser="node16_9">No</td>
-<td class="no" data-browser="node16_11">No</td>
-<td class="no obsolete" data-browser="node17_0">No</td>
-<td class="no obsolete" data-browser="node17_2">No</td>
-<td class="no obsolete" data-browser="node18_0">No</td>
-<td class="no" data-browser="node18_3">No</td>
-<td class="no obsolete" data-browser="node19_0">No</td>
-<td class="no obsolete" data-browser="node19_2">No</td>
-<td class="no" data-browser="node20_0">No</td>
-<td class="no obsolete" data-browser="node21_0">No</td>
-<td class="no" data-browser="node22_0">No</td>
-<td class="no obsolete" data-browser="duktape2_6">No</td>
-<td class="no" data-browser="duktape2_7">No</td>
-<td class="unknown obsolete" data-browser="graalvm19">?</td>
-<td class="unknown obsolete" data-browser="graalvm19_3_6">?</td>
-<td class="unknown obsolete" data-browser="graalvm20">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_1">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_3">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_3_1">?</td>
-<td class="unknown obsolete" data-browser="graalvm21">?</td>
-<td class="no" data-browser="graalvm21_3_3">No</td>
-<td class="no" data-browser="graalvm22_2">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
-<td class="no obsolete" data-browser="deno1_33">No</td>
-<td class="no obsolete" data-browser="deno1_34">No</td>
-<td class="no obsolete" data-browser="deno1_35">No</td>
-<td class="no" data-browser="deno1_36">No</td>
-<td class="unknown obsolete" data-browser="android4_4">?</td>
-<td class="unknown obsolete" data-browser="android4_4_3">?</td>
-<td class="unknown obsolete" data-browser="ios12_2">?</td>
-<td class="unknown obsolete" data-browser="ios13_4">?</td>
-<td class="unknown obsolete" data-browser="ios14_5">?</td>
-<td class="unknown obsolete" data-browser="ios16">?</td>
-<td class="unknown obsolete" data-browser="ios16_1">?</td>
-<td class="unknown obsolete" data-browser="ios16_2">?</td>
-<td class="unknown obsolete" data-browser="ios16_3">?</td>
-<td class="unknown obsolete" data-browser="ios16_4">?</td>
-<td class="unknown obsolete" data-browser="ios16_5">?</td>
-<td class="unknown obsolete" data-browser="ios16_6">?</td>
-<td class="unknown" data-browser="ios17">?</td>
-<td class="no obsolete" data-browser="samsung19">No</td>
-<td class="no obsolete" data-browser="samsung20">No</td>
-<td class="no obsolete" data-browser="samsung21">No</td>
-<td class="no" data-browser="samsung22">No</td>
-<td class="no obsolete" data-browser="opera_mobile72">No</td>
-<td class="no obsolete" data-browser="opera_mobile73">No</td>
-<td class="no obsolete" data-browser="opera_mobile74">No</td>
-<td class="no obsolete" data-browser="opera_mobile75">No</td>
-<td class="no obsolete" data-browser="opera_mobile76">No</td>
-<td class="no" data-browser="opera_mobile77">No</td>
-<td class="no" data-browser="reactnative0_70_3">No</td>
-</tr>
-<tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_AsyncIterator.prototype.reduce"><td><span><a class="anchor" href="#test-Iterator_Helpers_AsyncIterator.prototype.reduce">&#xA7;</a>AsyncIterator.prototype.reduce</span><script data-source="
-(async function*() { yield * [1, 2, 3] })().reduce((a, b) =&gt; a + b).then(it =&gt; {
-  if (it === 6) asyncTestPassed();
-});
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("36");try{return Function("asyncTestPassed","\n(async function*() { yield * [1, 2, 3] })().reduce((a, b) => a + b).then(it => {\n  if (it === 6) asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("36");return Function("asyncTestPassed","'use strict';"+"\n(async function*() { yield * [1, 2, 3] })().reduce((a, b) => a + b).then(it => {\n  if (it === 6) asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
-</script></td>
-<td class="unknown obsolete" data-browser="tr">?</td>
-<td class="no obsolete" data-browser="babel6corejs2">No</td>
-<td class="no obsolete" data-browser="babel7corejs2">No</td>
-<td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200927">?</td>
-<td class="unknown obsolete" data-browser="closure20210808">?</td>
-<td class="unknown obsolete" data-browser="closure20210906">?</td>
-<td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown obsolete" data-browser="closure20220502">?</td>
-<td class="unknown obsolete" data-browser="closure20220719">?</td>
-<td class="unknown" data-browser="closure20230228">?</td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes" data-browser="typescript5_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox114">No</td>
-<td class="no" data-browser="firefox115">No</td>
-<td class="no obsolete" data-browser="firefox116">No</td>
-<td class="no obsolete" data-browser="firefox117">No</td>
-<td class="no obsolete" data-browser="firefox118">No</td>
-<td class="no obsolete" data-browser="firefox119">No</td>
-<td class="no obsolete" data-browser="firefox120">No</td>
-<td class="no obsolete" data-browser="firefox121">No</td>
-<td class="no obsolete" data-browser="firefox122">No</td>
-<td class="no obsolete" data-browser="firefox123">No</td>
-<td class="no obsolete" data-browser="firefox124">No</td>
-<td class="no obsolete" data-browser="firefox125">No</td>
-<td class="no obsolete" data-browser="firefox126">No</td>
-<td class="no" data-browser="firefox127">No</td>
-<td class="no unstable" data-browser="firefox128">No</td>
-<td class="no unstable" data-browser="firefox129">No</td>
-<td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome115">No</td>
-<td class="no obsolete" data-browser="chrome116">No</td>
-<td class="no obsolete" data-browser="chrome117">No</td>
-<td class="no obsolete" data-browser="chrome118">No</td>
-<td class="no obsolete" data-browser="chrome119">No</td>
-<td class="no obsolete" data-browser="chrome120">No</td>
-<td class="no obsolete" data-browser="chrome121">No</td>
-<td class="no obsolete" data-browser="chrome122">No</td>
-<td class="no obsolete" data-browser="chrome123">No</td>
-<td class="no obsolete" data-browser="chrome124">No</td>
-<td class="no obsolete" data-browser="chrome125">No</td>
-<td class="no" data-browser="chrome126">No</td>
-<td class="no unstable" data-browser="chrome127">No</td>
-<td class="no obsolete" data-browser="edge18">No</td>
-<td class="no obsolete" data-browser="edge115">No</td>
-<td class="no obsolete" data-browser="edge116">No</td>
-<td class="no obsolete" data-browser="edge117">No</td>
-<td class="no obsolete" data-browser="edge118">No</td>
-<td class="no obsolete" data-browser="edge119">No</td>
-<td class="no obsolete" data-browser="edge120">No</td>
-<td class="no obsolete" data-browser="edge121">No</td>
-<td class="no obsolete" data-browser="edge122">No</td>
-<td class="no obsolete" data-browser="edge123">No</td>
-<td class="no obsolete" data-browser="edge124">No</td>
-<td class="no obsolete" data-browser="edge125">No</td>
-<td class="no" data-browser="edge126">No</td>
-<td class="no unstable" data-browser="edge127">No</td>
-<td class="unknown obsolete" data-browser="safari15_6">?</td>
-<td class="unknown obsolete" data-browser="safari16_6">?</td>
-<td class="unknown obsolete" data-browser="safari17">?</td>
-<td class="unknown obsolete" data-browser="safari17_1">?</td>
-<td class="unknown obsolete" data-browser="safari17_2">?</td>
-<td class="unknown obsolete" data-browser="safari17_3">?</td>
-<td class="unknown obsolete" data-browser="safari17_4">?</td>
-<td class="unknown" data-browser="safari17_5">?</td>
-<td class="unknown unstable" data-browser="safaritp">?</td>
-<td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera88">No</td>
-<td class="no obsolete" data-browser="opera89">No</td>
-<td class="no obsolete" data-browser="opera90">No</td>
-<td class="no obsolete" data-browser="opera91">No</td>
-<td class="no obsolete" data-browser="opera92">No</td>
-<td class="no obsolete" data-browser="opera93">No</td>
-<td class="no obsolete" data-browser="opera94">No</td>
-<td class="no obsolete" data-browser="opera95">No</td>
-<td class="no obsolete" data-browser="opera96">No</td>
-<td class="no obsolete" data-browser="opera97">No</td>
-<td class="no" data-browser="opera98">No</td>
-<td class="no unstable" data-browser="opera99">No</td>
-<td class="no obsolete" data-browser="rhino1_7_13">No</td>
-<td class="no obsolete" data-browser="rhino1_7_14">No</td>
-<td class="no obsolete" data-browser="rhino1_7_15">No</td>
-<td class="unknown obsolete" data-browser="phantom2_1">?</td>
-<td class="unknown obsolete" data-browser="node0_4">?</td>
-<td class="unknown obsolete" data-browser="node0_6">?</td>
-<td class="unknown obsolete" data-browser="node0_8">?</td>
-<td class="unknown obsolete" data-browser="node0_10">?</td>
-<td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node14_6">No</td>
-<td class="no obsolete" data-browser="node16_0">No</td>
-<td class="no obsolete" data-browser="node16_9">No</td>
-<td class="no" data-browser="node16_11">No</td>
-<td class="no obsolete" data-browser="node17_0">No</td>
-<td class="no obsolete" data-browser="node17_2">No</td>
-<td class="no obsolete" data-browser="node18_0">No</td>
-<td class="no" data-browser="node18_3">No</td>
-<td class="no obsolete" data-browser="node19_0">No</td>
-<td class="no obsolete" data-browser="node19_2">No</td>
-<td class="no" data-browser="node20_0">No</td>
-<td class="no obsolete" data-browser="node21_0">No</td>
-<td class="no" data-browser="node22_0">No</td>
-<td class="no obsolete" data-browser="duktape2_6">No</td>
-<td class="no" data-browser="duktape2_7">No</td>
-<td class="unknown obsolete" data-browser="graalvm19">?</td>
-<td class="unknown obsolete" data-browser="graalvm19_3_6">?</td>
-<td class="unknown obsolete" data-browser="graalvm20">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_1">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_3">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_3_1">?</td>
-<td class="unknown obsolete" data-browser="graalvm21">?</td>
-<td class="no" data-browser="graalvm21_3_3">No</td>
-<td class="no" data-browser="graalvm22_2">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
-<td class="no obsolete" data-browser="deno1_33">No</td>
-<td class="no obsolete" data-browser="deno1_34">No</td>
-<td class="no obsolete" data-browser="deno1_35">No</td>
-<td class="no" data-browser="deno1_36">No</td>
-<td class="unknown obsolete" data-browser="android4_4">?</td>
-<td class="unknown obsolete" data-browser="android4_4_3">?</td>
-<td class="unknown obsolete" data-browser="ios12_2">?</td>
-<td class="unknown obsolete" data-browser="ios13_4">?</td>
-<td class="unknown obsolete" data-browser="ios14_5">?</td>
-<td class="unknown obsolete" data-browser="ios16">?</td>
-<td class="unknown obsolete" data-browser="ios16_1">?</td>
-<td class="unknown obsolete" data-browser="ios16_2">?</td>
-<td class="unknown obsolete" data-browser="ios16_3">?</td>
-<td class="unknown obsolete" data-browser="ios16_4">?</td>
-<td class="unknown obsolete" data-browser="ios16_5">?</td>
-<td class="unknown obsolete" data-browser="ios16_6">?</td>
-<td class="unknown" data-browser="ios17">?</td>
-<td class="no obsolete" data-browser="samsung19">No</td>
-<td class="no obsolete" data-browser="samsung20">No</td>
-<td class="no obsolete" data-browser="samsung21">No</td>
-<td class="no" data-browser="samsung22">No</td>
-<td class="no obsolete" data-browser="opera_mobile72">No</td>
-<td class="no obsolete" data-browser="opera_mobile73">No</td>
-<td class="no obsolete" data-browser="opera_mobile74">No</td>
-<td class="no obsolete" data-browser="opera_mobile75">No</td>
-<td class="no obsolete" data-browser="opera_mobile76">No</td>
-<td class="no" data-browser="opera_mobile77">No</td>
-<td class="no" data-browser="reactnative0_70_3">No</td>
-</tr>
-<tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_AsyncIterator.prototype.some"><td><span><a class="anchor" href="#test-Iterator_Helpers_AsyncIterator.prototype.some">&#xA7;</a>AsyncIterator.prototype.some</span><script data-source="
-(async function*() { yield * [1, 2, 3] })().some(it =&gt; typeof it === &apos;number&apos;).then(it =&gt; {
-  if (it === true) asyncTestPassed();
-});
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("37");try{return Function("asyncTestPassed","\n(async function*() { yield * [1, 2, 3] })().some(it => typeof it === 'number').then(it => {\n  if (it === true) asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("37");return Function("asyncTestPassed","'use strict';"+"\n(async function*() { yield * [1, 2, 3] })().some(it => typeof it === 'number').then(it => {\n  if (it === true) asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
-</script></td>
-<td class="unknown obsolete" data-browser="tr">?</td>
-<td class="no obsolete" data-browser="babel6corejs2">No</td>
-<td class="no obsolete" data-browser="babel7corejs2">No</td>
-<td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200927">?</td>
-<td class="unknown obsolete" data-browser="closure20210808">?</td>
-<td class="unknown obsolete" data-browser="closure20210906">?</td>
-<td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown obsolete" data-browser="closure20220502">?</td>
-<td class="unknown obsolete" data-browser="closure20220719">?</td>
-<td class="unknown" data-browser="closure20230228">?</td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes" data-browser="typescript5_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox114">No</td>
-<td class="no" data-browser="firefox115">No</td>
-<td class="no obsolete" data-browser="firefox116">No</td>
-<td class="no obsolete" data-browser="firefox117">No</td>
-<td class="no obsolete" data-browser="firefox118">No</td>
-<td class="no obsolete" data-browser="firefox119">No</td>
-<td class="no obsolete" data-browser="firefox120">No</td>
-<td class="no obsolete" data-browser="firefox121">No</td>
-<td class="no obsolete" data-browser="firefox122">No</td>
-<td class="no obsolete" data-browser="firefox123">No</td>
-<td class="no obsolete" data-browser="firefox124">No</td>
-<td class="no obsolete" data-browser="firefox125">No</td>
-<td class="no obsolete" data-browser="firefox126">No</td>
-<td class="no" data-browser="firefox127">No</td>
-<td class="no unstable" data-browser="firefox128">No</td>
-<td class="no unstable" data-browser="firefox129">No</td>
-<td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome115">No</td>
-<td class="no obsolete" data-browser="chrome116">No</td>
-<td class="no obsolete" data-browser="chrome117">No</td>
-<td class="no obsolete" data-browser="chrome118">No</td>
-<td class="no obsolete" data-browser="chrome119">No</td>
-<td class="no obsolete" data-browser="chrome120">No</td>
-<td class="no obsolete" data-browser="chrome121">No</td>
-<td class="no obsolete" data-browser="chrome122">No</td>
-<td class="no obsolete" data-browser="chrome123">No</td>
-<td class="no obsolete" data-browser="chrome124">No</td>
-<td class="no obsolete" data-browser="chrome125">No</td>
-<td class="no" data-browser="chrome126">No</td>
-<td class="no unstable" data-browser="chrome127">No</td>
-<td class="no obsolete" data-browser="edge18">No</td>
-<td class="no obsolete" data-browser="edge115">No</td>
-<td class="no obsolete" data-browser="edge116">No</td>
-<td class="no obsolete" data-browser="edge117">No</td>
-<td class="no obsolete" data-browser="edge118">No</td>
-<td class="no obsolete" data-browser="edge119">No</td>
-<td class="no obsolete" data-browser="edge120">No</td>
-<td class="no obsolete" data-browser="edge121">No</td>
-<td class="no obsolete" data-browser="edge122">No</td>
-<td class="no obsolete" data-browser="edge123">No</td>
-<td class="no obsolete" data-browser="edge124">No</td>
-<td class="no obsolete" data-browser="edge125">No</td>
-<td class="no" data-browser="edge126">No</td>
-<td class="no unstable" data-browser="edge127">No</td>
-<td class="unknown obsolete" data-browser="safari15_6">?</td>
-<td class="unknown obsolete" data-browser="safari16_6">?</td>
-<td class="unknown obsolete" data-browser="safari17">?</td>
-<td class="unknown obsolete" data-browser="safari17_1">?</td>
-<td class="unknown obsolete" data-browser="safari17_2">?</td>
-<td class="unknown obsolete" data-browser="safari17_3">?</td>
-<td class="unknown obsolete" data-browser="safari17_4">?</td>
-<td class="unknown" data-browser="safari17_5">?</td>
-<td class="unknown unstable" data-browser="safaritp">?</td>
-<td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera88">No</td>
-<td class="no obsolete" data-browser="opera89">No</td>
-<td class="no obsolete" data-browser="opera90">No</td>
-<td class="no obsolete" data-browser="opera91">No</td>
-<td class="no obsolete" data-browser="opera92">No</td>
-<td class="no obsolete" data-browser="opera93">No</td>
-<td class="no obsolete" data-browser="opera94">No</td>
-<td class="no obsolete" data-browser="opera95">No</td>
-<td class="no obsolete" data-browser="opera96">No</td>
-<td class="no obsolete" data-browser="opera97">No</td>
-<td class="no" data-browser="opera98">No</td>
-<td class="no unstable" data-browser="opera99">No</td>
-<td class="no obsolete" data-browser="rhino1_7_13">No</td>
-<td class="no obsolete" data-browser="rhino1_7_14">No</td>
-<td class="no obsolete" data-browser="rhino1_7_15">No</td>
-<td class="unknown obsolete" data-browser="phantom2_1">?</td>
-<td class="unknown obsolete" data-browser="node0_4">?</td>
-<td class="unknown obsolete" data-browser="node0_6">?</td>
-<td class="unknown obsolete" data-browser="node0_8">?</td>
-<td class="unknown obsolete" data-browser="node0_10">?</td>
-<td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node14_6">No</td>
-<td class="no obsolete" data-browser="node16_0">No</td>
-<td class="no obsolete" data-browser="node16_9">No</td>
-<td class="no" data-browser="node16_11">No</td>
-<td class="no obsolete" data-browser="node17_0">No</td>
-<td class="no obsolete" data-browser="node17_2">No</td>
-<td class="no obsolete" data-browser="node18_0">No</td>
-<td class="no" data-browser="node18_3">No</td>
-<td class="no obsolete" data-browser="node19_0">No</td>
-<td class="no obsolete" data-browser="node19_2">No</td>
-<td class="no" data-browser="node20_0">No</td>
-<td class="no obsolete" data-browser="node21_0">No</td>
-<td class="no" data-browser="node22_0">No</td>
-<td class="no obsolete" data-browser="duktape2_6">No</td>
-<td class="no" data-browser="duktape2_7">No</td>
-<td class="unknown obsolete" data-browser="graalvm19">?</td>
-<td class="unknown obsolete" data-browser="graalvm19_3_6">?</td>
-<td class="unknown obsolete" data-browser="graalvm20">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_1">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_3">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_3_1">?</td>
-<td class="unknown obsolete" data-browser="graalvm21">?</td>
-<td class="no" data-browser="graalvm21_3_3">No</td>
-<td class="no" data-browser="graalvm22_2">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
-<td class="no obsolete" data-browser="deno1_33">No</td>
-<td class="no obsolete" data-browser="deno1_34">No</td>
-<td class="no obsolete" data-browser="deno1_35">No</td>
-<td class="no" data-browser="deno1_36">No</td>
-<td class="unknown obsolete" data-browser="android4_4">?</td>
-<td class="unknown obsolete" data-browser="android4_4_3">?</td>
-<td class="unknown obsolete" data-browser="ios12_2">?</td>
-<td class="unknown obsolete" data-browser="ios13_4">?</td>
-<td class="unknown obsolete" data-browser="ios14_5">?</td>
-<td class="unknown obsolete" data-browser="ios16">?</td>
-<td class="unknown obsolete" data-browser="ios16_1">?</td>
-<td class="unknown obsolete" data-browser="ios16_2">?</td>
-<td class="unknown obsolete" data-browser="ios16_3">?</td>
-<td class="unknown obsolete" data-browser="ios16_4">?</td>
-<td class="unknown obsolete" data-browser="ios16_5">?</td>
-<td class="unknown obsolete" data-browser="ios16_6">?</td>
-<td class="unknown" data-browser="ios17">?</td>
-<td class="no obsolete" data-browser="samsung19">No</td>
-<td class="no obsolete" data-browser="samsung20">No</td>
-<td class="no obsolete" data-browser="samsung21">No</td>
-<td class="no" data-browser="samsung22">No</td>
-<td class="no obsolete" data-browser="opera_mobile72">No</td>
-<td class="no obsolete" data-browser="opera_mobile73">No</td>
-<td class="no obsolete" data-browser="opera_mobile74">No</td>
-<td class="no obsolete" data-browser="opera_mobile75">No</td>
-<td class="no obsolete" data-browser="opera_mobile76">No</td>
-<td class="no" data-browser="opera_mobile77">No</td>
-<td class="no" data-browser="reactnative0_70_3">No</td>
-</tr>
-<tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_AsyncIterator.prototype.take"><td><span><a class="anchor" href="#test-Iterator_Helpers_AsyncIterator.prototype.take">&#xA7;</a>AsyncIterator.prototype.take</span><script data-source="
-async function toArray(iterator) {
-  const result = [];
-  for await (const it of iterator) result.push(it);
-  return result;
-}
-
-toArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it =&gt; {
-  if (it.join() === &apos;1,2&apos;) asyncTestPassed();
-});
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("38");try{return Function("asyncTestPassed","\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it => {\n  if (it.join() === '1,2') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("38");return Function("asyncTestPassed","'use strict';"+"\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it => {\n  if (it.join() === '1,2') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
-</script></td>
-<td class="unknown obsolete" data-browser="tr">?</td>
-<td class="no obsolete" data-browser="babel6corejs2">No</td>
-<td class="no obsolete" data-browser="babel7corejs2">No</td>
-<td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200927">?</td>
-<td class="unknown obsolete" data-browser="closure20210808">?</td>
-<td class="unknown obsolete" data-browser="closure20210906">?</td>
-<td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown obsolete" data-browser="closure20220502">?</td>
-<td class="unknown obsolete" data-browser="closure20220719">?</td>
-<td class="unknown" data-browser="closure20230228">?</td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes" data-browser="typescript5_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox114">No</td>
-<td class="no" data-browser="firefox115">No</td>
-<td class="no obsolete" data-browser="firefox116">No</td>
-<td class="no obsolete" data-browser="firefox117">No</td>
-<td class="no obsolete" data-browser="firefox118">No</td>
-<td class="no obsolete" data-browser="firefox119">No</td>
-<td class="no obsolete" data-browser="firefox120">No</td>
-<td class="no obsolete" data-browser="firefox121">No</td>
-<td class="no obsolete" data-browser="firefox122">No</td>
-<td class="no obsolete" data-browser="firefox123">No</td>
-<td class="no obsolete" data-browser="firefox124">No</td>
-<td class="no obsolete" data-browser="firefox125">No</td>
-<td class="no obsolete" data-browser="firefox126">No</td>
-<td class="no" data-browser="firefox127">No</td>
-<td class="no unstable" data-browser="firefox128">No</td>
-<td class="no unstable" data-browser="firefox129">No</td>
-<td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome115">No</td>
-<td class="no obsolete" data-browser="chrome116">No</td>
-<td class="no obsolete" data-browser="chrome117">No</td>
-<td class="no obsolete" data-browser="chrome118">No</td>
-<td class="no obsolete" data-browser="chrome119">No</td>
-<td class="no obsolete" data-browser="chrome120">No</td>
-<td class="no obsolete" data-browser="chrome121">No</td>
-<td class="no obsolete" data-browser="chrome122">No</td>
-<td class="no obsolete" data-browser="chrome123">No</td>
-<td class="no obsolete" data-browser="chrome124">No</td>
-<td class="no obsolete" data-browser="chrome125">No</td>
-<td class="no" data-browser="chrome126">No</td>
-<td class="no unstable" data-browser="chrome127">No</td>
-<td class="no obsolete" data-browser="edge18">No</td>
-<td class="no obsolete" data-browser="edge115">No</td>
-<td class="no obsolete" data-browser="edge116">No</td>
-<td class="no obsolete" data-browser="edge117">No</td>
-<td class="no obsolete" data-browser="edge118">No</td>
-<td class="no obsolete" data-browser="edge119">No</td>
-<td class="no obsolete" data-browser="edge120">No</td>
-<td class="no obsolete" data-browser="edge121">No</td>
-<td class="no obsolete" data-browser="edge122">No</td>
-<td class="no obsolete" data-browser="edge123">No</td>
-<td class="no obsolete" data-browser="edge124">No</td>
-<td class="no obsolete" data-browser="edge125">No</td>
-<td class="no" data-browser="edge126">No</td>
-<td class="no unstable" data-browser="edge127">No</td>
-<td class="unknown obsolete" data-browser="safari15_6">?</td>
-<td class="unknown obsolete" data-browser="safari16_6">?</td>
-<td class="unknown obsolete" data-browser="safari17">?</td>
-<td class="unknown obsolete" data-browser="safari17_1">?</td>
-<td class="unknown obsolete" data-browser="safari17_2">?</td>
-<td class="unknown obsolete" data-browser="safari17_3">?</td>
-<td class="unknown obsolete" data-browser="safari17_4">?</td>
-<td class="unknown" data-browser="safari17_5">?</td>
-<td class="unknown unstable" data-browser="safaritp">?</td>
-<td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera88">No</td>
-<td class="no obsolete" data-browser="opera89">No</td>
-<td class="no obsolete" data-browser="opera90">No</td>
-<td class="no obsolete" data-browser="opera91">No</td>
-<td class="no obsolete" data-browser="opera92">No</td>
-<td class="no obsolete" data-browser="opera93">No</td>
-<td class="no obsolete" data-browser="opera94">No</td>
-<td class="no obsolete" data-browser="opera95">No</td>
-<td class="no obsolete" data-browser="opera96">No</td>
-<td class="no obsolete" data-browser="opera97">No</td>
-<td class="no" data-browser="opera98">No</td>
-<td class="no unstable" data-browser="opera99">No</td>
-<td class="no obsolete" data-browser="rhino1_7_13">No</td>
-<td class="no obsolete" data-browser="rhino1_7_14">No</td>
-<td class="no obsolete" data-browser="rhino1_7_15">No</td>
-<td class="unknown obsolete" data-browser="phantom2_1">?</td>
-<td class="unknown obsolete" data-browser="node0_4">?</td>
-<td class="unknown obsolete" data-browser="node0_6">?</td>
-<td class="unknown obsolete" data-browser="node0_8">?</td>
-<td class="unknown obsolete" data-browser="node0_10">?</td>
-<td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node14_6">No</td>
-<td class="no obsolete" data-browser="node16_0">No</td>
-<td class="no obsolete" data-browser="node16_9">No</td>
-<td class="no" data-browser="node16_11">No</td>
-<td class="no obsolete" data-browser="node17_0">No</td>
-<td class="no obsolete" data-browser="node17_2">No</td>
-<td class="no obsolete" data-browser="node18_0">No</td>
-<td class="no" data-browser="node18_3">No</td>
-<td class="no obsolete" data-browser="node19_0">No</td>
-<td class="no obsolete" data-browser="node19_2">No</td>
-<td class="no" data-browser="node20_0">No</td>
-<td class="no obsolete" data-browser="node21_0">No</td>
-<td class="no" data-browser="node22_0">No</td>
-<td class="no obsolete" data-browser="duktape2_6">No</td>
-<td class="no" data-browser="duktape2_7">No</td>
-<td class="unknown obsolete" data-browser="graalvm19">?</td>
-<td class="unknown obsolete" data-browser="graalvm19_3_6">?</td>
-<td class="unknown obsolete" data-browser="graalvm20">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_1">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_3">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_3_1">?</td>
-<td class="unknown obsolete" data-browser="graalvm21">?</td>
-<td class="no" data-browser="graalvm21_3_3">No</td>
-<td class="no" data-browser="graalvm22_2">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
-<td class="no obsolete" data-browser="deno1_33">No</td>
-<td class="no obsolete" data-browser="deno1_34">No</td>
-<td class="no obsolete" data-browser="deno1_35">No</td>
-<td class="no" data-browser="deno1_36">No</td>
-<td class="unknown obsolete" data-browser="android4_4">?</td>
-<td class="unknown obsolete" data-browser="android4_4_3">?</td>
-<td class="unknown obsolete" data-browser="ios12_2">?</td>
-<td class="unknown obsolete" data-browser="ios13_4">?</td>
-<td class="unknown obsolete" data-browser="ios14_5">?</td>
-<td class="unknown obsolete" data-browser="ios16">?</td>
-<td class="unknown obsolete" data-browser="ios16_1">?</td>
-<td class="unknown obsolete" data-browser="ios16_2">?</td>
-<td class="unknown obsolete" data-browser="ios16_3">?</td>
-<td class="unknown obsolete" data-browser="ios16_4">?</td>
-<td class="unknown obsolete" data-browser="ios16_5">?</td>
-<td class="unknown obsolete" data-browser="ios16_6">?</td>
-<td class="unknown" data-browser="ios17">?</td>
-<td class="no obsolete" data-browser="samsung19">No</td>
-<td class="no obsolete" data-browser="samsung20">No</td>
-<td class="no obsolete" data-browser="samsung21">No</td>
-<td class="no" data-browser="samsung22">No</td>
-<td class="no obsolete" data-browser="opera_mobile72">No</td>
-<td class="no obsolete" data-browser="opera_mobile73">No</td>
-<td class="no obsolete" data-browser="opera_mobile74">No</td>
-<td class="no obsolete" data-browser="opera_mobile75">No</td>
-<td class="no obsolete" data-browser="opera_mobile76">No</td>
-<td class="no" data-browser="opera_mobile77">No</td>
-<td class="no" data-browser="reactnative0_70_3">No</td>
-</tr>
-<tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_AsyncIterator.prototype.toArray"><td><span><a class="anchor" href="#test-Iterator_Helpers_AsyncIterator.prototype.toArray">&#xA7;</a>AsyncIterator.prototype.toArray</span><script data-source="
-(async function*() { yield * [1, 2, 3] })().toArray().then(it =&gt; {
-  if (Array.isArray(it) &amp;&amp; it.join() === &apos;1,2,3&apos;) asyncTestPassed();
-});
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("39");try{return Function("asyncTestPassed","\n(async function*() { yield * [1, 2, 3] })().toArray().then(it => {\n  if (Array.isArray(it) && it.join() === '1,2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("39");return Function("asyncTestPassed","'use strict';"+"\n(async function*() { yield * [1, 2, 3] })().toArray().then(it => {\n  if (Array.isArray(it) && it.join() === '1,2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
-</script></td>
-<td class="unknown obsolete" data-browser="tr">?</td>
-<td class="no obsolete" data-browser="babel6corejs2">No</td>
-<td class="no obsolete" data-browser="babel7corejs2">No</td>
-<td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200927">?</td>
-<td class="unknown obsolete" data-browser="closure20210808">?</td>
-<td class="unknown obsolete" data-browser="closure20210906">?</td>
-<td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown obsolete" data-browser="closure20220502">?</td>
-<td class="unknown obsolete" data-browser="closure20220719">?</td>
-<td class="unknown" data-browser="closure20230228">?</td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes" data-browser="typescript5_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox114">No</td>
-<td class="no" data-browser="firefox115">No</td>
-<td class="no obsolete" data-browser="firefox116">No</td>
-<td class="no obsolete" data-browser="firefox117">No</td>
-<td class="no obsolete" data-browser="firefox118">No</td>
-<td class="no obsolete" data-browser="firefox119">No</td>
-<td class="no obsolete" data-browser="firefox120">No</td>
-<td class="no obsolete" data-browser="firefox121">No</td>
-<td class="no obsolete" data-browser="firefox122">No</td>
-<td class="no obsolete" data-browser="firefox123">No</td>
-<td class="no obsolete" data-browser="firefox124">No</td>
-<td class="no obsolete" data-browser="firefox125">No</td>
-<td class="no obsolete" data-browser="firefox126">No</td>
-<td class="no" data-browser="firefox127">No</td>
-<td class="no unstable" data-browser="firefox128">No</td>
-<td class="no unstable" data-browser="firefox129">No</td>
-<td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome115">No</td>
-<td class="no obsolete" data-browser="chrome116">No</td>
-<td class="no obsolete" data-browser="chrome117">No</td>
-<td class="no obsolete" data-browser="chrome118">No</td>
-<td class="no obsolete" data-browser="chrome119">No</td>
-<td class="no obsolete" data-browser="chrome120">No</td>
-<td class="no obsolete" data-browser="chrome121">No</td>
-<td class="no obsolete" data-browser="chrome122">No</td>
-<td class="no obsolete" data-browser="chrome123">No</td>
-<td class="no obsolete" data-browser="chrome124">No</td>
-<td class="no obsolete" data-browser="chrome125">No</td>
-<td class="no" data-browser="chrome126">No</td>
-<td class="no unstable" data-browser="chrome127">No</td>
-<td class="no obsolete" data-browser="edge18">No</td>
-<td class="no obsolete" data-browser="edge115">No</td>
-<td class="no obsolete" data-browser="edge116">No</td>
-<td class="no obsolete" data-browser="edge117">No</td>
-<td class="no obsolete" data-browser="edge118">No</td>
-<td class="no obsolete" data-browser="edge119">No</td>
-<td class="no obsolete" data-browser="edge120">No</td>
-<td class="no obsolete" data-browser="edge121">No</td>
-<td class="no obsolete" data-browser="edge122">No</td>
-<td class="no obsolete" data-browser="edge123">No</td>
-<td class="no obsolete" data-browser="edge124">No</td>
-<td class="no obsolete" data-browser="edge125">No</td>
-<td class="no" data-browser="edge126">No</td>
-<td class="no unstable" data-browser="edge127">No</td>
-<td class="unknown obsolete" data-browser="safari15_6">?</td>
-<td class="unknown obsolete" data-browser="safari16_6">?</td>
-<td class="unknown obsolete" data-browser="safari17">?</td>
-<td class="unknown obsolete" data-browser="safari17_1">?</td>
-<td class="unknown obsolete" data-browser="safari17_2">?</td>
-<td class="unknown obsolete" data-browser="safari17_3">?</td>
-<td class="unknown obsolete" data-browser="safari17_4">?</td>
-<td class="unknown" data-browser="safari17_5">?</td>
-<td class="unknown unstable" data-browser="safaritp">?</td>
-<td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera88">No</td>
-<td class="no obsolete" data-browser="opera89">No</td>
-<td class="no obsolete" data-browser="opera90">No</td>
-<td class="no obsolete" data-browser="opera91">No</td>
-<td class="no obsolete" data-browser="opera92">No</td>
-<td class="no obsolete" data-browser="opera93">No</td>
-<td class="no obsolete" data-browser="opera94">No</td>
-<td class="no obsolete" data-browser="opera95">No</td>
-<td class="no obsolete" data-browser="opera96">No</td>
-<td class="no obsolete" data-browser="opera97">No</td>
-<td class="no" data-browser="opera98">No</td>
-<td class="no unstable" data-browser="opera99">No</td>
-<td class="no obsolete" data-browser="rhino1_7_13">No</td>
-<td class="no obsolete" data-browser="rhino1_7_14">No</td>
-<td class="no obsolete" data-browser="rhino1_7_15">No</td>
-<td class="unknown obsolete" data-browser="phantom2_1">?</td>
-<td class="unknown obsolete" data-browser="node0_4">?</td>
-<td class="unknown obsolete" data-browser="node0_6">?</td>
-<td class="unknown obsolete" data-browser="node0_8">?</td>
-<td class="unknown obsolete" data-browser="node0_10">?</td>
-<td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node14_6">No</td>
-<td class="no obsolete" data-browser="node16_0">No</td>
-<td class="no obsolete" data-browser="node16_9">No</td>
-<td class="no" data-browser="node16_11">No</td>
-<td class="no obsolete" data-browser="node17_0">No</td>
-<td class="no obsolete" data-browser="node17_2">No</td>
-<td class="no obsolete" data-browser="node18_0">No</td>
-<td class="no" data-browser="node18_3">No</td>
-<td class="no obsolete" data-browser="node19_0">No</td>
-<td class="no obsolete" data-browser="node19_2">No</td>
-<td class="no" data-browser="node20_0">No</td>
-<td class="no obsolete" data-browser="node21_0">No</td>
-<td class="no" data-browser="node22_0">No</td>
-<td class="no obsolete" data-browser="duktape2_6">No</td>
-<td class="no" data-browser="duktape2_7">No</td>
-<td class="unknown obsolete" data-browser="graalvm19">?</td>
-<td class="unknown obsolete" data-browser="graalvm19_3_6">?</td>
-<td class="unknown obsolete" data-browser="graalvm20">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_1">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_3">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_3_1">?</td>
-<td class="unknown obsolete" data-browser="graalvm21">?</td>
-<td class="no" data-browser="graalvm21_3_3">No</td>
-<td class="no" data-browser="graalvm22_2">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
-<td class="no obsolete" data-browser="deno1_33">No</td>
-<td class="no obsolete" data-browser="deno1_34">No</td>
-<td class="no obsolete" data-browser="deno1_35">No</td>
-<td class="no" data-browser="deno1_36">No</td>
-<td class="unknown obsolete" data-browser="android4_4">?</td>
-<td class="unknown obsolete" data-browser="android4_4_3">?</td>
-<td class="unknown obsolete" data-browser="ios12_2">?</td>
-<td class="unknown obsolete" data-browser="ios13_4">?</td>
-<td class="unknown obsolete" data-browser="ios14_5">?</td>
-<td class="unknown obsolete" data-browser="ios16">?</td>
-<td class="unknown obsolete" data-browser="ios16_1">?</td>
-<td class="unknown obsolete" data-browser="ios16_2">?</td>
-<td class="unknown obsolete" data-browser="ios16_3">?</td>
-<td class="unknown obsolete" data-browser="ios16_4">?</td>
-<td class="unknown obsolete" data-browser="ios16_5">?</td>
-<td class="unknown obsolete" data-browser="ios16_6">?</td>
-<td class="unknown" data-browser="ios17">?</td>
-<td class="no obsolete" data-browser="samsung19">No</td>
-<td class="no obsolete" data-browser="samsung20">No</td>
-<td class="no obsolete" data-browser="samsung21">No</td>
-<td class="no" data-browser="samsung22">No</td>
-<td class="no obsolete" data-browser="opera_mobile72">No</td>
-<td class="no obsolete" data-browser="opera_mobile73">No</td>
-<td class="no obsolete" data-browser="opera_mobile74">No</td>
-<td class="no obsolete" data-browser="opera_mobile75">No</td>
-<td class="no obsolete" data-browser="opera_mobile76">No</td>
-<td class="no" data-browser="opera_mobile77">No</td>
-<td class="no" data-browser="reactnative0_70_3">No</td>
-</tr>
-<tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_AsyncIterator.prototype[@@toStringTag]"><td><span><a class="anchor" href="#test-Iterator_Helpers_AsyncIterator.prototype[@@toStringTag]">&#xA7;</a>AsyncIterator.prototype[@@toStringTag]</span><script data-source="
-return AsyncIterator.prototype[Symbol.toStringTag] === &apos;AsyncIterator&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("40");try{return Function("asyncTestPassed","\nreturn AsyncIterator.prototype[Symbol.toStringTag] === 'AsyncIterator';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("40");return Function("asyncTestPassed","'use strict';"+"\nreturn AsyncIterator.prototype[Symbol.toStringTag] === 'AsyncIterator';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
-</script></td>
-<td class="unknown obsolete" data-browser="tr">?</td>
-<td class="no obsolete" data-browser="babel6corejs2">No</td>
-<td class="no obsolete" data-browser="babel7corejs2">No</td>
-<td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200927">?</td>
-<td class="unknown obsolete" data-browser="closure20210808">?</td>
-<td class="unknown obsolete" data-browser="closure20210906">?</td>
-<td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown obsolete" data-browser="closure20211107">?</td>
-<td class="unknown obsolete" data-browser="closure20220502">?</td>
-<td class="unknown obsolete" data-browser="closure20220719">?</td>
-<td class="unknown" data-browser="closure20230228">?</td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript5_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="yes" data-browser="typescript5_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
-<td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no obsolete" data-browser="firefox114">No</td>
-<td class="no" data-browser="firefox115">No</td>
-<td class="no obsolete" data-browser="firefox116">No</td>
-<td class="no obsolete" data-browser="firefox117">No</td>
-<td class="no obsolete" data-browser="firefox118">No</td>
-<td class="no obsolete" data-browser="firefox119">No</td>
-<td class="no obsolete" data-browser="firefox120">No</td>
-<td class="no obsolete" data-browser="firefox121">No</td>
-<td class="no obsolete" data-browser="firefox122">No</td>
-<td class="no obsolete" data-browser="firefox123">No</td>
-<td class="no obsolete" data-browser="firefox124">No</td>
-<td class="no obsolete" data-browser="firefox125">No</td>
-<td class="no obsolete" data-browser="firefox126">No</td>
-<td class="no" data-browser="firefox127">No</td>
-<td class="no unstable" data-browser="firefox128">No</td>
-<td class="no unstable" data-browser="firefox129">No</td>
-<td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome115">No</td>
-<td class="no obsolete" data-browser="chrome116">No</td>
-<td class="no obsolete" data-browser="chrome117">No</td>
-<td class="no obsolete" data-browser="chrome118">No</td>
-<td class="no obsolete" data-browser="chrome119">No</td>
-<td class="no obsolete" data-browser="chrome120">No</td>
-<td class="no obsolete" data-browser="chrome121">No</td>
-<td class="no obsolete" data-browser="chrome122">No</td>
-<td class="no obsolete" data-browser="chrome123">No</td>
-<td class="no obsolete" data-browser="chrome124">No</td>
-<td class="no obsolete" data-browser="chrome125">No</td>
-<td class="no" data-browser="chrome126">No</td>
-<td class="no unstable" data-browser="chrome127">No</td>
-<td class="no obsolete" data-browser="edge18">No</td>
-<td class="no obsolete" data-browser="edge115">No</td>
-<td class="no obsolete" data-browser="edge116">No</td>
-<td class="no obsolete" data-browser="edge117">No</td>
-<td class="no obsolete" data-browser="edge118">No</td>
-<td class="no obsolete" data-browser="edge119">No</td>
-<td class="no obsolete" data-browser="edge120">No</td>
-<td class="no obsolete" data-browser="edge121">No</td>
-<td class="no obsolete" data-browser="edge122">No</td>
-<td class="no obsolete" data-browser="edge123">No</td>
-<td class="no obsolete" data-browser="edge124">No</td>
-<td class="no obsolete" data-browser="edge125">No</td>
-<td class="no" data-browser="edge126">No</td>
-<td class="no unstable" data-browser="edge127">No</td>
-<td class="unknown obsolete" data-browser="safari15_6">?</td>
-<td class="unknown obsolete" data-browser="safari16_6">?</td>
-<td class="unknown obsolete" data-browser="safari17">?</td>
-<td class="unknown obsolete" data-browser="safari17_1">?</td>
-<td class="unknown obsolete" data-browser="safari17_2">?</td>
-<td class="unknown obsolete" data-browser="safari17_3">?</td>
-<td class="unknown obsolete" data-browser="safari17_4">?</td>
-<td class="unknown" data-browser="safari17_5">?</td>
-<td class="unknown unstable" data-browser="safaritp">?</td>
-<td class="unknown unstable" data-browser="webkit">?</td>
-<td class="no obsolete" data-browser="opera88">No</td>
-<td class="no obsolete" data-browser="opera89">No</td>
-<td class="no obsolete" data-browser="opera90">No</td>
-<td class="no obsolete" data-browser="opera91">No</td>
-<td class="no obsolete" data-browser="opera92">No</td>
-<td class="no obsolete" data-browser="opera93">No</td>
-<td class="no obsolete" data-browser="opera94">No</td>
-<td class="no obsolete" data-browser="opera95">No</td>
-<td class="no obsolete" data-browser="opera96">No</td>
-<td class="no obsolete" data-browser="opera97">No</td>
-<td class="no" data-browser="opera98">No</td>
-<td class="no unstable" data-browser="opera99">No</td>
-<td class="no obsolete" data-browser="rhino1_7_13">No</td>
-<td class="no obsolete" data-browser="rhino1_7_14">No</td>
-<td class="no obsolete" data-browser="rhino1_7_15">No</td>
-<td class="unknown obsolete" data-browser="phantom2_1">?</td>
-<td class="unknown obsolete" data-browser="node0_4">?</td>
-<td class="unknown obsolete" data-browser="node0_6">?</td>
-<td class="unknown obsolete" data-browser="node0_8">?</td>
-<td class="unknown obsolete" data-browser="node0_10">?</td>
-<td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node14_6">No</td>
-<td class="no obsolete" data-browser="node16_0">No</td>
-<td class="no obsolete" data-browser="node16_9">No</td>
-<td class="no" data-browser="node16_11">No</td>
-<td class="no obsolete" data-browser="node17_0">No</td>
-<td class="no obsolete" data-browser="node17_2">No</td>
-<td class="no obsolete" data-browser="node18_0">No</td>
-<td class="no" data-browser="node18_3">No</td>
-<td class="no obsolete" data-browser="node19_0">No</td>
-<td class="no obsolete" data-browser="node19_2">No</td>
-<td class="no" data-browser="node20_0">No</td>
-<td class="no obsolete" data-browser="node21_0">No</td>
-<td class="no" data-browser="node22_0">No</td>
-<td class="no obsolete" data-browser="duktape2_6">No</td>
-<td class="no" data-browser="duktape2_7">No</td>
-<td class="unknown obsolete" data-browser="graalvm19">?</td>
-<td class="unknown obsolete" data-browser="graalvm19_3_6">?</td>
-<td class="unknown obsolete" data-browser="graalvm20">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_1">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_3">?</td>
-<td class="unknown obsolete" data-browser="graalvm20_3_1">?</td>
-<td class="unknown obsolete" data-browser="graalvm21">?</td>
-<td class="no" data-browser="graalvm21_3_3">No</td>
-<td class="no" data-browser="graalvm22_2">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
-<td class="no obsolete" data-browser="deno1_33">No</td>
-<td class="no obsolete" data-browser="deno1_34">No</td>
-<td class="no obsolete" data-browser="deno1_35">No</td>
-<td class="no" data-browser="deno1_36">No</td>
-<td class="unknown obsolete" data-browser="android4_4">?</td>
-<td class="unknown obsolete" data-browser="android4_4_3">?</td>
-<td class="unknown obsolete" data-browser="ios12_2">?</td>
-<td class="unknown obsolete" data-browser="ios13_4">?</td>
-<td class="unknown obsolete" data-browser="ios14_5">?</td>
-<td class="unknown obsolete" data-browser="ios16">?</td>
-<td class="unknown obsolete" data-browser="ios16_1">?</td>
-<td class="unknown obsolete" data-browser="ios16_2">?</td>
-<td class="unknown obsolete" data-browser="ios16_3">?</td>
-<td class="unknown obsolete" data-browser="ios16_4">?</td>
-<td class="unknown obsolete" data-browser="ios16_5">?</td>
-<td class="unknown obsolete" data-browser="ios16_6">?</td>
-<td class="unknown" data-browser="ios17">?</td>
-<td class="no obsolete" data-browser="samsung19">No</td>
-<td class="no obsolete" data-browser="samsung20">No</td>
-<td class="no obsolete" data-browser="samsung21">No</td>
-<td class="no" data-browser="samsung22">No</td>
-<td class="no obsolete" data-browser="opera_mobile72">No</td>
-<td class="no obsolete" data-browser="opera_mobile73">No</td>
-<td class="no obsolete" data-browser="opera_mobile74">No</td>
-<td class="no obsolete" data-browser="opera_mobile75">No</td>
-<td class="no obsolete" data-browser="opera_mobile76">No</td>
-<td class="no" data-browser="opera_mobile77">No</td>
-<td class="no" data-browser="reactnative0_70_3">No</td>
-</tr>
 <tr class="category"><td colspan="151"><span>Stage 2.7</span></td>
 </tr>
 <tr significance="1"><td id="test-ShadowRealm"><span><a class="anchor" href="#test-ShadowRealm">&#xA7;</a><a href="https://github.com/tc39/proposal-shadowrealm">ShadowRealm</a></span><script data-source="
@@ -6693,7 +3840,7 @@ return typeof ShadowRealm === &quot;function&quot;
   &amp;&amp; [&quot;evaluate&quot;, &quot;importValue&quot;].every(function(key){
     return key in ShadowRealm.prototype;
   });
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("41");try{return Function("asyncTestPassed","\nreturn typeof ShadowRealm === \"function\"\n  && [\"evaluate\", \"importValue\"].every(function(key){\n    return key in ShadowRealm.prototype;\n  });\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("41");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof ShadowRealm === \"function\"\n  && [\"evaluate\", \"importValue\"].every(function(key){\n    return key in ShadowRealm.prototype;\n  });\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("23");try{return Function("asyncTestPassed","\nreturn typeof ShadowRealm === \"function\"\n  && [\"evaluate\", \"importValue\"].every(function(key){\n    return key in ShadowRealm.prototype;\n  });\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("23");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof ShadowRealm === \"function\"\n  && [\"evaluate\", \"importValue\"].every(function(key){\n    return key in ShadowRealm.prototype;\n  });\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -6715,22 +3862,22 @@ return typeof ShadowRealm === &quot;function&quot;
 <td class="unknown obsolete" data-browser="typescript5_4corejs3">?</td>
 <td class="unknown" data-browser="typescript5_5corejs3">?</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
-<td class="no flagged obsolete" data-browser="firefox114">Flag<a href="#ff-shadow-realm-note"><sup>[9]</sup></a></td>
-<td class="no flagged" data-browser="firefox115">Flag<a href="#ff-shadow-realm-note"><sup>[9]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox116">Flag<a href="#ff-shadow-realm-note"><sup>[9]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox117">Flag<a href="#ff-shadow-realm-note"><sup>[9]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox118">Flag<a href="#ff-shadow-realm-note"><sup>[9]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox119">Flag<a href="#ff-shadow-realm-note"><sup>[9]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox120">Flag<a href="#ff-shadow-realm-note"><sup>[9]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox121">Flag<a href="#ff-shadow-realm-note"><sup>[9]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox122">Flag<a href="#ff-shadow-realm-note"><sup>[9]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox123">Flag<a href="#ff-shadow-realm-note"><sup>[9]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox124">Flag<a href="#ff-shadow-realm-note"><sup>[9]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox125">Flag<a href="#ff-shadow-realm-note"><sup>[9]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox126">Flag<a href="#ff-shadow-realm-note"><sup>[9]</sup></a></td>
-<td class="no flagged" data-browser="firefox127">Flag<a href="#ff-shadow-realm-note"><sup>[9]</sup></a></td>
-<td class="no flagged unstable" data-browser="firefox128">Flag<a href="#ff-shadow-realm-note"><sup>[9]</sup></a></td>
-<td class="no flagged unstable" data-browser="firefox129">Flag<a href="#ff-shadow-realm-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox114">Flag<a href="#ff-shadow-realm-note"><sup>[10]</sup></a></td>
+<td class="no flagged" data-browser="firefox115">Flag<a href="#ff-shadow-realm-note"><sup>[10]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox116">Flag<a href="#ff-shadow-realm-note"><sup>[10]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox117">Flag<a href="#ff-shadow-realm-note"><sup>[10]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox118">Flag<a href="#ff-shadow-realm-note"><sup>[10]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox119">Flag<a href="#ff-shadow-realm-note"><sup>[10]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox120">Flag<a href="#ff-shadow-realm-note"><sup>[10]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox121">Flag<a href="#ff-shadow-realm-note"><sup>[10]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox122">Flag<a href="#ff-shadow-realm-note"><sup>[10]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox123">Flag<a href="#ff-shadow-realm-note"><sup>[10]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox124">Flag<a href="#ff-shadow-realm-note"><sup>[10]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox125">Flag<a href="#ff-shadow-realm-note"><sup>[10]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox126">Flag<a href="#ff-shadow-realm-note"><sup>[10]</sup></a></td>
+<td class="no flagged" data-browser="firefox127">Flag<a href="#ff-shadow-realm-note"><sup>[10]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox128">Flag<a href="#ff-shadow-realm-note"><sup>[10]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox129">Flag<a href="#ff-shadow-realm-note"><sup>[10]</sup></a></td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome115">No</td>
 <td class="no obsolete" data-browser="chrome116">No</td>
@@ -6854,7 +4001,7 @@ function* generator() {
 var iter = generator();
 iter.next(&apos;tromple&apos;);
 return result === &apos;tromple&apos;;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("42");try{return Function("asyncTestPassed","\nvar result;\nfunction* generator() {\n  result = function.sent;\n}\nvar iter = generator();\niter.next('tromple');\nreturn result === 'tromple';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("42");return Function("asyncTestPassed","'use strict';"+"\nvar result;\nfunction* generator() {\n  result = function.sent;\n}\nvar iter = generator();\niter.next('tromple');\nreturn result === 'tromple';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("24");try{return Function("asyncTestPassed","\nvar result;\nfunction* generator() {\n  result = function.sent;\n}\nvar iter = generator();\niter.next('tromple');\nreturn result === 'tromple';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("24");return Function("asyncTestPassed","'use strict';"+"\nvar result;\nfunction* generator() {\n  result = function.sent;\n}\nvar iter = generator();\niter.next('tromple');\nreturn result === 'tromple';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
@@ -7163,7 +4310,7 @@ try {
 } catch (e) {
   return a + e === 42;
 }
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("44");try{return Function("asyncTestPassed","\nvar a, b;\ntry {\n  a = 19 || throw 77;\n  b = 88 && throw 23;\n} catch (e) {\n  return a + e === 42;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("44");return Function("asyncTestPassed","'use strict';"+"\nvar a, b;\ntry {\n  a = 19 || throw 77;\n  b = 88 && throw 23;\n} catch (e) {\n  return a + e === 42;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("26");try{return Function("asyncTestPassed","\nvar a, b;\ntry {\n  a = 19 || throw 77;\n  b = 88 && throw 23;\n} catch (e) {\n  return a + e === 42;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("26");return Function("asyncTestPassed","'use strict';"+"\nvar a, b;\ntry {\n  a = 19 || throw 77;\n  b = 88 && throw 23;\n} catch (e) {\n  return a + e === 42;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -7326,7 +4473,7 @@ try {
 } catch (e) {
   return e === 42;
 }
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("45");try{return Function("asyncTestPassed","\nfunction fn (arg = throw 42) {\n  return arg;\n}\n\nif (fn(21) !== 21) return false;\n\ntry {\n  fn();\n} catch (e) {\n  return e === 42;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("45");return Function("asyncTestPassed","'use strict';"+"\nfunction fn (arg = throw 42) {\n  return arg;\n}\n\nif (fn(21) !== 21) return false;\n\ntry {\n  fn();\n} catch (e) {\n  return e === 42;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("27");try{return Function("asyncTestPassed","\nfunction fn (arg = throw 42) {\n  return arg;\n}\n\nif (fn(21) !== 21) return false;\n\ntry {\n  fn();\n} catch (e) {\n  return e === 42;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("27");return Function("asyncTestPassed","'use strict';"+"\nfunction fn (arg = throw 42) {\n  return arg;\n}\n\nif (fn(21) !== 21) return false;\n\ntry {\n  fn();\n} catch (e) {\n  return e === 42;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -7484,7 +4631,7 @@ try {
 } catch (e) {
   return e === 42;
 }
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("46");try{return Function("asyncTestPassed","\nvar fn = () => throw 42;\ntry {\n  fn();\n} catch (e) {\n  return e === 42;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("46");return Function("asyncTestPassed","'use strict';"+"\nvar fn = () => throw 42;\ntry {\n  fn();\n} catch (e) {\n  return e === 42;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("28");try{return Function("asyncTestPassed","\nvar fn = () => throw 42;\ntry {\n  fn();\n} catch (e) {\n  return e === 42;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("28");return Function("asyncTestPassed","'use strict';"+"\nvar fn = () => throw 42;\ntry {\n  fn();\n} catch (e) {\n  return e === 42;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -7642,7 +4789,7 @@ try {
 } catch (e) {
   return e === 21;
 }
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("47");try{return Function("asyncTestPassed","\ntrue ? 42 : throw 21;\ntry {\n  false ? 42 : throw 21;\n} catch (e) {\n  return e === 21;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("47");return Function("asyncTestPassed","'use strict';"+"\ntrue ? 42 : throw 21;\ntry {\n  false ? 42 : throw 21;\n} catch (e) {\n  return e === 21;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("29");try{return Function("asyncTestPassed","\ntrue ? 42 : throw 21;\ntry {\n  false ? 42 : throw 21;\n} catch (e) {\n  return e === 21;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("29");return Function("asyncTestPassed","'use strict';"+"\ntrue ? 42 : throw 21;\ntry {\n  false ? 42 : throw 21;\n} catch (e) {\n  return e === 21;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -7948,7 +5095,7 @@ const map = new Map([[&apos;a&apos;, 1]]);
 if (map.upsert(&apos;a&apos;, it =&gt; 2, () =&gt; 3) !== 2) return false;
 if (map.upsert(&apos;b&apos;, it =&gt; 2, () =&gt; 3) !== 3) return false;
 return Array.from(map).join() === &apos;a,2,b,3&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("49");try{return Function("asyncTestPassed","\nconst map = new Map([['a', 1]]);\nif (map.upsert('a', it => 2, () => 3) !== 2) return false;\nif (map.upsert('b', it => 2, () => 3) !== 3) return false;\nreturn Array.from(map).join() === 'a,2,b,3';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("49");return Function("asyncTestPassed","'use strict';"+"\nconst map = new Map([['a', 1]]);\nif (map.upsert('a', it => 2, () => 3) !== 2) return false;\nif (map.upsert('b', it => 2, () => 3) !== 3) return false;\nreturn Array.from(map).join() === 'a,2,b,3';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("31");try{return Function("asyncTestPassed","\nconst map = new Map([['a', 1]]);\nif (map.upsert('a', it => 2, () => 3) !== 2) return false;\nif (map.upsert('b', it => 2, () => 3) !== 3) return false;\nreturn Array.from(map).join() === 'a,2,b,3';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("31");return Function("asyncTestPassed","'use strict';"+"\nconst map = new Map([['a', 1]]);\nif (map.upsert('a', it => 2, () => 3) !== 2) return false;\nif (map.upsert('b', it => 2, () => 3) !== 3) return false;\nreturn Array.from(map).join() === 'a,2,b,3';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -8105,7 +5252,7 @@ const map = new WeakMap([[a, 1]]);
 if (map.upsert(a, it =&gt; 2, () =&gt; 3) !== 2) return false;
 if (map.upsert(b, it =&gt; 2, () =&gt; 3) !== 3) return false;
 return map.get(a) === 2 &amp;&amp; map.get(b) === 3;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("50");try{return Function("asyncTestPassed","\nconst a = {}, b = {};\nconst map = new WeakMap([[a, 1]]);\nif (map.upsert(a, it => 2, () => 3) !== 2) return false;\nif (map.upsert(b, it => 2, () => 3) !== 3) return false;\nreturn map.get(a) === 2 && map.get(b) === 3;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("50");return Function("asyncTestPassed","'use strict';"+"\nconst a = {}, b = {};\nconst map = new WeakMap([[a, 1]]);\nif (map.upsert(a, it => 2, () => 3) !== 2) return false;\nif (map.upsert(b, it => 2, () => 3) !== 3) return false;\nreturn map.get(a) === 2 && map.get(b) === 3;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("32");try{return Function("asyncTestPassed","\nconst a = {}, b = {};\nconst map = new WeakMap([[a, 1]]);\nif (map.upsert(a, it => 2, () => 3) !== 2) return false;\nif (map.upsert(b, it => 2, () => 3) !== 3) return false;\nreturn map.get(a) === 2 && map.get(b) === 3;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("32");return Function("asyncTestPassed","'use strict';"+"\nconst a = {}, b = {};\nconst map = new WeakMap([[a, 1]]);\nif (map.upsert(a, it => 2, () => 3) !== 2) return false;\nif (map.upsert(b, it => 2, () => 3) !== 3) return false;\nreturn map.get(a) === 2 && map.get(b) === 3;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -8259,7 +5406,3010 @@ return map.get(a) === 2 &amp;&amp; map.get(b) === 3;
 <tr significance="0.25"><td id="test-Array.isTemplateObject"><span><a class="anchor" href="#test-Array.isTemplateObject">&#xA7;</a><a href="https://github.com/tc39/proposal-array-is-template-object">Array.isTemplateObject</a></span><script data-source="
 return !Array.isTemplateObject([])
   &amp;&amp; Array.isTemplateObject((it =&gt; it)`a${1}c`);
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("51");try{return Function("asyncTestPassed","\nreturn !Array.isTemplateObject([])\n  && Array.isTemplateObject((it => it)`a${1}c`);\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("51");return Function("asyncTestPassed","'use strict';"+"\nreturn !Array.isTemplateObject([])\n  && Array.isTemplateObject((it => it)`a${1}c`);\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("33");try{return Function("asyncTestPassed","\nreturn !Array.isTemplateObject([])\n  && Array.isTemplateObject((it => it)`a${1}c`);\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("33");return Function("asyncTestPassed","'use strict';"+"\nreturn !Array.isTemplateObject([])\n  && Array.isTemplateObject((it => it)`a${1}c`);\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+</script></td>
+<td class="unknown obsolete" data-browser="tr">?</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
+<td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20210808">?</td>
+<td class="unknown obsolete" data-browser="closure20210906">?</td>
+<td class="unknown obsolete" data-browser="closure20211006">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220719">?</td>
+<td class="unknown" data-browser="closure20230228">?</td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes" data-browser="typescript5_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="no obsolete" data-browser="firefox102">No</td>
+<td class="no obsolete" data-browser="firefox114">No</td>
+<td class="no" data-browser="firefox115">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no obsolete" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox118">No</td>
+<td class="no obsolete" data-browser="firefox119">No</td>
+<td class="no obsolete" data-browser="firefox120">No</td>
+<td class="no obsolete" data-browser="firefox121">No</td>
+<td class="no obsolete" data-browser="firefox122">No</td>
+<td class="no obsolete" data-browser="firefox123">No</td>
+<td class="no obsolete" data-browser="firefox124">No</td>
+<td class="no obsolete" data-browser="firefox125">No</td>
+<td class="no obsolete" data-browser="firefox126">No</td>
+<td class="no" data-browser="firefox127">No</td>
+<td class="no unstable" data-browser="firefox128">No</td>
+<td class="no unstable" data-browser="firefox129">No</td>
+<td class="unknown obsolete" data-browser="opera12_10">?</td>
+<td class="no obsolete" data-browser="chrome115">No</td>
+<td class="no obsolete" data-browser="chrome116">No</td>
+<td class="no obsolete" data-browser="chrome117">No</td>
+<td class="no obsolete" data-browser="chrome118">No</td>
+<td class="no obsolete" data-browser="chrome119">No</td>
+<td class="no obsolete" data-browser="chrome120">No</td>
+<td class="no obsolete" data-browser="chrome121">No</td>
+<td class="no obsolete" data-browser="chrome122">No</td>
+<td class="no obsolete" data-browser="chrome123">No</td>
+<td class="no obsolete" data-browser="chrome124">No</td>
+<td class="no obsolete" data-browser="chrome125">No</td>
+<td class="no" data-browser="chrome126">No</td>
+<td class="no unstable" data-browser="chrome127">No</td>
+<td class="no obsolete" data-browser="edge18">No</td>
+<td class="no obsolete" data-browser="edge115">No</td>
+<td class="no obsolete" data-browser="edge116">No</td>
+<td class="no obsolete" data-browser="edge117">No</td>
+<td class="no obsolete" data-browser="edge118">No</td>
+<td class="no obsolete" data-browser="edge119">No</td>
+<td class="no obsolete" data-browser="edge120">No</td>
+<td class="no obsolete" data-browser="edge121">No</td>
+<td class="no obsolete" data-browser="edge122">No</td>
+<td class="no obsolete" data-browser="edge123">No</td>
+<td class="no obsolete" data-browser="edge124">No</td>
+<td class="no obsolete" data-browser="edge125">No</td>
+<td class="no" data-browser="edge126">No</td>
+<td class="no unstable" data-browser="edge127">No</td>
+<td class="unknown obsolete" data-browser="safari15_6">?</td>
+<td class="unknown obsolete" data-browser="safari16_6">?</td>
+<td class="unknown obsolete" data-browser="safari17">?</td>
+<td class="unknown obsolete" data-browser="safari17_1">?</td>
+<td class="unknown obsolete" data-browser="safari17_2">?</td>
+<td class="unknown obsolete" data-browser="safari17_3">?</td>
+<td class="unknown obsolete" data-browser="safari17_4">?</td>
+<td class="unknown" data-browser="safari17_5">?</td>
+<td class="unknown unstable" data-browser="safaritp">?</td>
+<td class="unknown unstable" data-browser="webkit">?</td>
+<td class="no obsolete" data-browser="opera88">No</td>
+<td class="no obsolete" data-browser="opera89">No</td>
+<td class="no obsolete" data-browser="opera90">No</td>
+<td class="no obsolete" data-browser="opera91">No</td>
+<td class="no obsolete" data-browser="opera92">No</td>
+<td class="no obsolete" data-browser="opera93">No</td>
+<td class="no obsolete" data-browser="opera94">No</td>
+<td class="no obsolete" data-browser="opera95">No</td>
+<td class="no obsolete" data-browser="opera96">No</td>
+<td class="no obsolete" data-browser="opera97">No</td>
+<td class="no" data-browser="opera98">No</td>
+<td class="no unstable" data-browser="opera99">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
+<td class="no obsolete" data-browser="rhino1_7_14">No</td>
+<td class="no obsolete" data-browser="rhino1_7_15">No</td>
+<td class="unknown obsolete" data-browser="phantom2_1">?</td>
+<td class="unknown obsolete" data-browser="node0_4">?</td>
+<td class="unknown obsolete" data-browser="node0_6">?</td>
+<td class="unknown obsolete" data-browser="node0_8">?</td>
+<td class="unknown obsolete" data-browser="node0_10">?</td>
+<td class="unknown obsolete" data-browser="node0_12">?</td>
+<td class="no obsolete" data-browser="node14_6">No</td>
+<td class="no obsolete" data-browser="node16_0">No</td>
+<td class="no obsolete" data-browser="node16_9">No</td>
+<td class="no" data-browser="node16_11">No</td>
+<td class="no obsolete" data-browser="node17_0">No</td>
+<td class="no obsolete" data-browser="node17_2">No</td>
+<td class="no obsolete" data-browser="node18_0">No</td>
+<td class="no" data-browser="node18_3">No</td>
+<td class="no obsolete" data-browser="node19_0">No</td>
+<td class="no obsolete" data-browser="node19_2">No</td>
+<td class="no" data-browser="node20_0">No</td>
+<td class="no obsolete" data-browser="node21_0">No</td>
+<td class="no" data-browser="node22_0">No</td>
+<td class="no obsolete" data-browser="duktape2_6">No</td>
+<td class="no" data-browser="duktape2_7">No</td>
+<td class="unknown obsolete" data-browser="graalvm19">?</td>
+<td class="unknown obsolete" data-browser="graalvm19_3_6">?</td>
+<td class="unknown obsolete" data-browser="graalvm20">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_1">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_3">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_3_1">?</td>
+<td class="unknown obsolete" data-browser="graalvm21">?</td>
+<td class="no" data-browser="graalvm21_3_3">No</td>
+<td class="no" data-browser="graalvm22_2">No</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="deno1_33">No</td>
+<td class="no obsolete" data-browser="deno1_34">No</td>
+<td class="no obsolete" data-browser="deno1_35">No</td>
+<td class="no" data-browser="deno1_36">No</td>
+<td class="unknown obsolete" data-browser="android4_4">?</td>
+<td class="unknown obsolete" data-browser="android4_4_3">?</td>
+<td class="unknown obsolete" data-browser="ios12_2">?</td>
+<td class="unknown obsolete" data-browser="ios13_4">?</td>
+<td class="unknown obsolete" data-browser="ios14_5">?</td>
+<td class="unknown obsolete" data-browser="ios16">?</td>
+<td class="unknown obsolete" data-browser="ios16_1">?</td>
+<td class="unknown obsolete" data-browser="ios16_2">?</td>
+<td class="unknown obsolete" data-browser="ios16_3">?</td>
+<td class="unknown obsolete" data-browser="ios16_4">?</td>
+<td class="unknown obsolete" data-browser="ios16_5">?</td>
+<td class="unknown obsolete" data-browser="ios16_6">?</td>
+<td class="unknown" data-browser="ios17">?</td>
+<td class="no obsolete" data-browser="samsung19">No</td>
+<td class="no obsolete" data-browser="samsung20">No</td>
+<td class="no obsolete" data-browser="samsung21">No</td>
+<td class="no" data-browser="samsung22">No</td>
+<td class="no obsolete" data-browser="opera_mobile72">No</td>
+<td class="no obsolete" data-browser="opera_mobile73">No</td>
+<td class="no obsolete" data-browser="opera_mobile74">No</td>
+<td class="no obsolete" data-browser="opera_mobile75">No</td>
+<td class="no obsolete" data-browser="opera_mobile76">No</td>
+<td class="no" data-browser="opera_mobile77">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
+</tr>
+<tr class="supertest" significance="1"><td id="test-Async_Iterator_Helpers"><span><a class="anchor" href="#test-Async_Iterator_Helpers">&#xA7;</a><a href="https://github.com/tc39/proposal-async-iterator-helpers">Async Iterator Helpers</a></span></td>
+<td class="tally obsolete" data-browser="tr" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/18</td>
+<td class="tally" data-browser="babel7corejs3" data-tally="1">18/18</td>
+<td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="closure20210808" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="closure20210906" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="closure20211006" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="closure20211107" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="closure20220502" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="closure20220719" data-tally="0">0/18</td>
+<td class="tally" data-browser="closure20230228" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="typescript3_9corejs3" data-tally="1">18/18</td>
+<td class="tally obsolete" data-browser="typescript4_9corejs3" data-tally="1">18/18</td>
+<td class="tally obsolete" data-browser="typescript5_2corejs3" data-tally="1">18/18</td>
+<td class="tally obsolete" data-browser="typescript5_3corejs3" data-tally="1">18/18</td>
+<td class="tally obsolete" data-browser="typescript5_4corejs3" data-tally="1">18/18</td>
+<td class="tally" data-browser="typescript5_5corejs3" data-tally="1">18/18</td>
+<td class="tally obsolete" data-browser="firefox102" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="firefox114" data-tally="0">0/18</td>
+<td class="tally" data-browser="firefox115" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="firefox116" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="firefox117" data-tally="0" data-flagged-tally="0.7777777777777778">0/18</td>
+<td class="tally obsolete" data-browser="firefox118" data-tally="0" data-flagged-tally="0.7777777777777778">0/18</td>
+<td class="tally obsolete" data-browser="firefox119" data-tally="0" data-flagged-tally="0.7777777777777778">0/18</td>
+<td class="tally obsolete" data-browser="firefox120" data-tally="0" data-flagged-tally="0.7777777777777778">0/18</td>
+<td class="tally obsolete" data-browser="firefox121" data-tally="0" data-flagged-tally="0.7777777777777778">0/18</td>
+<td class="tally obsolete" data-browser="firefox122" data-tally="0" data-flagged-tally="0.7777777777777778">0/18</td>
+<td class="tally obsolete" data-browser="firefox123" data-tally="0" data-flagged-tally="0.7777777777777778">0/18</td>
+<td class="tally obsolete" data-browser="firefox124" data-tally="0" data-flagged-tally="0.7777777777777778">0/18</td>
+<td class="tally obsolete" data-browser="firefox125" data-tally="0" data-flagged-tally="0.7777777777777778">0/18</td>
+<td class="tally obsolete" data-browser="firefox126" data-tally="0" data-flagged-tally="0.7777777777777778">0/18</td>
+<td class="tally" data-browser="firefox127" data-tally="0" data-flagged-tally="0.7777777777777778">0/18</td>
+<td class="tally unstable" data-browser="firefox128" data-tally="0" data-flagged-tally="0.7777777777777778">0/18</td>
+<td class="tally unstable" data-browser="firefox129" data-tally="0" data-flagged-tally="0.7777777777777778">0/18</td>
+<td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="chrome115" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="chrome116" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="chrome117" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="chrome118" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="chrome119" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="chrome120" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="chrome121" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="chrome122" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="chrome123" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="chrome124" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="chrome125" data-tally="0">0/18</td>
+<td class="tally" data-browser="chrome126" data-tally="0">0/18</td>
+<td class="tally unstable" data-browser="chrome127" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="edge18" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="edge115" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="edge116" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="edge117" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="edge118" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="edge119" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="edge120" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="edge121" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="edge122" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="edge123" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="edge124" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="edge125" data-tally="0">0/18</td>
+<td class="tally" data-browser="edge126" data-tally="0">0/18</td>
+<td class="tally unstable" data-browser="edge127" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="safari15_6" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="safari16_6" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="safari17" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="safari17_1" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="safari17_2" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="safari17_3" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="safari17_4" data-tally="0">0/18</td>
+<td class="tally" data-browser="safari17_5" data-tally="0">0/18</td>
+<td class="tally unstable" data-browser="safaritp" data-tally="0">0/18</td>
+<td class="tally unstable" data-browser="webkit" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="opera88" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="opera89" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="opera90" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="opera91" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="opera92" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="opera93" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="opera94" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="opera95" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="opera96" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="opera97" data-tally="0">0/18</td>
+<td class="tally" data-browser="opera98" data-tally="0">0/18</td>
+<td class="tally unstable" data-browser="opera99" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="rhino1_7_15" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="node0_4" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="node0_6" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="node0_8" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="node0_10" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="node0_12" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="node14_6" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="node16_0" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="node16_9" data-tally="0">0/18</td>
+<td class="tally" data-browser="node16_11" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="node17_0" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="node17_2" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="node18_0" data-tally="0">0/18</td>
+<td class="tally" data-browser="node18_3" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="node19_0" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="node19_2" data-tally="0">0/18</td>
+<td class="tally" data-browser="node20_0" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="node21_0" data-tally="0">0/18</td>
+<td class="tally" data-browser="node22_0" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="duktape2_6" data-tally="0">0/18</td>
+<td class="tally" data-browser="duktape2_7" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="graalvm19" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="graalvm19_3_6" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="graalvm20" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="graalvm20_1" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="graalvm20_3" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="graalvm20_3_1" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="graalvm21" data-tally="0">0/18</td>
+<td class="tally" data-browser="graalvm21_3_3" data-tally="0">0/18</td>
+<td class="tally" data-browser="graalvm22_2" data-tally="0">0/18</td>
+<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="deno1_33" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="deno1_34" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="deno1_35" data-tally="0">0/18</td>
+<td class="tally" data-browser="deno1_36" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="android4_4" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="ios12_2" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="ios13_4" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="ios14_5" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="ios16" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="ios16_1" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="ios16_2" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="ios16_3" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="ios16_4" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="ios16_5" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="ios16_6" data-tally="0">0/18</td>
+<td class="tally" data-browser="ios17" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="samsung19" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="samsung20" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="samsung21" data-tally="0">0/18</td>
+<td class="tally" data-browser="samsung22" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="opera_mobile72" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="opera_mobile73" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="opera_mobile74" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="opera_mobile75" data-tally="0">0/18</td>
+<td class="tally obsolete" data-browser="opera_mobile76" data-tally="0">0/18</td>
+<td class="tally" data-browser="opera_mobile77" data-tally="0">0/18</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/18</td>
+</tr>
+<tr class="subtest" data-parent="Async_Iterator_Helpers" id="test-Async_Iterator_Helpers_instanceof_AsyncIterator"><td><span><a class="anchor" href="#test-Async_Iterator_Helpers_instanceof_AsyncIterator">&#xA7;</a>instanceof AsyncIterator</span><script data-source="
+return (async function*() {})() instanceof AsyncIterator;
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("35");try{return Function("asyncTestPassed","\nreturn (async function*() {})() instanceof AsyncIterator;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("35");return Function("asyncTestPassed","'use strict';"+"\nreturn (async function*() {})() instanceof AsyncIterator;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+</script></td>
+<td class="unknown obsolete" data-browser="tr">?</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
+<td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20210808">?</td>
+<td class="unknown obsolete" data-browser="closure20210906">?</td>
+<td class="unknown obsolete" data-browser="closure20211006">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220719">?</td>
+<td class="unknown" data-browser="closure20230228">?</td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes" data-browser="typescript5_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="no obsolete" data-browser="firefox102">No</td>
+<td class="no obsolete" data-browser="firefox114">No</td>
+<td class="no" data-browser="firefox115">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no flagged obsolete" data-browser="firefox117">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox118">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox119">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox120">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox121">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox122">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox123">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox124">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox125">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox126">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged" data-browser="firefox127">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox128">Flag<a href="#ff-async-iterator-helpers-note"><sup>[11]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox129">Flag<a href="#ff-async-iterator-helpers-note"><sup>[11]</sup></a></td>
+<td class="unknown obsolete" data-browser="opera12_10">?</td>
+<td class="no obsolete" data-browser="chrome115">No</td>
+<td class="no obsolete" data-browser="chrome116">No</td>
+<td class="no obsolete" data-browser="chrome117">No</td>
+<td class="no obsolete" data-browser="chrome118">No</td>
+<td class="no obsolete" data-browser="chrome119">No</td>
+<td class="no obsolete" data-browser="chrome120">No</td>
+<td class="no obsolete" data-browser="chrome121">No</td>
+<td class="no obsolete" data-browser="chrome122">No</td>
+<td class="no obsolete" data-browser="chrome123">No</td>
+<td class="no obsolete" data-browser="chrome124">No</td>
+<td class="no obsolete" data-browser="chrome125">No</td>
+<td class="no" data-browser="chrome126">No</td>
+<td class="no unstable" data-browser="chrome127">No</td>
+<td class="no obsolete" data-browser="edge18">No</td>
+<td class="no obsolete" data-browser="edge115">No</td>
+<td class="no obsolete" data-browser="edge116">No</td>
+<td class="no obsolete" data-browser="edge117">No</td>
+<td class="no obsolete" data-browser="edge118">No</td>
+<td class="no obsolete" data-browser="edge119">No</td>
+<td class="no obsolete" data-browser="edge120">No</td>
+<td class="no obsolete" data-browser="edge121">No</td>
+<td class="no obsolete" data-browser="edge122">No</td>
+<td class="no obsolete" data-browser="edge123">No</td>
+<td class="no obsolete" data-browser="edge124">No</td>
+<td class="no obsolete" data-browser="edge125">No</td>
+<td class="no" data-browser="edge126">No</td>
+<td class="no unstable" data-browser="edge127">No</td>
+<td class="unknown obsolete" data-browser="safari15_6">?</td>
+<td class="unknown obsolete" data-browser="safari16_6">?</td>
+<td class="unknown obsolete" data-browser="safari17">?</td>
+<td class="unknown obsolete" data-browser="safari17_1">?</td>
+<td class="unknown obsolete" data-browser="safari17_2">?</td>
+<td class="unknown obsolete" data-browser="safari17_3">?</td>
+<td class="unknown obsolete" data-browser="safari17_4">?</td>
+<td class="unknown" data-browser="safari17_5">?</td>
+<td class="unknown unstable" data-browser="safaritp">?</td>
+<td class="unknown unstable" data-browser="webkit">?</td>
+<td class="no obsolete" data-browser="opera88">No</td>
+<td class="no obsolete" data-browser="opera89">No</td>
+<td class="no obsolete" data-browser="opera90">No</td>
+<td class="no obsolete" data-browser="opera91">No</td>
+<td class="no obsolete" data-browser="opera92">No</td>
+<td class="no obsolete" data-browser="opera93">No</td>
+<td class="no obsolete" data-browser="opera94">No</td>
+<td class="no obsolete" data-browser="opera95">No</td>
+<td class="no obsolete" data-browser="opera96">No</td>
+<td class="no obsolete" data-browser="opera97">No</td>
+<td class="no" data-browser="opera98">No</td>
+<td class="no unstable" data-browser="opera99">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
+<td class="no obsolete" data-browser="rhino1_7_14">No</td>
+<td class="no obsolete" data-browser="rhino1_7_15">No</td>
+<td class="unknown obsolete" data-browser="phantom2_1">?</td>
+<td class="unknown obsolete" data-browser="node0_4">?</td>
+<td class="unknown obsolete" data-browser="node0_6">?</td>
+<td class="unknown obsolete" data-browser="node0_8">?</td>
+<td class="unknown obsolete" data-browser="node0_10">?</td>
+<td class="unknown obsolete" data-browser="node0_12">?</td>
+<td class="no obsolete" data-browser="node14_6">No</td>
+<td class="no obsolete" data-browser="node16_0">No</td>
+<td class="no obsolete" data-browser="node16_9">No</td>
+<td class="no" data-browser="node16_11">No</td>
+<td class="no obsolete" data-browser="node17_0">No</td>
+<td class="no obsolete" data-browser="node17_2">No</td>
+<td class="no obsolete" data-browser="node18_0">No</td>
+<td class="no" data-browser="node18_3">No</td>
+<td class="no obsolete" data-browser="node19_0">No</td>
+<td class="no obsolete" data-browser="node19_2">No</td>
+<td class="no" data-browser="node20_0">No</td>
+<td class="no obsolete" data-browser="node21_0">No</td>
+<td class="no" data-browser="node22_0">No</td>
+<td class="no obsolete" data-browser="duktape2_6">No</td>
+<td class="no" data-browser="duktape2_7">No</td>
+<td class="unknown obsolete" data-browser="graalvm19">?</td>
+<td class="unknown obsolete" data-browser="graalvm19_3_6">?</td>
+<td class="unknown obsolete" data-browser="graalvm20">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_1">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_3">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_3_1">?</td>
+<td class="unknown obsolete" data-browser="graalvm21">?</td>
+<td class="no" data-browser="graalvm21_3_3">No</td>
+<td class="no" data-browser="graalvm22_2">No</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="deno1_33">No</td>
+<td class="no obsolete" data-browser="deno1_34">No</td>
+<td class="no obsolete" data-browser="deno1_35">No</td>
+<td class="no" data-browser="deno1_36">No</td>
+<td class="unknown obsolete" data-browser="android4_4">?</td>
+<td class="unknown obsolete" data-browser="android4_4_3">?</td>
+<td class="unknown obsolete" data-browser="ios12_2">?</td>
+<td class="unknown obsolete" data-browser="ios13_4">?</td>
+<td class="unknown obsolete" data-browser="ios14_5">?</td>
+<td class="unknown obsolete" data-browser="ios16">?</td>
+<td class="unknown obsolete" data-browser="ios16_1">?</td>
+<td class="unknown obsolete" data-browser="ios16_2">?</td>
+<td class="unknown obsolete" data-browser="ios16_3">?</td>
+<td class="unknown obsolete" data-browser="ios16_4">?</td>
+<td class="unknown obsolete" data-browser="ios16_5">?</td>
+<td class="unknown obsolete" data-browser="ios16_6">?</td>
+<td class="unknown" data-browser="ios17">?</td>
+<td class="no obsolete" data-browser="samsung19">No</td>
+<td class="no obsolete" data-browser="samsung20">No</td>
+<td class="no obsolete" data-browser="samsung21">No</td>
+<td class="no" data-browser="samsung22">No</td>
+<td class="no obsolete" data-browser="opera_mobile72">No</td>
+<td class="no obsolete" data-browser="opera_mobile73">No</td>
+<td class="no obsolete" data-browser="opera_mobile74">No</td>
+<td class="no obsolete" data-browser="opera_mobile75">No</td>
+<td class="no obsolete" data-browser="opera_mobile76">No</td>
+<td class="no" data-browser="opera_mobile77">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
+</tr>
+<tr class="subtest" data-parent="Async_Iterator_Helpers" id="test-Async_Iterator_Helpers_extends_AsyncIterator"><td><span><a class="anchor" href="#test-Async_Iterator_Helpers_extends_AsyncIterator">&#xA7;</a>extends AsyncIterator</span><script data-source="
+class Class extends AsyncIterator { }
+const instance = new Class();
+return instance[Symbol.asyncIterator]() === instance;
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("36");try{return Function("asyncTestPassed","\nclass Class extends AsyncIterator { }\nconst instance = new Class();\nreturn instance[Symbol.asyncIterator]() === instance;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("36");return Function("asyncTestPassed","'use strict';"+"\nclass Class extends AsyncIterator { }\nconst instance = new Class();\nreturn instance[Symbol.asyncIterator]() === instance;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+</script></td>
+<td class="unknown obsolete" data-browser="tr">?</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
+<td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20210808">?</td>
+<td class="unknown obsolete" data-browser="closure20210906">?</td>
+<td class="unknown obsolete" data-browser="closure20211006">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220719">?</td>
+<td class="unknown" data-browser="closure20230228">?</td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes" data-browser="typescript5_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="no obsolete" data-browser="firefox102">No</td>
+<td class="no obsolete" data-browser="firefox114">No</td>
+<td class="no" data-browser="firefox115">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no flagged obsolete" data-browser="firefox117">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox118">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox119">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox120">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox121">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox122">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox123">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox124">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox125">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox126">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged" data-browser="firefox127">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox128">Flag<a href="#ff-async-iterator-helpers-note"><sup>[11]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox129">Flag<a href="#ff-async-iterator-helpers-note"><sup>[11]</sup></a></td>
+<td class="unknown obsolete" data-browser="opera12_10">?</td>
+<td class="no obsolete" data-browser="chrome115">No</td>
+<td class="no obsolete" data-browser="chrome116">No</td>
+<td class="no obsolete" data-browser="chrome117">No</td>
+<td class="no obsolete" data-browser="chrome118">No</td>
+<td class="no obsolete" data-browser="chrome119">No</td>
+<td class="no obsolete" data-browser="chrome120">No</td>
+<td class="no obsolete" data-browser="chrome121">No</td>
+<td class="no obsolete" data-browser="chrome122">No</td>
+<td class="no obsolete" data-browser="chrome123">No</td>
+<td class="no obsolete" data-browser="chrome124">No</td>
+<td class="no obsolete" data-browser="chrome125">No</td>
+<td class="no" data-browser="chrome126">No</td>
+<td class="no unstable" data-browser="chrome127">No</td>
+<td class="no obsolete" data-browser="edge18">No</td>
+<td class="no obsolete" data-browser="edge115">No</td>
+<td class="no obsolete" data-browser="edge116">No</td>
+<td class="no obsolete" data-browser="edge117">No</td>
+<td class="no obsolete" data-browser="edge118">No</td>
+<td class="no obsolete" data-browser="edge119">No</td>
+<td class="no obsolete" data-browser="edge120">No</td>
+<td class="no obsolete" data-browser="edge121">No</td>
+<td class="no obsolete" data-browser="edge122">No</td>
+<td class="no obsolete" data-browser="edge123">No</td>
+<td class="no obsolete" data-browser="edge124">No</td>
+<td class="no obsolete" data-browser="edge125">No</td>
+<td class="no" data-browser="edge126">No</td>
+<td class="no unstable" data-browser="edge127">No</td>
+<td class="unknown obsolete" data-browser="safari15_6">?</td>
+<td class="unknown obsolete" data-browser="safari16_6">?</td>
+<td class="unknown obsolete" data-browser="safari17">?</td>
+<td class="unknown obsolete" data-browser="safari17_1">?</td>
+<td class="unknown obsolete" data-browser="safari17_2">?</td>
+<td class="unknown obsolete" data-browser="safari17_3">?</td>
+<td class="unknown obsolete" data-browser="safari17_4">?</td>
+<td class="unknown" data-browser="safari17_5">?</td>
+<td class="unknown unstable" data-browser="safaritp">?</td>
+<td class="unknown unstable" data-browser="webkit">?</td>
+<td class="no obsolete" data-browser="opera88">No</td>
+<td class="no obsolete" data-browser="opera89">No</td>
+<td class="no obsolete" data-browser="opera90">No</td>
+<td class="no obsolete" data-browser="opera91">No</td>
+<td class="no obsolete" data-browser="opera92">No</td>
+<td class="no obsolete" data-browser="opera93">No</td>
+<td class="no obsolete" data-browser="opera94">No</td>
+<td class="no obsolete" data-browser="opera95">No</td>
+<td class="no obsolete" data-browser="opera96">No</td>
+<td class="no obsolete" data-browser="opera97">No</td>
+<td class="no" data-browser="opera98">No</td>
+<td class="no unstable" data-browser="opera99">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
+<td class="no obsolete" data-browser="rhino1_7_14">No</td>
+<td class="no obsolete" data-browser="rhino1_7_15">No</td>
+<td class="unknown obsolete" data-browser="phantom2_1">?</td>
+<td class="unknown obsolete" data-browser="node0_4">?</td>
+<td class="unknown obsolete" data-browser="node0_6">?</td>
+<td class="unknown obsolete" data-browser="node0_8">?</td>
+<td class="unknown obsolete" data-browser="node0_10">?</td>
+<td class="unknown obsolete" data-browser="node0_12">?</td>
+<td class="no obsolete" data-browser="node14_6">No</td>
+<td class="no obsolete" data-browser="node16_0">No</td>
+<td class="no obsolete" data-browser="node16_9">No</td>
+<td class="no" data-browser="node16_11">No</td>
+<td class="no obsolete" data-browser="node17_0">No</td>
+<td class="no obsolete" data-browser="node17_2">No</td>
+<td class="no obsolete" data-browser="node18_0">No</td>
+<td class="no" data-browser="node18_3">No</td>
+<td class="no obsolete" data-browser="node19_0">No</td>
+<td class="no obsolete" data-browser="node19_2">No</td>
+<td class="no" data-browser="node20_0">No</td>
+<td class="no obsolete" data-browser="node21_0">No</td>
+<td class="no" data-browser="node22_0">No</td>
+<td class="no obsolete" data-browser="duktape2_6">No</td>
+<td class="no" data-browser="duktape2_7">No</td>
+<td class="unknown obsolete" data-browser="graalvm19">?</td>
+<td class="unknown obsolete" data-browser="graalvm19_3_6">?</td>
+<td class="unknown obsolete" data-browser="graalvm20">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_1">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_3">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_3_1">?</td>
+<td class="unknown obsolete" data-browser="graalvm21">?</td>
+<td class="no" data-browser="graalvm21_3_3">No</td>
+<td class="no" data-browser="graalvm22_2">No</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="deno1_33">No</td>
+<td class="no obsolete" data-browser="deno1_34">No</td>
+<td class="no obsolete" data-browser="deno1_35">No</td>
+<td class="no" data-browser="deno1_36">No</td>
+<td class="unknown obsolete" data-browser="android4_4">?</td>
+<td class="unknown obsolete" data-browser="android4_4_3">?</td>
+<td class="unknown obsolete" data-browser="ios12_2">?</td>
+<td class="unknown obsolete" data-browser="ios13_4">?</td>
+<td class="unknown obsolete" data-browser="ios14_5">?</td>
+<td class="unknown obsolete" data-browser="ios16">?</td>
+<td class="unknown obsolete" data-browser="ios16_1">?</td>
+<td class="unknown obsolete" data-browser="ios16_2">?</td>
+<td class="unknown obsolete" data-browser="ios16_3">?</td>
+<td class="unknown obsolete" data-browser="ios16_4">?</td>
+<td class="unknown obsolete" data-browser="ios16_5">?</td>
+<td class="unknown obsolete" data-browser="ios16_6">?</td>
+<td class="unknown" data-browser="ios17">?</td>
+<td class="no obsolete" data-browser="samsung19">No</td>
+<td class="no obsolete" data-browser="samsung20">No</td>
+<td class="no obsolete" data-browser="samsung21">No</td>
+<td class="no" data-browser="samsung22">No</td>
+<td class="no obsolete" data-browser="opera_mobile72">No</td>
+<td class="no obsolete" data-browser="opera_mobile73">No</td>
+<td class="no obsolete" data-browser="opera_mobile74">No</td>
+<td class="no obsolete" data-browser="opera_mobile75">No</td>
+<td class="no obsolete" data-browser="opera_mobile76">No</td>
+<td class="no" data-browser="opera_mobile77">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
+</tr>
+<tr class="subtest" data-parent="Async_Iterator_Helpers" id="test-Async_Iterator_Helpers_AsyncIterator.from,_async_iterable"><td><span><a class="anchor" href="#test-Async_Iterator_Helpers_AsyncIterator.from,_async_iterable">&#xA7;</a>AsyncIterator.from, async iterable</span><script data-source="
+async function toArray(iterator) {
+  const result = [];
+  for await (const it of iterator) result.push(it);
+  return result;
+}
+
+const iterator = AsyncIterator.from(async function*() { yield * [1, 2, 3] }());
+
+if (!(&apos;next&apos; in iterator) || !(iterator instanceof AsyncIterator)) return false;
+
+toArray(iterator).then(it =&gt; {
+  if (it.join() === &apos;1,2,3&apos;) asyncTestPassed();
+});
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("37");try{return Function("asyncTestPassed","\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\nconst iterator = AsyncIterator.from(async function*() { yield * [1, 2, 3] }());\n\nif (!('next' in iterator) || !(iterator instanceof AsyncIterator)) return false;\n\ntoArray(iterator).then(it => {\n  if (it.join() === '1,2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("37");return Function("asyncTestPassed","'use strict';"+"\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\nconst iterator = AsyncIterator.from(async function*() { yield * [1, 2, 3] }());\n\nif (!('next' in iterator) || !(iterator instanceof AsyncIterator)) return false;\n\ntoArray(iterator).then(it => {\n  if (it.join() === '1,2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+</script></td>
+<td class="unknown obsolete" data-browser="tr">?</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
+<td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20210808">?</td>
+<td class="unknown obsolete" data-browser="closure20210906">?</td>
+<td class="unknown obsolete" data-browser="closure20211006">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220719">?</td>
+<td class="unknown" data-browser="closure20230228">?</td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes" data-browser="typescript5_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="no obsolete" data-browser="firefox102">No</td>
+<td class="no obsolete" data-browser="firefox114">No</td>
+<td class="no" data-browser="firefox115">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no obsolete" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox118">No</td>
+<td class="no obsolete" data-browser="firefox119">No</td>
+<td class="no obsolete" data-browser="firefox120">No</td>
+<td class="no obsolete" data-browser="firefox121">No</td>
+<td class="no obsolete" data-browser="firefox122">No</td>
+<td class="no obsolete" data-browser="firefox123">No</td>
+<td class="no obsolete" data-browser="firefox124">No</td>
+<td class="no obsolete" data-browser="firefox125">No</td>
+<td class="no obsolete" data-browser="firefox126">No</td>
+<td class="no" data-browser="firefox127">No</td>
+<td class="no unstable" data-browser="firefox128">No</td>
+<td class="no unstable" data-browser="firefox129">No</td>
+<td class="unknown obsolete" data-browser="opera12_10">?</td>
+<td class="no obsolete" data-browser="chrome115">No</td>
+<td class="no obsolete" data-browser="chrome116">No</td>
+<td class="no obsolete" data-browser="chrome117">No</td>
+<td class="no obsolete" data-browser="chrome118">No</td>
+<td class="no obsolete" data-browser="chrome119">No</td>
+<td class="no obsolete" data-browser="chrome120">No</td>
+<td class="no obsolete" data-browser="chrome121">No</td>
+<td class="no obsolete" data-browser="chrome122">No</td>
+<td class="no obsolete" data-browser="chrome123">No</td>
+<td class="no obsolete" data-browser="chrome124">No</td>
+<td class="no obsolete" data-browser="chrome125">No</td>
+<td class="no" data-browser="chrome126">No</td>
+<td class="no unstable" data-browser="chrome127">No</td>
+<td class="no obsolete" data-browser="edge18">No</td>
+<td class="no obsolete" data-browser="edge115">No</td>
+<td class="no obsolete" data-browser="edge116">No</td>
+<td class="no obsolete" data-browser="edge117">No</td>
+<td class="no obsolete" data-browser="edge118">No</td>
+<td class="no obsolete" data-browser="edge119">No</td>
+<td class="no obsolete" data-browser="edge120">No</td>
+<td class="no obsolete" data-browser="edge121">No</td>
+<td class="no obsolete" data-browser="edge122">No</td>
+<td class="no obsolete" data-browser="edge123">No</td>
+<td class="no obsolete" data-browser="edge124">No</td>
+<td class="no obsolete" data-browser="edge125">No</td>
+<td class="no" data-browser="edge126">No</td>
+<td class="no unstable" data-browser="edge127">No</td>
+<td class="unknown obsolete" data-browser="safari15_6">?</td>
+<td class="unknown obsolete" data-browser="safari16_6">?</td>
+<td class="unknown obsolete" data-browser="safari17">?</td>
+<td class="unknown obsolete" data-browser="safari17_1">?</td>
+<td class="unknown obsolete" data-browser="safari17_2">?</td>
+<td class="unknown obsolete" data-browser="safari17_3">?</td>
+<td class="unknown obsolete" data-browser="safari17_4">?</td>
+<td class="unknown" data-browser="safari17_5">?</td>
+<td class="unknown unstable" data-browser="safaritp">?</td>
+<td class="unknown unstable" data-browser="webkit">?</td>
+<td class="no obsolete" data-browser="opera88">No</td>
+<td class="no obsolete" data-browser="opera89">No</td>
+<td class="no obsolete" data-browser="opera90">No</td>
+<td class="no obsolete" data-browser="opera91">No</td>
+<td class="no obsolete" data-browser="opera92">No</td>
+<td class="no obsolete" data-browser="opera93">No</td>
+<td class="no obsolete" data-browser="opera94">No</td>
+<td class="no obsolete" data-browser="opera95">No</td>
+<td class="no obsolete" data-browser="opera96">No</td>
+<td class="no obsolete" data-browser="opera97">No</td>
+<td class="no" data-browser="opera98">No</td>
+<td class="no unstable" data-browser="opera99">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
+<td class="no obsolete" data-browser="rhino1_7_14">No</td>
+<td class="no obsolete" data-browser="rhino1_7_15">No</td>
+<td class="unknown obsolete" data-browser="phantom2_1">?</td>
+<td class="unknown obsolete" data-browser="node0_4">?</td>
+<td class="unknown obsolete" data-browser="node0_6">?</td>
+<td class="unknown obsolete" data-browser="node0_8">?</td>
+<td class="unknown obsolete" data-browser="node0_10">?</td>
+<td class="unknown obsolete" data-browser="node0_12">?</td>
+<td class="no obsolete" data-browser="node14_6">No</td>
+<td class="no obsolete" data-browser="node16_0">No</td>
+<td class="no obsolete" data-browser="node16_9">No</td>
+<td class="no" data-browser="node16_11">No</td>
+<td class="no obsolete" data-browser="node17_0">No</td>
+<td class="no obsolete" data-browser="node17_2">No</td>
+<td class="no obsolete" data-browser="node18_0">No</td>
+<td class="no" data-browser="node18_3">No</td>
+<td class="no obsolete" data-browser="node19_0">No</td>
+<td class="no obsolete" data-browser="node19_2">No</td>
+<td class="no" data-browser="node20_0">No</td>
+<td class="no obsolete" data-browser="node21_0">No</td>
+<td class="no" data-browser="node22_0">No</td>
+<td class="no obsolete" data-browser="duktape2_6">No</td>
+<td class="no" data-browser="duktape2_7">No</td>
+<td class="unknown obsolete" data-browser="graalvm19">?</td>
+<td class="unknown obsolete" data-browser="graalvm19_3_6">?</td>
+<td class="unknown obsolete" data-browser="graalvm20">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_1">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_3">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_3_1">?</td>
+<td class="unknown obsolete" data-browser="graalvm21">?</td>
+<td class="no" data-browser="graalvm21_3_3">No</td>
+<td class="no" data-browser="graalvm22_2">No</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="deno1_33">No</td>
+<td class="no obsolete" data-browser="deno1_34">No</td>
+<td class="no obsolete" data-browser="deno1_35">No</td>
+<td class="no" data-browser="deno1_36">No</td>
+<td class="unknown obsolete" data-browser="android4_4">?</td>
+<td class="unknown obsolete" data-browser="android4_4_3">?</td>
+<td class="unknown obsolete" data-browser="ios12_2">?</td>
+<td class="unknown obsolete" data-browser="ios13_4">?</td>
+<td class="unknown obsolete" data-browser="ios14_5">?</td>
+<td class="unknown obsolete" data-browser="ios16">?</td>
+<td class="unknown obsolete" data-browser="ios16_1">?</td>
+<td class="unknown obsolete" data-browser="ios16_2">?</td>
+<td class="unknown obsolete" data-browser="ios16_3">?</td>
+<td class="unknown obsolete" data-browser="ios16_4">?</td>
+<td class="unknown obsolete" data-browser="ios16_5">?</td>
+<td class="unknown obsolete" data-browser="ios16_6">?</td>
+<td class="unknown" data-browser="ios17">?</td>
+<td class="no obsolete" data-browser="samsung19">No</td>
+<td class="no obsolete" data-browser="samsung20">No</td>
+<td class="no obsolete" data-browser="samsung21">No</td>
+<td class="no" data-browser="samsung22">No</td>
+<td class="no obsolete" data-browser="opera_mobile72">No</td>
+<td class="no obsolete" data-browser="opera_mobile73">No</td>
+<td class="no obsolete" data-browser="opera_mobile74">No</td>
+<td class="no obsolete" data-browser="opera_mobile75">No</td>
+<td class="no obsolete" data-browser="opera_mobile76">No</td>
+<td class="no" data-browser="opera_mobile77">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
+</tr>
+<tr class="subtest" data-parent="Async_Iterator_Helpers" id="test-Async_Iterator_Helpers_AsyncIterator.from,_iterable"><td><span><a class="anchor" href="#test-Async_Iterator_Helpers_AsyncIterator.from,_iterable">&#xA7;</a>AsyncIterator.from, iterable</span><script data-source="
+async function toArray(iterator) {
+  const result = [];
+  for await (const it of iterator) result.push(it);
+  return result;
+}
+
+const iterator = AsyncIterator.from([1, 2, 3]);
+
+if (!(&apos;next&apos; in iterator) || !(iterator instanceof AsyncIterator)) return false;
+
+toArray(iterator).then(it =&gt; {
+  if (it.join() === &apos;1,2,3&apos;) asyncTestPassed();
+});
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("38");try{return Function("asyncTestPassed","\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\nconst iterator = AsyncIterator.from([1, 2, 3]);\n\nif (!('next' in iterator) || !(iterator instanceof AsyncIterator)) return false;\n\ntoArray(iterator).then(it => {\n  if (it.join() === '1,2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("38");return Function("asyncTestPassed","'use strict';"+"\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\nconst iterator = AsyncIterator.from([1, 2, 3]);\n\nif (!('next' in iterator) || !(iterator instanceof AsyncIterator)) return false;\n\ntoArray(iterator).then(it => {\n  if (it.join() === '1,2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+</script></td>
+<td class="unknown obsolete" data-browser="tr">?</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
+<td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20210808">?</td>
+<td class="unknown obsolete" data-browser="closure20210906">?</td>
+<td class="unknown obsolete" data-browser="closure20211006">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220719">?</td>
+<td class="unknown" data-browser="closure20230228">?</td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes" data-browser="typescript5_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="no obsolete" data-browser="firefox102">No</td>
+<td class="no obsolete" data-browser="firefox114">No</td>
+<td class="no" data-browser="firefox115">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no obsolete" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox118">No</td>
+<td class="no obsolete" data-browser="firefox119">No</td>
+<td class="no obsolete" data-browser="firefox120">No</td>
+<td class="no obsolete" data-browser="firefox121">No</td>
+<td class="no obsolete" data-browser="firefox122">No</td>
+<td class="no obsolete" data-browser="firefox123">No</td>
+<td class="no obsolete" data-browser="firefox124">No</td>
+<td class="no obsolete" data-browser="firefox125">No</td>
+<td class="no obsolete" data-browser="firefox126">No</td>
+<td class="no" data-browser="firefox127">No</td>
+<td class="no unstable" data-browser="firefox128">No</td>
+<td class="no unstable" data-browser="firefox129">No</td>
+<td class="unknown obsolete" data-browser="opera12_10">?</td>
+<td class="no obsolete" data-browser="chrome115">No</td>
+<td class="no obsolete" data-browser="chrome116">No</td>
+<td class="no obsolete" data-browser="chrome117">No</td>
+<td class="no obsolete" data-browser="chrome118">No</td>
+<td class="no obsolete" data-browser="chrome119">No</td>
+<td class="no obsolete" data-browser="chrome120">No</td>
+<td class="no obsolete" data-browser="chrome121">No</td>
+<td class="no obsolete" data-browser="chrome122">No</td>
+<td class="no obsolete" data-browser="chrome123">No</td>
+<td class="no obsolete" data-browser="chrome124">No</td>
+<td class="no obsolete" data-browser="chrome125">No</td>
+<td class="no" data-browser="chrome126">No</td>
+<td class="no unstable" data-browser="chrome127">No</td>
+<td class="no obsolete" data-browser="edge18">No</td>
+<td class="no obsolete" data-browser="edge115">No</td>
+<td class="no obsolete" data-browser="edge116">No</td>
+<td class="no obsolete" data-browser="edge117">No</td>
+<td class="no obsolete" data-browser="edge118">No</td>
+<td class="no obsolete" data-browser="edge119">No</td>
+<td class="no obsolete" data-browser="edge120">No</td>
+<td class="no obsolete" data-browser="edge121">No</td>
+<td class="no obsolete" data-browser="edge122">No</td>
+<td class="no obsolete" data-browser="edge123">No</td>
+<td class="no obsolete" data-browser="edge124">No</td>
+<td class="no obsolete" data-browser="edge125">No</td>
+<td class="no" data-browser="edge126">No</td>
+<td class="no unstable" data-browser="edge127">No</td>
+<td class="unknown obsolete" data-browser="safari15_6">?</td>
+<td class="unknown obsolete" data-browser="safari16_6">?</td>
+<td class="unknown obsolete" data-browser="safari17">?</td>
+<td class="unknown obsolete" data-browser="safari17_1">?</td>
+<td class="unknown obsolete" data-browser="safari17_2">?</td>
+<td class="unknown obsolete" data-browser="safari17_3">?</td>
+<td class="unknown obsolete" data-browser="safari17_4">?</td>
+<td class="unknown" data-browser="safari17_5">?</td>
+<td class="unknown unstable" data-browser="safaritp">?</td>
+<td class="unknown unstable" data-browser="webkit">?</td>
+<td class="no obsolete" data-browser="opera88">No</td>
+<td class="no obsolete" data-browser="opera89">No</td>
+<td class="no obsolete" data-browser="opera90">No</td>
+<td class="no obsolete" data-browser="opera91">No</td>
+<td class="no obsolete" data-browser="opera92">No</td>
+<td class="no obsolete" data-browser="opera93">No</td>
+<td class="no obsolete" data-browser="opera94">No</td>
+<td class="no obsolete" data-browser="opera95">No</td>
+<td class="no obsolete" data-browser="opera96">No</td>
+<td class="no obsolete" data-browser="opera97">No</td>
+<td class="no" data-browser="opera98">No</td>
+<td class="no unstable" data-browser="opera99">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
+<td class="no obsolete" data-browser="rhino1_7_14">No</td>
+<td class="no obsolete" data-browser="rhino1_7_15">No</td>
+<td class="unknown obsolete" data-browser="phantom2_1">?</td>
+<td class="unknown obsolete" data-browser="node0_4">?</td>
+<td class="unknown obsolete" data-browser="node0_6">?</td>
+<td class="unknown obsolete" data-browser="node0_8">?</td>
+<td class="unknown obsolete" data-browser="node0_10">?</td>
+<td class="unknown obsolete" data-browser="node0_12">?</td>
+<td class="no obsolete" data-browser="node14_6">No</td>
+<td class="no obsolete" data-browser="node16_0">No</td>
+<td class="no obsolete" data-browser="node16_9">No</td>
+<td class="no" data-browser="node16_11">No</td>
+<td class="no obsolete" data-browser="node17_0">No</td>
+<td class="no obsolete" data-browser="node17_2">No</td>
+<td class="no obsolete" data-browser="node18_0">No</td>
+<td class="no" data-browser="node18_3">No</td>
+<td class="no obsolete" data-browser="node19_0">No</td>
+<td class="no obsolete" data-browser="node19_2">No</td>
+<td class="no" data-browser="node20_0">No</td>
+<td class="no obsolete" data-browser="node21_0">No</td>
+<td class="no" data-browser="node22_0">No</td>
+<td class="no obsolete" data-browser="duktape2_6">No</td>
+<td class="no" data-browser="duktape2_7">No</td>
+<td class="unknown obsolete" data-browser="graalvm19">?</td>
+<td class="unknown obsolete" data-browser="graalvm19_3_6">?</td>
+<td class="unknown obsolete" data-browser="graalvm20">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_1">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_3">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_3_1">?</td>
+<td class="unknown obsolete" data-browser="graalvm21">?</td>
+<td class="no" data-browser="graalvm21_3_3">No</td>
+<td class="no" data-browser="graalvm22_2">No</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="deno1_33">No</td>
+<td class="no obsolete" data-browser="deno1_34">No</td>
+<td class="no obsolete" data-browser="deno1_35">No</td>
+<td class="no" data-browser="deno1_36">No</td>
+<td class="unknown obsolete" data-browser="android4_4">?</td>
+<td class="unknown obsolete" data-browser="android4_4_3">?</td>
+<td class="unknown obsolete" data-browser="ios12_2">?</td>
+<td class="unknown obsolete" data-browser="ios13_4">?</td>
+<td class="unknown obsolete" data-browser="ios14_5">?</td>
+<td class="unknown obsolete" data-browser="ios16">?</td>
+<td class="unknown obsolete" data-browser="ios16_1">?</td>
+<td class="unknown obsolete" data-browser="ios16_2">?</td>
+<td class="unknown obsolete" data-browser="ios16_3">?</td>
+<td class="unknown obsolete" data-browser="ios16_4">?</td>
+<td class="unknown obsolete" data-browser="ios16_5">?</td>
+<td class="unknown obsolete" data-browser="ios16_6">?</td>
+<td class="unknown" data-browser="ios17">?</td>
+<td class="no obsolete" data-browser="samsung19">No</td>
+<td class="no obsolete" data-browser="samsung20">No</td>
+<td class="no obsolete" data-browser="samsung21">No</td>
+<td class="no" data-browser="samsung22">No</td>
+<td class="no obsolete" data-browser="opera_mobile72">No</td>
+<td class="no obsolete" data-browser="opera_mobile73">No</td>
+<td class="no obsolete" data-browser="opera_mobile74">No</td>
+<td class="no obsolete" data-browser="opera_mobile75">No</td>
+<td class="no obsolete" data-browser="opera_mobile76">No</td>
+<td class="no" data-browser="opera_mobile77">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
+</tr>
+<tr class="subtest" data-parent="Async_Iterator_Helpers" id="test-Async_Iterator_Helpers_AsyncIterator.from,_iterator"><td><span><a class="anchor" href="#test-Async_Iterator_Helpers_AsyncIterator.from,_iterator">&#xA7;</a>AsyncIterator.from, iterator</span><script data-source="
+async function toArray(iterator) {
+  const result = [];
+  for await (const it of iterator) result.push(it);
+  return result;
+}
+
+const iterator = AsyncIterator.from([1, 2, 3].values());
+
+if (!(&apos;next&apos; in iterator) || !(iterator instanceof AsyncIterator)) return false;
+
+toArray(iterator).then(it =&gt; {
+  if (it.join() === &apos;1,2,3&apos;) asyncTestPassed();
+});
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("39");try{return Function("asyncTestPassed","\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\nconst iterator = AsyncIterator.from([1, 2, 3].values());\n\nif (!('next' in iterator) || !(iterator instanceof AsyncIterator)) return false;\n\ntoArray(iterator).then(it => {\n  if (it.join() === '1,2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("39");return Function("asyncTestPassed","'use strict';"+"\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\nconst iterator = AsyncIterator.from([1, 2, 3].values());\n\nif (!('next' in iterator) || !(iterator instanceof AsyncIterator)) return false;\n\ntoArray(iterator).then(it => {\n  if (it.join() === '1,2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+</script></td>
+<td class="unknown obsolete" data-browser="tr">?</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
+<td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20210808">?</td>
+<td class="unknown obsolete" data-browser="closure20210906">?</td>
+<td class="unknown obsolete" data-browser="closure20211006">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220719">?</td>
+<td class="unknown" data-browser="closure20230228">?</td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes" data-browser="typescript5_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="no obsolete" data-browser="firefox102">No</td>
+<td class="no obsolete" data-browser="firefox114">No</td>
+<td class="no" data-browser="firefox115">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no obsolete" data-browser="firefox117">No</td>
+<td class="no obsolete" data-browser="firefox118">No</td>
+<td class="no obsolete" data-browser="firefox119">No</td>
+<td class="no obsolete" data-browser="firefox120">No</td>
+<td class="no obsolete" data-browser="firefox121">No</td>
+<td class="no obsolete" data-browser="firefox122">No</td>
+<td class="no obsolete" data-browser="firefox123">No</td>
+<td class="no obsolete" data-browser="firefox124">No</td>
+<td class="no obsolete" data-browser="firefox125">No</td>
+<td class="no obsolete" data-browser="firefox126">No</td>
+<td class="no" data-browser="firefox127">No</td>
+<td class="no unstable" data-browser="firefox128">No</td>
+<td class="no unstable" data-browser="firefox129">No</td>
+<td class="unknown obsolete" data-browser="opera12_10">?</td>
+<td class="no obsolete" data-browser="chrome115">No</td>
+<td class="no obsolete" data-browser="chrome116">No</td>
+<td class="no obsolete" data-browser="chrome117">No</td>
+<td class="no obsolete" data-browser="chrome118">No</td>
+<td class="no obsolete" data-browser="chrome119">No</td>
+<td class="no obsolete" data-browser="chrome120">No</td>
+<td class="no obsolete" data-browser="chrome121">No</td>
+<td class="no obsolete" data-browser="chrome122">No</td>
+<td class="no obsolete" data-browser="chrome123">No</td>
+<td class="no obsolete" data-browser="chrome124">No</td>
+<td class="no obsolete" data-browser="chrome125">No</td>
+<td class="no" data-browser="chrome126">No</td>
+<td class="no unstable" data-browser="chrome127">No</td>
+<td class="no obsolete" data-browser="edge18">No</td>
+<td class="no obsolete" data-browser="edge115">No</td>
+<td class="no obsolete" data-browser="edge116">No</td>
+<td class="no obsolete" data-browser="edge117">No</td>
+<td class="no obsolete" data-browser="edge118">No</td>
+<td class="no obsolete" data-browser="edge119">No</td>
+<td class="no obsolete" data-browser="edge120">No</td>
+<td class="no obsolete" data-browser="edge121">No</td>
+<td class="no obsolete" data-browser="edge122">No</td>
+<td class="no obsolete" data-browser="edge123">No</td>
+<td class="no obsolete" data-browser="edge124">No</td>
+<td class="no obsolete" data-browser="edge125">No</td>
+<td class="no" data-browser="edge126">No</td>
+<td class="no unstable" data-browser="edge127">No</td>
+<td class="unknown obsolete" data-browser="safari15_6">?</td>
+<td class="unknown obsolete" data-browser="safari16_6">?</td>
+<td class="unknown obsolete" data-browser="safari17">?</td>
+<td class="unknown obsolete" data-browser="safari17_1">?</td>
+<td class="unknown obsolete" data-browser="safari17_2">?</td>
+<td class="unknown obsolete" data-browser="safari17_3">?</td>
+<td class="unknown obsolete" data-browser="safari17_4">?</td>
+<td class="unknown" data-browser="safari17_5">?</td>
+<td class="unknown unstable" data-browser="safaritp">?</td>
+<td class="unknown unstable" data-browser="webkit">?</td>
+<td class="no obsolete" data-browser="opera88">No</td>
+<td class="no obsolete" data-browser="opera89">No</td>
+<td class="no obsolete" data-browser="opera90">No</td>
+<td class="no obsolete" data-browser="opera91">No</td>
+<td class="no obsolete" data-browser="opera92">No</td>
+<td class="no obsolete" data-browser="opera93">No</td>
+<td class="no obsolete" data-browser="opera94">No</td>
+<td class="no obsolete" data-browser="opera95">No</td>
+<td class="no obsolete" data-browser="opera96">No</td>
+<td class="no obsolete" data-browser="opera97">No</td>
+<td class="no" data-browser="opera98">No</td>
+<td class="no unstable" data-browser="opera99">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
+<td class="no obsolete" data-browser="rhino1_7_14">No</td>
+<td class="no obsolete" data-browser="rhino1_7_15">No</td>
+<td class="unknown obsolete" data-browser="phantom2_1">?</td>
+<td class="unknown obsolete" data-browser="node0_4">?</td>
+<td class="unknown obsolete" data-browser="node0_6">?</td>
+<td class="unknown obsolete" data-browser="node0_8">?</td>
+<td class="unknown obsolete" data-browser="node0_10">?</td>
+<td class="unknown obsolete" data-browser="node0_12">?</td>
+<td class="no obsolete" data-browser="node14_6">No</td>
+<td class="no obsolete" data-browser="node16_0">No</td>
+<td class="no obsolete" data-browser="node16_9">No</td>
+<td class="no" data-browser="node16_11">No</td>
+<td class="no obsolete" data-browser="node17_0">No</td>
+<td class="no obsolete" data-browser="node17_2">No</td>
+<td class="no obsolete" data-browser="node18_0">No</td>
+<td class="no" data-browser="node18_3">No</td>
+<td class="no obsolete" data-browser="node19_0">No</td>
+<td class="no obsolete" data-browser="node19_2">No</td>
+<td class="no" data-browser="node20_0">No</td>
+<td class="no obsolete" data-browser="node21_0">No</td>
+<td class="no" data-browser="node22_0">No</td>
+<td class="no obsolete" data-browser="duktape2_6">No</td>
+<td class="no" data-browser="duktape2_7">No</td>
+<td class="unknown obsolete" data-browser="graalvm19">?</td>
+<td class="unknown obsolete" data-browser="graalvm19_3_6">?</td>
+<td class="unknown obsolete" data-browser="graalvm20">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_1">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_3">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_3_1">?</td>
+<td class="unknown obsolete" data-browser="graalvm21">?</td>
+<td class="no" data-browser="graalvm21_3_3">No</td>
+<td class="no" data-browser="graalvm22_2">No</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="deno1_33">No</td>
+<td class="no obsolete" data-browser="deno1_34">No</td>
+<td class="no obsolete" data-browser="deno1_35">No</td>
+<td class="no" data-browser="deno1_36">No</td>
+<td class="unknown obsolete" data-browser="android4_4">?</td>
+<td class="unknown obsolete" data-browser="android4_4_3">?</td>
+<td class="unknown obsolete" data-browser="ios12_2">?</td>
+<td class="unknown obsolete" data-browser="ios13_4">?</td>
+<td class="unknown obsolete" data-browser="ios14_5">?</td>
+<td class="unknown obsolete" data-browser="ios16">?</td>
+<td class="unknown obsolete" data-browser="ios16_1">?</td>
+<td class="unknown obsolete" data-browser="ios16_2">?</td>
+<td class="unknown obsolete" data-browser="ios16_3">?</td>
+<td class="unknown obsolete" data-browser="ios16_4">?</td>
+<td class="unknown obsolete" data-browser="ios16_5">?</td>
+<td class="unknown obsolete" data-browser="ios16_6">?</td>
+<td class="unknown" data-browser="ios17">?</td>
+<td class="no obsolete" data-browser="samsung19">No</td>
+<td class="no obsolete" data-browser="samsung20">No</td>
+<td class="no obsolete" data-browser="samsung21">No</td>
+<td class="no" data-browser="samsung22">No</td>
+<td class="no obsolete" data-browser="opera_mobile72">No</td>
+<td class="no obsolete" data-browser="opera_mobile73">No</td>
+<td class="no obsolete" data-browser="opera_mobile74">No</td>
+<td class="no obsolete" data-browser="opera_mobile75">No</td>
+<td class="no obsolete" data-browser="opera_mobile76">No</td>
+<td class="no" data-browser="opera_mobile77">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
+</tr>
+<tr class="subtest" data-parent="Async_Iterator_Helpers" id="test-Async_Iterator_Helpers_AsyncIterator.prototype.asIndexedPairs"><td><span><a class="anchor" href="#test-Async_Iterator_Helpers_AsyncIterator.prototype.asIndexedPairs">&#xA7;</a>AsyncIterator.prototype.asIndexedPairs</span><script data-source="
+async function toArray(iterator) {
+  const result = [];
+  for await (const it of iterator) result.push(it);
+  return result;
+}
+
+toArray((async function*() { yield * [1, 2, 3] })().asIndexedPairs()).then(it =&gt; {
+  if (it.join() === &apos;0,1,1,2,2,3&apos;) asyncTestPassed();
+});
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("40");try{return Function("asyncTestPassed","\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray((async function*() { yield * [1, 2, 3] })().asIndexedPairs()).then(it => {\n  if (it.join() === '0,1,1,2,2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("40");return Function("asyncTestPassed","'use strict';"+"\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray((async function*() { yield * [1, 2, 3] })().asIndexedPairs()).then(it => {\n  if (it.join() === '0,1,1,2,2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+</script></td>
+<td class="unknown obsolete" data-browser="tr">?</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
+<td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20210808">?</td>
+<td class="unknown obsolete" data-browser="closure20210906">?</td>
+<td class="unknown obsolete" data-browser="closure20211006">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220719">?</td>
+<td class="unknown" data-browser="closure20230228">?</td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes" data-browser="typescript5_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="no obsolete" data-browser="firefox102">No</td>
+<td class="no obsolete" data-browser="firefox114">No</td>
+<td class="no" data-browser="firefox115">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no flagged obsolete" data-browser="firefox117">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox118">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox119">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox120">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox121">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox122">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox123">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox124">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox125">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox126">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged" data-browser="firefox127">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox128">Flag<a href="#ff-async-iterator-helpers-note"><sup>[11]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox129">Flag<a href="#ff-async-iterator-helpers-note"><sup>[11]</sup></a></td>
+<td class="unknown obsolete" data-browser="opera12_10">?</td>
+<td class="no obsolete" data-browser="chrome115">No</td>
+<td class="no obsolete" data-browser="chrome116">No</td>
+<td class="no obsolete" data-browser="chrome117">No</td>
+<td class="no obsolete" data-browser="chrome118">No</td>
+<td class="no obsolete" data-browser="chrome119">No</td>
+<td class="no obsolete" data-browser="chrome120">No</td>
+<td class="no obsolete" data-browser="chrome121">No</td>
+<td class="no obsolete" data-browser="chrome122">No</td>
+<td class="no obsolete" data-browser="chrome123">No</td>
+<td class="no obsolete" data-browser="chrome124">No</td>
+<td class="no obsolete" data-browser="chrome125">No</td>
+<td class="no" data-browser="chrome126">No</td>
+<td class="no unstable" data-browser="chrome127">No</td>
+<td class="no obsolete" data-browser="edge18">No</td>
+<td class="no obsolete" data-browser="edge115">No</td>
+<td class="no obsolete" data-browser="edge116">No</td>
+<td class="no obsolete" data-browser="edge117">No</td>
+<td class="no obsolete" data-browser="edge118">No</td>
+<td class="no obsolete" data-browser="edge119">No</td>
+<td class="no obsolete" data-browser="edge120">No</td>
+<td class="no obsolete" data-browser="edge121">No</td>
+<td class="no obsolete" data-browser="edge122">No</td>
+<td class="no obsolete" data-browser="edge123">No</td>
+<td class="no obsolete" data-browser="edge124">No</td>
+<td class="no obsolete" data-browser="edge125">No</td>
+<td class="no" data-browser="edge126">No</td>
+<td class="no unstable" data-browser="edge127">No</td>
+<td class="unknown obsolete" data-browser="safari15_6">?</td>
+<td class="unknown obsolete" data-browser="safari16_6">?</td>
+<td class="unknown obsolete" data-browser="safari17">?</td>
+<td class="unknown obsolete" data-browser="safari17_1">?</td>
+<td class="unknown obsolete" data-browser="safari17_2">?</td>
+<td class="unknown obsolete" data-browser="safari17_3">?</td>
+<td class="unknown obsolete" data-browser="safari17_4">?</td>
+<td class="unknown" data-browser="safari17_5">?</td>
+<td class="unknown unstable" data-browser="safaritp">?</td>
+<td class="unknown unstable" data-browser="webkit">?</td>
+<td class="no obsolete" data-browser="opera88">No</td>
+<td class="no obsolete" data-browser="opera89">No</td>
+<td class="no obsolete" data-browser="opera90">No</td>
+<td class="no obsolete" data-browser="opera91">No</td>
+<td class="no obsolete" data-browser="opera92">No</td>
+<td class="no obsolete" data-browser="opera93">No</td>
+<td class="no obsolete" data-browser="opera94">No</td>
+<td class="no obsolete" data-browser="opera95">No</td>
+<td class="no obsolete" data-browser="opera96">No</td>
+<td class="no obsolete" data-browser="opera97">No</td>
+<td class="no" data-browser="opera98">No</td>
+<td class="no unstable" data-browser="opera99">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
+<td class="no obsolete" data-browser="rhino1_7_14">No</td>
+<td class="no obsolete" data-browser="rhino1_7_15">No</td>
+<td class="unknown obsolete" data-browser="phantom2_1">?</td>
+<td class="unknown obsolete" data-browser="node0_4">?</td>
+<td class="unknown obsolete" data-browser="node0_6">?</td>
+<td class="unknown obsolete" data-browser="node0_8">?</td>
+<td class="unknown obsolete" data-browser="node0_10">?</td>
+<td class="unknown obsolete" data-browser="node0_12">?</td>
+<td class="no obsolete" data-browser="node14_6">No</td>
+<td class="no obsolete" data-browser="node16_0">No</td>
+<td class="no obsolete" data-browser="node16_9">No</td>
+<td class="no" data-browser="node16_11">No</td>
+<td class="no obsolete" data-browser="node17_0">No</td>
+<td class="no obsolete" data-browser="node17_2">No</td>
+<td class="no obsolete" data-browser="node18_0">No</td>
+<td class="no" data-browser="node18_3">No</td>
+<td class="no obsolete" data-browser="node19_0">No</td>
+<td class="no obsolete" data-browser="node19_2">No</td>
+<td class="no" data-browser="node20_0">No</td>
+<td class="no obsolete" data-browser="node21_0">No</td>
+<td class="no" data-browser="node22_0">No</td>
+<td class="no obsolete" data-browser="duktape2_6">No</td>
+<td class="no" data-browser="duktape2_7">No</td>
+<td class="unknown obsolete" data-browser="graalvm19">?</td>
+<td class="unknown obsolete" data-browser="graalvm19_3_6">?</td>
+<td class="unknown obsolete" data-browser="graalvm20">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_1">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_3">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_3_1">?</td>
+<td class="unknown obsolete" data-browser="graalvm21">?</td>
+<td class="no" data-browser="graalvm21_3_3">No</td>
+<td class="no" data-browser="graalvm22_2">No</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="deno1_33">No</td>
+<td class="no obsolete" data-browser="deno1_34">No</td>
+<td class="no obsolete" data-browser="deno1_35">No</td>
+<td class="no" data-browser="deno1_36">No</td>
+<td class="unknown obsolete" data-browser="android4_4">?</td>
+<td class="unknown obsolete" data-browser="android4_4_3">?</td>
+<td class="unknown obsolete" data-browser="ios12_2">?</td>
+<td class="unknown obsolete" data-browser="ios13_4">?</td>
+<td class="unknown obsolete" data-browser="ios14_5">?</td>
+<td class="unknown obsolete" data-browser="ios16">?</td>
+<td class="unknown obsolete" data-browser="ios16_1">?</td>
+<td class="unknown obsolete" data-browser="ios16_2">?</td>
+<td class="unknown obsolete" data-browser="ios16_3">?</td>
+<td class="unknown obsolete" data-browser="ios16_4">?</td>
+<td class="unknown obsolete" data-browser="ios16_5">?</td>
+<td class="unknown obsolete" data-browser="ios16_6">?</td>
+<td class="unknown" data-browser="ios17">?</td>
+<td class="no obsolete" data-browser="samsung19">No</td>
+<td class="no obsolete" data-browser="samsung20">No</td>
+<td class="no obsolete" data-browser="samsung21">No</td>
+<td class="no" data-browser="samsung22">No</td>
+<td class="no obsolete" data-browser="opera_mobile72">No</td>
+<td class="no obsolete" data-browser="opera_mobile73">No</td>
+<td class="no obsolete" data-browser="opera_mobile74">No</td>
+<td class="no obsolete" data-browser="opera_mobile75">No</td>
+<td class="no obsolete" data-browser="opera_mobile76">No</td>
+<td class="no" data-browser="opera_mobile77">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
+</tr>
+<tr class="subtest" data-parent="Async_Iterator_Helpers" id="test-Async_Iterator_Helpers_AsyncIterator.prototype.drop"><td><span><a class="anchor" href="#test-Async_Iterator_Helpers_AsyncIterator.prototype.drop">&#xA7;</a>AsyncIterator.prototype.drop</span><script data-source="
+async function toArray(iterator) {
+  const result = [];
+  for await (const it of iterator) result.push(it);
+  return result;
+}
+
+toArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it =&gt; {
+  if (it.join() === &apos;2,3&apos;) asyncTestPassed();
+});
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("41");try{return Function("asyncTestPassed","\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it => {\n  if (it.join() === '2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("41");return Function("asyncTestPassed","'use strict';"+"\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it => {\n  if (it.join() === '2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+</script></td>
+<td class="unknown obsolete" data-browser="tr">?</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
+<td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20210808">?</td>
+<td class="unknown obsolete" data-browser="closure20210906">?</td>
+<td class="unknown obsolete" data-browser="closure20211006">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220719">?</td>
+<td class="unknown" data-browser="closure20230228">?</td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes" data-browser="typescript5_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="no obsolete" data-browser="firefox102">No</td>
+<td class="no obsolete" data-browser="firefox114">No</td>
+<td class="no" data-browser="firefox115">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no flagged obsolete" data-browser="firefox117">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox118">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox119">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox120">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox121">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox122">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox123">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox124">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox125">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox126">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged" data-browser="firefox127">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox128">Flag<a href="#ff-async-iterator-helpers-note"><sup>[11]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox129">Flag<a href="#ff-async-iterator-helpers-note"><sup>[11]</sup></a></td>
+<td class="unknown obsolete" data-browser="opera12_10">?</td>
+<td class="no obsolete" data-browser="chrome115">No</td>
+<td class="no obsolete" data-browser="chrome116">No</td>
+<td class="no obsolete" data-browser="chrome117">No</td>
+<td class="no obsolete" data-browser="chrome118">No</td>
+<td class="no obsolete" data-browser="chrome119">No</td>
+<td class="no obsolete" data-browser="chrome120">No</td>
+<td class="no obsolete" data-browser="chrome121">No</td>
+<td class="no obsolete" data-browser="chrome122">No</td>
+<td class="no obsolete" data-browser="chrome123">No</td>
+<td class="no obsolete" data-browser="chrome124">No</td>
+<td class="no obsolete" data-browser="chrome125">No</td>
+<td class="no" data-browser="chrome126">No</td>
+<td class="no unstable" data-browser="chrome127">No</td>
+<td class="no obsolete" data-browser="edge18">No</td>
+<td class="no obsolete" data-browser="edge115">No</td>
+<td class="no obsolete" data-browser="edge116">No</td>
+<td class="no obsolete" data-browser="edge117">No</td>
+<td class="no obsolete" data-browser="edge118">No</td>
+<td class="no obsolete" data-browser="edge119">No</td>
+<td class="no obsolete" data-browser="edge120">No</td>
+<td class="no obsolete" data-browser="edge121">No</td>
+<td class="no obsolete" data-browser="edge122">No</td>
+<td class="no obsolete" data-browser="edge123">No</td>
+<td class="no obsolete" data-browser="edge124">No</td>
+<td class="no obsolete" data-browser="edge125">No</td>
+<td class="no" data-browser="edge126">No</td>
+<td class="no unstable" data-browser="edge127">No</td>
+<td class="unknown obsolete" data-browser="safari15_6">?</td>
+<td class="unknown obsolete" data-browser="safari16_6">?</td>
+<td class="unknown obsolete" data-browser="safari17">?</td>
+<td class="unknown obsolete" data-browser="safari17_1">?</td>
+<td class="unknown obsolete" data-browser="safari17_2">?</td>
+<td class="unknown obsolete" data-browser="safari17_3">?</td>
+<td class="unknown obsolete" data-browser="safari17_4">?</td>
+<td class="unknown" data-browser="safari17_5">?</td>
+<td class="unknown unstable" data-browser="safaritp">?</td>
+<td class="unknown unstable" data-browser="webkit">?</td>
+<td class="no obsolete" data-browser="opera88">No</td>
+<td class="no obsolete" data-browser="opera89">No</td>
+<td class="no obsolete" data-browser="opera90">No</td>
+<td class="no obsolete" data-browser="opera91">No</td>
+<td class="no obsolete" data-browser="opera92">No</td>
+<td class="no obsolete" data-browser="opera93">No</td>
+<td class="no obsolete" data-browser="opera94">No</td>
+<td class="no obsolete" data-browser="opera95">No</td>
+<td class="no obsolete" data-browser="opera96">No</td>
+<td class="no obsolete" data-browser="opera97">No</td>
+<td class="no" data-browser="opera98">No</td>
+<td class="no unstable" data-browser="opera99">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
+<td class="no obsolete" data-browser="rhino1_7_14">No</td>
+<td class="no obsolete" data-browser="rhino1_7_15">No</td>
+<td class="unknown obsolete" data-browser="phantom2_1">?</td>
+<td class="unknown obsolete" data-browser="node0_4">?</td>
+<td class="unknown obsolete" data-browser="node0_6">?</td>
+<td class="unknown obsolete" data-browser="node0_8">?</td>
+<td class="unknown obsolete" data-browser="node0_10">?</td>
+<td class="unknown obsolete" data-browser="node0_12">?</td>
+<td class="no obsolete" data-browser="node14_6">No</td>
+<td class="no obsolete" data-browser="node16_0">No</td>
+<td class="no obsolete" data-browser="node16_9">No</td>
+<td class="no" data-browser="node16_11">No</td>
+<td class="no obsolete" data-browser="node17_0">No</td>
+<td class="no obsolete" data-browser="node17_2">No</td>
+<td class="no obsolete" data-browser="node18_0">No</td>
+<td class="no" data-browser="node18_3">No</td>
+<td class="no obsolete" data-browser="node19_0">No</td>
+<td class="no obsolete" data-browser="node19_2">No</td>
+<td class="no" data-browser="node20_0">No</td>
+<td class="no obsolete" data-browser="node21_0">No</td>
+<td class="no" data-browser="node22_0">No</td>
+<td class="no obsolete" data-browser="duktape2_6">No</td>
+<td class="no" data-browser="duktape2_7">No</td>
+<td class="unknown obsolete" data-browser="graalvm19">?</td>
+<td class="unknown obsolete" data-browser="graalvm19_3_6">?</td>
+<td class="unknown obsolete" data-browser="graalvm20">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_1">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_3">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_3_1">?</td>
+<td class="unknown obsolete" data-browser="graalvm21">?</td>
+<td class="no" data-browser="graalvm21_3_3">No</td>
+<td class="no" data-browser="graalvm22_2">No</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="deno1_33">No</td>
+<td class="no obsolete" data-browser="deno1_34">No</td>
+<td class="no obsolete" data-browser="deno1_35">No</td>
+<td class="no" data-browser="deno1_36">No</td>
+<td class="unknown obsolete" data-browser="android4_4">?</td>
+<td class="unknown obsolete" data-browser="android4_4_3">?</td>
+<td class="unknown obsolete" data-browser="ios12_2">?</td>
+<td class="unknown obsolete" data-browser="ios13_4">?</td>
+<td class="unknown obsolete" data-browser="ios14_5">?</td>
+<td class="unknown obsolete" data-browser="ios16">?</td>
+<td class="unknown obsolete" data-browser="ios16_1">?</td>
+<td class="unknown obsolete" data-browser="ios16_2">?</td>
+<td class="unknown obsolete" data-browser="ios16_3">?</td>
+<td class="unknown obsolete" data-browser="ios16_4">?</td>
+<td class="unknown obsolete" data-browser="ios16_5">?</td>
+<td class="unknown obsolete" data-browser="ios16_6">?</td>
+<td class="unknown" data-browser="ios17">?</td>
+<td class="no obsolete" data-browser="samsung19">No</td>
+<td class="no obsolete" data-browser="samsung20">No</td>
+<td class="no obsolete" data-browser="samsung21">No</td>
+<td class="no" data-browser="samsung22">No</td>
+<td class="no obsolete" data-browser="opera_mobile72">No</td>
+<td class="no obsolete" data-browser="opera_mobile73">No</td>
+<td class="no obsolete" data-browser="opera_mobile74">No</td>
+<td class="no obsolete" data-browser="opera_mobile75">No</td>
+<td class="no obsolete" data-browser="opera_mobile76">No</td>
+<td class="no" data-browser="opera_mobile77">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
+</tr>
+<tr class="subtest" data-parent="Async_Iterator_Helpers" id="test-Async_Iterator_Helpers_AsyncIterator.prototype.every"><td><span><a class="anchor" href="#test-Async_Iterator_Helpers_AsyncIterator.prototype.every">&#xA7;</a>AsyncIterator.prototype.every</span><script data-source="
+(async function*() { yield * [1, 2, 3] })().every(it =&gt; typeof it === &apos;number&apos;).then(it =&gt; {
+  if (it === true) asyncTestPassed();
+});
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("42");try{return Function("asyncTestPassed","\n(async function*() { yield * [1, 2, 3] })().every(it => typeof it === 'number').then(it => {\n  if (it === true) asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("42");return Function("asyncTestPassed","'use strict';"+"\n(async function*() { yield * [1, 2, 3] })().every(it => typeof it === 'number').then(it => {\n  if (it === true) asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+</script></td>
+<td class="unknown obsolete" data-browser="tr">?</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
+<td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20210808">?</td>
+<td class="unknown obsolete" data-browser="closure20210906">?</td>
+<td class="unknown obsolete" data-browser="closure20211006">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220719">?</td>
+<td class="unknown" data-browser="closure20230228">?</td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes" data-browser="typescript5_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="no obsolete" data-browser="firefox102">No</td>
+<td class="no obsolete" data-browser="firefox114">No</td>
+<td class="no" data-browser="firefox115">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no flagged obsolete" data-browser="firefox117">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox118">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox119">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox120">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox121">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox122">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox123">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox124">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox125">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox126">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged" data-browser="firefox127">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox128">Flag<a href="#ff-async-iterator-helpers-note"><sup>[11]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox129">Flag<a href="#ff-async-iterator-helpers-note"><sup>[11]</sup></a></td>
+<td class="unknown obsolete" data-browser="opera12_10">?</td>
+<td class="no obsolete" data-browser="chrome115">No</td>
+<td class="no obsolete" data-browser="chrome116">No</td>
+<td class="no obsolete" data-browser="chrome117">No</td>
+<td class="no obsolete" data-browser="chrome118">No</td>
+<td class="no obsolete" data-browser="chrome119">No</td>
+<td class="no obsolete" data-browser="chrome120">No</td>
+<td class="no obsolete" data-browser="chrome121">No</td>
+<td class="no obsolete" data-browser="chrome122">No</td>
+<td class="no obsolete" data-browser="chrome123">No</td>
+<td class="no obsolete" data-browser="chrome124">No</td>
+<td class="no obsolete" data-browser="chrome125">No</td>
+<td class="no" data-browser="chrome126">No</td>
+<td class="no unstable" data-browser="chrome127">No</td>
+<td class="no obsolete" data-browser="edge18">No</td>
+<td class="no obsolete" data-browser="edge115">No</td>
+<td class="no obsolete" data-browser="edge116">No</td>
+<td class="no obsolete" data-browser="edge117">No</td>
+<td class="no obsolete" data-browser="edge118">No</td>
+<td class="no obsolete" data-browser="edge119">No</td>
+<td class="no obsolete" data-browser="edge120">No</td>
+<td class="no obsolete" data-browser="edge121">No</td>
+<td class="no obsolete" data-browser="edge122">No</td>
+<td class="no obsolete" data-browser="edge123">No</td>
+<td class="no obsolete" data-browser="edge124">No</td>
+<td class="no obsolete" data-browser="edge125">No</td>
+<td class="no" data-browser="edge126">No</td>
+<td class="no unstable" data-browser="edge127">No</td>
+<td class="unknown obsolete" data-browser="safari15_6">?</td>
+<td class="unknown obsolete" data-browser="safari16_6">?</td>
+<td class="unknown obsolete" data-browser="safari17">?</td>
+<td class="unknown obsolete" data-browser="safari17_1">?</td>
+<td class="unknown obsolete" data-browser="safari17_2">?</td>
+<td class="unknown obsolete" data-browser="safari17_3">?</td>
+<td class="unknown obsolete" data-browser="safari17_4">?</td>
+<td class="unknown" data-browser="safari17_5">?</td>
+<td class="unknown unstable" data-browser="safaritp">?</td>
+<td class="unknown unstable" data-browser="webkit">?</td>
+<td class="no obsolete" data-browser="opera88">No</td>
+<td class="no obsolete" data-browser="opera89">No</td>
+<td class="no obsolete" data-browser="opera90">No</td>
+<td class="no obsolete" data-browser="opera91">No</td>
+<td class="no obsolete" data-browser="opera92">No</td>
+<td class="no obsolete" data-browser="opera93">No</td>
+<td class="no obsolete" data-browser="opera94">No</td>
+<td class="no obsolete" data-browser="opera95">No</td>
+<td class="no obsolete" data-browser="opera96">No</td>
+<td class="no obsolete" data-browser="opera97">No</td>
+<td class="no" data-browser="opera98">No</td>
+<td class="no unstable" data-browser="opera99">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
+<td class="no obsolete" data-browser="rhino1_7_14">No</td>
+<td class="no obsolete" data-browser="rhino1_7_15">No</td>
+<td class="unknown obsolete" data-browser="phantom2_1">?</td>
+<td class="unknown obsolete" data-browser="node0_4">?</td>
+<td class="unknown obsolete" data-browser="node0_6">?</td>
+<td class="unknown obsolete" data-browser="node0_8">?</td>
+<td class="unknown obsolete" data-browser="node0_10">?</td>
+<td class="unknown obsolete" data-browser="node0_12">?</td>
+<td class="no obsolete" data-browser="node14_6">No</td>
+<td class="no obsolete" data-browser="node16_0">No</td>
+<td class="no obsolete" data-browser="node16_9">No</td>
+<td class="no" data-browser="node16_11">No</td>
+<td class="no obsolete" data-browser="node17_0">No</td>
+<td class="no obsolete" data-browser="node17_2">No</td>
+<td class="no obsolete" data-browser="node18_0">No</td>
+<td class="no" data-browser="node18_3">No</td>
+<td class="no obsolete" data-browser="node19_0">No</td>
+<td class="no obsolete" data-browser="node19_2">No</td>
+<td class="no" data-browser="node20_0">No</td>
+<td class="no obsolete" data-browser="node21_0">No</td>
+<td class="no" data-browser="node22_0">No</td>
+<td class="no obsolete" data-browser="duktape2_6">No</td>
+<td class="no" data-browser="duktape2_7">No</td>
+<td class="unknown obsolete" data-browser="graalvm19">?</td>
+<td class="unknown obsolete" data-browser="graalvm19_3_6">?</td>
+<td class="unknown obsolete" data-browser="graalvm20">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_1">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_3">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_3_1">?</td>
+<td class="unknown obsolete" data-browser="graalvm21">?</td>
+<td class="no" data-browser="graalvm21_3_3">No</td>
+<td class="no" data-browser="graalvm22_2">No</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="deno1_33">No</td>
+<td class="no obsolete" data-browser="deno1_34">No</td>
+<td class="no obsolete" data-browser="deno1_35">No</td>
+<td class="no" data-browser="deno1_36">No</td>
+<td class="unknown obsolete" data-browser="android4_4">?</td>
+<td class="unknown obsolete" data-browser="android4_4_3">?</td>
+<td class="unknown obsolete" data-browser="ios12_2">?</td>
+<td class="unknown obsolete" data-browser="ios13_4">?</td>
+<td class="unknown obsolete" data-browser="ios14_5">?</td>
+<td class="unknown obsolete" data-browser="ios16">?</td>
+<td class="unknown obsolete" data-browser="ios16_1">?</td>
+<td class="unknown obsolete" data-browser="ios16_2">?</td>
+<td class="unknown obsolete" data-browser="ios16_3">?</td>
+<td class="unknown obsolete" data-browser="ios16_4">?</td>
+<td class="unknown obsolete" data-browser="ios16_5">?</td>
+<td class="unknown obsolete" data-browser="ios16_6">?</td>
+<td class="unknown" data-browser="ios17">?</td>
+<td class="no obsolete" data-browser="samsung19">No</td>
+<td class="no obsolete" data-browser="samsung20">No</td>
+<td class="no obsolete" data-browser="samsung21">No</td>
+<td class="no" data-browser="samsung22">No</td>
+<td class="no obsolete" data-browser="opera_mobile72">No</td>
+<td class="no obsolete" data-browser="opera_mobile73">No</td>
+<td class="no obsolete" data-browser="opera_mobile74">No</td>
+<td class="no obsolete" data-browser="opera_mobile75">No</td>
+<td class="no obsolete" data-browser="opera_mobile76">No</td>
+<td class="no" data-browser="opera_mobile77">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
+</tr>
+<tr class="subtest" data-parent="Async_Iterator_Helpers" id="test-Async_Iterator_Helpers_AsyncIterator.prototype.filter"><td><span><a class="anchor" href="#test-Async_Iterator_Helpers_AsyncIterator.prototype.filter">&#xA7;</a>AsyncIterator.prototype.filter</span><script data-source="
+async function toArray(iterator) {
+  const result = [];
+  for await (const it of iterator) result.push(it);
+  return result;
+}
+
+toArray(async function*() { yield * [1, 2, 3] }().filter(it =&gt; it % 2)).then(it =&gt; {
+  if (it.join() === &apos;1,3&apos;) asyncTestPassed();
+});
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("43");try{return Function("asyncTestPassed","\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray(async function*() { yield * [1, 2, 3] }().filter(it => it % 2)).then(it => {\n  if (it.join() === '1,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("43");return Function("asyncTestPassed","'use strict';"+"\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray(async function*() { yield * [1, 2, 3] }().filter(it => it % 2)).then(it => {\n  if (it.join() === '1,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+</script></td>
+<td class="unknown obsolete" data-browser="tr">?</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
+<td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20210808">?</td>
+<td class="unknown obsolete" data-browser="closure20210906">?</td>
+<td class="unknown obsolete" data-browser="closure20211006">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220719">?</td>
+<td class="unknown" data-browser="closure20230228">?</td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes" data-browser="typescript5_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="no obsolete" data-browser="firefox102">No</td>
+<td class="no obsolete" data-browser="firefox114">No</td>
+<td class="no" data-browser="firefox115">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no flagged obsolete" data-browser="firefox117">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox118">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox119">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox120">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox121">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox122">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox123">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox124">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox125">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox126">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged" data-browser="firefox127">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox128">Flag<a href="#ff-async-iterator-helpers-note"><sup>[11]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox129">Flag<a href="#ff-async-iterator-helpers-note"><sup>[11]</sup></a></td>
+<td class="unknown obsolete" data-browser="opera12_10">?</td>
+<td class="no obsolete" data-browser="chrome115">No</td>
+<td class="no obsolete" data-browser="chrome116">No</td>
+<td class="no obsolete" data-browser="chrome117">No</td>
+<td class="no obsolete" data-browser="chrome118">No</td>
+<td class="no obsolete" data-browser="chrome119">No</td>
+<td class="no obsolete" data-browser="chrome120">No</td>
+<td class="no obsolete" data-browser="chrome121">No</td>
+<td class="no obsolete" data-browser="chrome122">No</td>
+<td class="no obsolete" data-browser="chrome123">No</td>
+<td class="no obsolete" data-browser="chrome124">No</td>
+<td class="no obsolete" data-browser="chrome125">No</td>
+<td class="no" data-browser="chrome126">No</td>
+<td class="no unstable" data-browser="chrome127">No</td>
+<td class="no obsolete" data-browser="edge18">No</td>
+<td class="no obsolete" data-browser="edge115">No</td>
+<td class="no obsolete" data-browser="edge116">No</td>
+<td class="no obsolete" data-browser="edge117">No</td>
+<td class="no obsolete" data-browser="edge118">No</td>
+<td class="no obsolete" data-browser="edge119">No</td>
+<td class="no obsolete" data-browser="edge120">No</td>
+<td class="no obsolete" data-browser="edge121">No</td>
+<td class="no obsolete" data-browser="edge122">No</td>
+<td class="no obsolete" data-browser="edge123">No</td>
+<td class="no obsolete" data-browser="edge124">No</td>
+<td class="no obsolete" data-browser="edge125">No</td>
+<td class="no" data-browser="edge126">No</td>
+<td class="no unstable" data-browser="edge127">No</td>
+<td class="unknown obsolete" data-browser="safari15_6">?</td>
+<td class="unknown obsolete" data-browser="safari16_6">?</td>
+<td class="unknown obsolete" data-browser="safari17">?</td>
+<td class="unknown obsolete" data-browser="safari17_1">?</td>
+<td class="unknown obsolete" data-browser="safari17_2">?</td>
+<td class="unknown obsolete" data-browser="safari17_3">?</td>
+<td class="unknown obsolete" data-browser="safari17_4">?</td>
+<td class="unknown" data-browser="safari17_5">?</td>
+<td class="unknown unstable" data-browser="safaritp">?</td>
+<td class="unknown unstable" data-browser="webkit">?</td>
+<td class="no obsolete" data-browser="opera88">No</td>
+<td class="no obsolete" data-browser="opera89">No</td>
+<td class="no obsolete" data-browser="opera90">No</td>
+<td class="no obsolete" data-browser="opera91">No</td>
+<td class="no obsolete" data-browser="opera92">No</td>
+<td class="no obsolete" data-browser="opera93">No</td>
+<td class="no obsolete" data-browser="opera94">No</td>
+<td class="no obsolete" data-browser="opera95">No</td>
+<td class="no obsolete" data-browser="opera96">No</td>
+<td class="no obsolete" data-browser="opera97">No</td>
+<td class="no" data-browser="opera98">No</td>
+<td class="no unstable" data-browser="opera99">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
+<td class="no obsolete" data-browser="rhino1_7_14">No</td>
+<td class="no obsolete" data-browser="rhino1_7_15">No</td>
+<td class="unknown obsolete" data-browser="phantom2_1">?</td>
+<td class="unknown obsolete" data-browser="node0_4">?</td>
+<td class="unknown obsolete" data-browser="node0_6">?</td>
+<td class="unknown obsolete" data-browser="node0_8">?</td>
+<td class="unknown obsolete" data-browser="node0_10">?</td>
+<td class="unknown obsolete" data-browser="node0_12">?</td>
+<td class="no obsolete" data-browser="node14_6">No</td>
+<td class="no obsolete" data-browser="node16_0">No</td>
+<td class="no obsolete" data-browser="node16_9">No</td>
+<td class="no" data-browser="node16_11">No</td>
+<td class="no obsolete" data-browser="node17_0">No</td>
+<td class="no obsolete" data-browser="node17_2">No</td>
+<td class="no obsolete" data-browser="node18_0">No</td>
+<td class="no" data-browser="node18_3">No</td>
+<td class="no obsolete" data-browser="node19_0">No</td>
+<td class="no obsolete" data-browser="node19_2">No</td>
+<td class="no" data-browser="node20_0">No</td>
+<td class="no obsolete" data-browser="node21_0">No</td>
+<td class="no" data-browser="node22_0">No</td>
+<td class="no obsolete" data-browser="duktape2_6">No</td>
+<td class="no" data-browser="duktape2_7">No</td>
+<td class="unknown obsolete" data-browser="graalvm19">?</td>
+<td class="unknown obsolete" data-browser="graalvm19_3_6">?</td>
+<td class="unknown obsolete" data-browser="graalvm20">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_1">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_3">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_3_1">?</td>
+<td class="unknown obsolete" data-browser="graalvm21">?</td>
+<td class="no" data-browser="graalvm21_3_3">No</td>
+<td class="no" data-browser="graalvm22_2">No</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="deno1_33">No</td>
+<td class="no obsolete" data-browser="deno1_34">No</td>
+<td class="no obsolete" data-browser="deno1_35">No</td>
+<td class="no" data-browser="deno1_36">No</td>
+<td class="unknown obsolete" data-browser="android4_4">?</td>
+<td class="unknown obsolete" data-browser="android4_4_3">?</td>
+<td class="unknown obsolete" data-browser="ios12_2">?</td>
+<td class="unknown obsolete" data-browser="ios13_4">?</td>
+<td class="unknown obsolete" data-browser="ios14_5">?</td>
+<td class="unknown obsolete" data-browser="ios16">?</td>
+<td class="unknown obsolete" data-browser="ios16_1">?</td>
+<td class="unknown obsolete" data-browser="ios16_2">?</td>
+<td class="unknown obsolete" data-browser="ios16_3">?</td>
+<td class="unknown obsolete" data-browser="ios16_4">?</td>
+<td class="unknown obsolete" data-browser="ios16_5">?</td>
+<td class="unknown obsolete" data-browser="ios16_6">?</td>
+<td class="unknown" data-browser="ios17">?</td>
+<td class="no obsolete" data-browser="samsung19">No</td>
+<td class="no obsolete" data-browser="samsung20">No</td>
+<td class="no obsolete" data-browser="samsung21">No</td>
+<td class="no" data-browser="samsung22">No</td>
+<td class="no obsolete" data-browser="opera_mobile72">No</td>
+<td class="no obsolete" data-browser="opera_mobile73">No</td>
+<td class="no obsolete" data-browser="opera_mobile74">No</td>
+<td class="no obsolete" data-browser="opera_mobile75">No</td>
+<td class="no obsolete" data-browser="opera_mobile76">No</td>
+<td class="no" data-browser="opera_mobile77">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
+</tr>
+<tr class="subtest" data-parent="Async_Iterator_Helpers" id="test-Async_Iterator_Helpers_AsyncIterator.prototype.find"><td><span><a class="anchor" href="#test-Async_Iterator_Helpers_AsyncIterator.prototype.find">&#xA7;</a>AsyncIterator.prototype.find</span><script data-source="
+(async function*() { yield * [1, 2, 3] })().find(it =&gt; it % 2).then(it =&gt; {
+  if (it === 1) asyncTestPassed();
+});
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("44");try{return Function("asyncTestPassed","\n(async function*() { yield * [1, 2, 3] })().find(it => it % 2).then(it => {\n  if (it === 1) asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("44");return Function("asyncTestPassed","'use strict';"+"\n(async function*() { yield * [1, 2, 3] })().find(it => it % 2).then(it => {\n  if (it === 1) asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+</script></td>
+<td class="unknown obsolete" data-browser="tr">?</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
+<td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20210808">?</td>
+<td class="unknown obsolete" data-browser="closure20210906">?</td>
+<td class="unknown obsolete" data-browser="closure20211006">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220719">?</td>
+<td class="unknown" data-browser="closure20230228">?</td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes" data-browser="typescript5_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="no obsolete" data-browser="firefox102">No</td>
+<td class="no obsolete" data-browser="firefox114">No</td>
+<td class="no" data-browser="firefox115">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no flagged obsolete" data-browser="firefox117">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox118">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox119">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox120">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox121">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox122">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox123">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox124">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox125">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox126">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged" data-browser="firefox127">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox128">Flag<a href="#ff-async-iterator-helpers-note"><sup>[11]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox129">Flag<a href="#ff-async-iterator-helpers-note"><sup>[11]</sup></a></td>
+<td class="unknown obsolete" data-browser="opera12_10">?</td>
+<td class="no obsolete" data-browser="chrome115">No</td>
+<td class="no obsolete" data-browser="chrome116">No</td>
+<td class="no obsolete" data-browser="chrome117">No</td>
+<td class="no obsolete" data-browser="chrome118">No</td>
+<td class="no obsolete" data-browser="chrome119">No</td>
+<td class="no obsolete" data-browser="chrome120">No</td>
+<td class="no obsolete" data-browser="chrome121">No</td>
+<td class="no obsolete" data-browser="chrome122">No</td>
+<td class="no obsolete" data-browser="chrome123">No</td>
+<td class="no obsolete" data-browser="chrome124">No</td>
+<td class="no obsolete" data-browser="chrome125">No</td>
+<td class="no" data-browser="chrome126">No</td>
+<td class="no unstable" data-browser="chrome127">No</td>
+<td class="no obsolete" data-browser="edge18">No</td>
+<td class="no obsolete" data-browser="edge115">No</td>
+<td class="no obsolete" data-browser="edge116">No</td>
+<td class="no obsolete" data-browser="edge117">No</td>
+<td class="no obsolete" data-browser="edge118">No</td>
+<td class="no obsolete" data-browser="edge119">No</td>
+<td class="no obsolete" data-browser="edge120">No</td>
+<td class="no obsolete" data-browser="edge121">No</td>
+<td class="no obsolete" data-browser="edge122">No</td>
+<td class="no obsolete" data-browser="edge123">No</td>
+<td class="no obsolete" data-browser="edge124">No</td>
+<td class="no obsolete" data-browser="edge125">No</td>
+<td class="no" data-browser="edge126">No</td>
+<td class="no unstable" data-browser="edge127">No</td>
+<td class="unknown obsolete" data-browser="safari15_6">?</td>
+<td class="unknown obsolete" data-browser="safari16_6">?</td>
+<td class="unknown obsolete" data-browser="safari17">?</td>
+<td class="unknown obsolete" data-browser="safari17_1">?</td>
+<td class="unknown obsolete" data-browser="safari17_2">?</td>
+<td class="unknown obsolete" data-browser="safari17_3">?</td>
+<td class="unknown obsolete" data-browser="safari17_4">?</td>
+<td class="unknown" data-browser="safari17_5">?</td>
+<td class="unknown unstable" data-browser="safaritp">?</td>
+<td class="unknown unstable" data-browser="webkit">?</td>
+<td class="no obsolete" data-browser="opera88">No</td>
+<td class="no obsolete" data-browser="opera89">No</td>
+<td class="no obsolete" data-browser="opera90">No</td>
+<td class="no obsolete" data-browser="opera91">No</td>
+<td class="no obsolete" data-browser="opera92">No</td>
+<td class="no obsolete" data-browser="opera93">No</td>
+<td class="no obsolete" data-browser="opera94">No</td>
+<td class="no obsolete" data-browser="opera95">No</td>
+<td class="no obsolete" data-browser="opera96">No</td>
+<td class="no obsolete" data-browser="opera97">No</td>
+<td class="no" data-browser="opera98">No</td>
+<td class="no unstable" data-browser="opera99">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
+<td class="no obsolete" data-browser="rhino1_7_14">No</td>
+<td class="no obsolete" data-browser="rhino1_7_15">No</td>
+<td class="unknown obsolete" data-browser="phantom2_1">?</td>
+<td class="unknown obsolete" data-browser="node0_4">?</td>
+<td class="unknown obsolete" data-browser="node0_6">?</td>
+<td class="unknown obsolete" data-browser="node0_8">?</td>
+<td class="unknown obsolete" data-browser="node0_10">?</td>
+<td class="unknown obsolete" data-browser="node0_12">?</td>
+<td class="no obsolete" data-browser="node14_6">No</td>
+<td class="no obsolete" data-browser="node16_0">No</td>
+<td class="no obsolete" data-browser="node16_9">No</td>
+<td class="no" data-browser="node16_11">No</td>
+<td class="no obsolete" data-browser="node17_0">No</td>
+<td class="no obsolete" data-browser="node17_2">No</td>
+<td class="no obsolete" data-browser="node18_0">No</td>
+<td class="no" data-browser="node18_3">No</td>
+<td class="no obsolete" data-browser="node19_0">No</td>
+<td class="no obsolete" data-browser="node19_2">No</td>
+<td class="no" data-browser="node20_0">No</td>
+<td class="no obsolete" data-browser="node21_0">No</td>
+<td class="no" data-browser="node22_0">No</td>
+<td class="no obsolete" data-browser="duktape2_6">No</td>
+<td class="no" data-browser="duktape2_7">No</td>
+<td class="unknown obsolete" data-browser="graalvm19">?</td>
+<td class="unknown obsolete" data-browser="graalvm19_3_6">?</td>
+<td class="unknown obsolete" data-browser="graalvm20">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_1">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_3">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_3_1">?</td>
+<td class="unknown obsolete" data-browser="graalvm21">?</td>
+<td class="no" data-browser="graalvm21_3_3">No</td>
+<td class="no" data-browser="graalvm22_2">No</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="deno1_33">No</td>
+<td class="no obsolete" data-browser="deno1_34">No</td>
+<td class="no obsolete" data-browser="deno1_35">No</td>
+<td class="no" data-browser="deno1_36">No</td>
+<td class="unknown obsolete" data-browser="android4_4">?</td>
+<td class="unknown obsolete" data-browser="android4_4_3">?</td>
+<td class="unknown obsolete" data-browser="ios12_2">?</td>
+<td class="unknown obsolete" data-browser="ios13_4">?</td>
+<td class="unknown obsolete" data-browser="ios14_5">?</td>
+<td class="unknown obsolete" data-browser="ios16">?</td>
+<td class="unknown obsolete" data-browser="ios16_1">?</td>
+<td class="unknown obsolete" data-browser="ios16_2">?</td>
+<td class="unknown obsolete" data-browser="ios16_3">?</td>
+<td class="unknown obsolete" data-browser="ios16_4">?</td>
+<td class="unknown obsolete" data-browser="ios16_5">?</td>
+<td class="unknown obsolete" data-browser="ios16_6">?</td>
+<td class="unknown" data-browser="ios17">?</td>
+<td class="no obsolete" data-browser="samsung19">No</td>
+<td class="no obsolete" data-browser="samsung20">No</td>
+<td class="no obsolete" data-browser="samsung21">No</td>
+<td class="no" data-browser="samsung22">No</td>
+<td class="no obsolete" data-browser="opera_mobile72">No</td>
+<td class="no obsolete" data-browser="opera_mobile73">No</td>
+<td class="no obsolete" data-browser="opera_mobile74">No</td>
+<td class="no obsolete" data-browser="opera_mobile75">No</td>
+<td class="no obsolete" data-browser="opera_mobile76">No</td>
+<td class="no" data-browser="opera_mobile77">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
+</tr>
+<tr class="subtest" data-parent="Async_Iterator_Helpers" id="test-Async_Iterator_Helpers_AsyncIterator.prototype.flatMap"><td><span><a class="anchor" href="#test-Async_Iterator_Helpers_AsyncIterator.prototype.flatMap">&#xA7;</a>AsyncIterator.prototype.flatMap</span><script data-source="
+async function toArray(iterator) {
+  const result = [];
+  for await (const it of iterator) result.push(it);
+  return result;
+}
+
+toArray(async function*() { yield * [1, 2, 3] }().flatMap(it =&gt; [it, 0])).then(it =&gt; {
+  if (it.join() === &apos;1,0,2,0,3,0&apos;) asyncTestPassed();
+});
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("45");try{return Function("asyncTestPassed","\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray(async function*() { yield * [1, 2, 3] }().flatMap(it => [it, 0])).then(it => {\n  if (it.join() === '1,0,2,0,3,0') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("45");return Function("asyncTestPassed","'use strict';"+"\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray(async function*() { yield * [1, 2, 3] }().flatMap(it => [it, 0])).then(it => {\n  if (it.join() === '1,0,2,0,3,0') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+</script></td>
+<td class="unknown obsolete" data-browser="tr">?</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
+<td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20210808">?</td>
+<td class="unknown obsolete" data-browser="closure20210906">?</td>
+<td class="unknown obsolete" data-browser="closure20211006">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220719">?</td>
+<td class="unknown" data-browser="closure20230228">?</td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes" data-browser="typescript5_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="no obsolete" data-browser="firefox102">No</td>
+<td class="no obsolete" data-browser="firefox114">No</td>
+<td class="no" data-browser="firefox115">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no flagged obsolete" data-browser="firefox117">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox118">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox119">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox120">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox121">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox122">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox123">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox124">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox125">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox126">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged" data-browser="firefox127">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox128">Flag<a href="#ff-async-iterator-helpers-note"><sup>[11]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox129">Flag<a href="#ff-async-iterator-helpers-note"><sup>[11]</sup></a></td>
+<td class="unknown obsolete" data-browser="opera12_10">?</td>
+<td class="no obsolete" data-browser="chrome115">No</td>
+<td class="no obsolete" data-browser="chrome116">No</td>
+<td class="no obsolete" data-browser="chrome117">No</td>
+<td class="no obsolete" data-browser="chrome118">No</td>
+<td class="no obsolete" data-browser="chrome119">No</td>
+<td class="no obsolete" data-browser="chrome120">No</td>
+<td class="no obsolete" data-browser="chrome121">No</td>
+<td class="no obsolete" data-browser="chrome122">No</td>
+<td class="no obsolete" data-browser="chrome123">No</td>
+<td class="no obsolete" data-browser="chrome124">No</td>
+<td class="no obsolete" data-browser="chrome125">No</td>
+<td class="no" data-browser="chrome126">No</td>
+<td class="no unstable" data-browser="chrome127">No</td>
+<td class="no obsolete" data-browser="edge18">No</td>
+<td class="no obsolete" data-browser="edge115">No</td>
+<td class="no obsolete" data-browser="edge116">No</td>
+<td class="no obsolete" data-browser="edge117">No</td>
+<td class="no obsolete" data-browser="edge118">No</td>
+<td class="no obsolete" data-browser="edge119">No</td>
+<td class="no obsolete" data-browser="edge120">No</td>
+<td class="no obsolete" data-browser="edge121">No</td>
+<td class="no obsolete" data-browser="edge122">No</td>
+<td class="no obsolete" data-browser="edge123">No</td>
+<td class="no obsolete" data-browser="edge124">No</td>
+<td class="no obsolete" data-browser="edge125">No</td>
+<td class="no" data-browser="edge126">No</td>
+<td class="no unstable" data-browser="edge127">No</td>
+<td class="unknown obsolete" data-browser="safari15_6">?</td>
+<td class="unknown obsolete" data-browser="safari16_6">?</td>
+<td class="unknown obsolete" data-browser="safari17">?</td>
+<td class="unknown obsolete" data-browser="safari17_1">?</td>
+<td class="unknown obsolete" data-browser="safari17_2">?</td>
+<td class="unknown obsolete" data-browser="safari17_3">?</td>
+<td class="unknown obsolete" data-browser="safari17_4">?</td>
+<td class="unknown" data-browser="safari17_5">?</td>
+<td class="unknown unstable" data-browser="safaritp">?</td>
+<td class="unknown unstable" data-browser="webkit">?</td>
+<td class="no obsolete" data-browser="opera88">No</td>
+<td class="no obsolete" data-browser="opera89">No</td>
+<td class="no obsolete" data-browser="opera90">No</td>
+<td class="no obsolete" data-browser="opera91">No</td>
+<td class="no obsolete" data-browser="opera92">No</td>
+<td class="no obsolete" data-browser="opera93">No</td>
+<td class="no obsolete" data-browser="opera94">No</td>
+<td class="no obsolete" data-browser="opera95">No</td>
+<td class="no obsolete" data-browser="opera96">No</td>
+<td class="no obsolete" data-browser="opera97">No</td>
+<td class="no" data-browser="opera98">No</td>
+<td class="no unstable" data-browser="opera99">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
+<td class="no obsolete" data-browser="rhino1_7_14">No</td>
+<td class="no obsolete" data-browser="rhino1_7_15">No</td>
+<td class="unknown obsolete" data-browser="phantom2_1">?</td>
+<td class="unknown obsolete" data-browser="node0_4">?</td>
+<td class="unknown obsolete" data-browser="node0_6">?</td>
+<td class="unknown obsolete" data-browser="node0_8">?</td>
+<td class="unknown obsolete" data-browser="node0_10">?</td>
+<td class="unknown obsolete" data-browser="node0_12">?</td>
+<td class="no obsolete" data-browser="node14_6">No</td>
+<td class="no obsolete" data-browser="node16_0">No</td>
+<td class="no obsolete" data-browser="node16_9">No</td>
+<td class="no" data-browser="node16_11">No</td>
+<td class="no obsolete" data-browser="node17_0">No</td>
+<td class="no obsolete" data-browser="node17_2">No</td>
+<td class="no obsolete" data-browser="node18_0">No</td>
+<td class="no" data-browser="node18_3">No</td>
+<td class="no obsolete" data-browser="node19_0">No</td>
+<td class="no obsolete" data-browser="node19_2">No</td>
+<td class="no" data-browser="node20_0">No</td>
+<td class="no obsolete" data-browser="node21_0">No</td>
+<td class="no" data-browser="node22_0">No</td>
+<td class="no obsolete" data-browser="duktape2_6">No</td>
+<td class="no" data-browser="duktape2_7">No</td>
+<td class="unknown obsolete" data-browser="graalvm19">?</td>
+<td class="unknown obsolete" data-browser="graalvm19_3_6">?</td>
+<td class="unknown obsolete" data-browser="graalvm20">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_1">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_3">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_3_1">?</td>
+<td class="unknown obsolete" data-browser="graalvm21">?</td>
+<td class="no" data-browser="graalvm21_3_3">No</td>
+<td class="no" data-browser="graalvm22_2">No</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="deno1_33">No</td>
+<td class="no obsolete" data-browser="deno1_34">No</td>
+<td class="no obsolete" data-browser="deno1_35">No</td>
+<td class="no" data-browser="deno1_36">No</td>
+<td class="unknown obsolete" data-browser="android4_4">?</td>
+<td class="unknown obsolete" data-browser="android4_4_3">?</td>
+<td class="unknown obsolete" data-browser="ios12_2">?</td>
+<td class="unknown obsolete" data-browser="ios13_4">?</td>
+<td class="unknown obsolete" data-browser="ios14_5">?</td>
+<td class="unknown obsolete" data-browser="ios16">?</td>
+<td class="unknown obsolete" data-browser="ios16_1">?</td>
+<td class="unknown obsolete" data-browser="ios16_2">?</td>
+<td class="unknown obsolete" data-browser="ios16_3">?</td>
+<td class="unknown obsolete" data-browser="ios16_4">?</td>
+<td class="unknown obsolete" data-browser="ios16_5">?</td>
+<td class="unknown obsolete" data-browser="ios16_6">?</td>
+<td class="unknown" data-browser="ios17">?</td>
+<td class="no obsolete" data-browser="samsung19">No</td>
+<td class="no obsolete" data-browser="samsung20">No</td>
+<td class="no obsolete" data-browser="samsung21">No</td>
+<td class="no" data-browser="samsung22">No</td>
+<td class="no obsolete" data-browser="opera_mobile72">No</td>
+<td class="no obsolete" data-browser="opera_mobile73">No</td>
+<td class="no obsolete" data-browser="opera_mobile74">No</td>
+<td class="no obsolete" data-browser="opera_mobile75">No</td>
+<td class="no obsolete" data-browser="opera_mobile76">No</td>
+<td class="no" data-browser="opera_mobile77">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
+</tr>
+<tr class="subtest" data-parent="Async_Iterator_Helpers" id="test-Async_Iterator_Helpers_AsyncIterator.prototype.forEach"><td><span><a class="anchor" href="#test-Async_Iterator_Helpers_AsyncIterator.prototype.forEach">&#xA7;</a>AsyncIterator.prototype.forEach</span><script data-source="
+let result = &apos;&apos;;
+(async function*() { yield * [1, 2, 3] })().forEach(it =&gt; result += it).then(() =&gt; {
+  if (result === &apos;123&apos;) asyncTestPassed();
+});
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("46");try{return Function("asyncTestPassed","\nlet result = '';\n(async function*() { yield * [1, 2, 3] })().forEach(it => result += it).then(() => {\n  if (result === '123') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("46");return Function("asyncTestPassed","'use strict';"+"\nlet result = '';\n(async function*() { yield * [1, 2, 3] })().forEach(it => result += it).then(() => {\n  if (result === '123') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+</script></td>
+<td class="unknown obsolete" data-browser="tr">?</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
+<td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20210808">?</td>
+<td class="unknown obsolete" data-browser="closure20210906">?</td>
+<td class="unknown obsolete" data-browser="closure20211006">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220719">?</td>
+<td class="unknown" data-browser="closure20230228">?</td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes" data-browser="typescript5_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="no obsolete" data-browser="firefox102">No</td>
+<td class="no obsolete" data-browser="firefox114">No</td>
+<td class="no" data-browser="firefox115">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no flagged obsolete" data-browser="firefox117">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox118">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox119">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox120">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox121">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox122">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox123">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox124">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox125">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox126">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged" data-browser="firefox127">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox128">Flag<a href="#ff-async-iterator-helpers-note"><sup>[11]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox129">Flag<a href="#ff-async-iterator-helpers-note"><sup>[11]</sup></a></td>
+<td class="unknown obsolete" data-browser="opera12_10">?</td>
+<td class="no obsolete" data-browser="chrome115">No</td>
+<td class="no obsolete" data-browser="chrome116">No</td>
+<td class="no obsolete" data-browser="chrome117">No</td>
+<td class="no obsolete" data-browser="chrome118">No</td>
+<td class="no obsolete" data-browser="chrome119">No</td>
+<td class="no obsolete" data-browser="chrome120">No</td>
+<td class="no obsolete" data-browser="chrome121">No</td>
+<td class="no obsolete" data-browser="chrome122">No</td>
+<td class="no obsolete" data-browser="chrome123">No</td>
+<td class="no obsolete" data-browser="chrome124">No</td>
+<td class="no obsolete" data-browser="chrome125">No</td>
+<td class="no" data-browser="chrome126">No</td>
+<td class="no unstable" data-browser="chrome127">No</td>
+<td class="no obsolete" data-browser="edge18">No</td>
+<td class="no obsolete" data-browser="edge115">No</td>
+<td class="no obsolete" data-browser="edge116">No</td>
+<td class="no obsolete" data-browser="edge117">No</td>
+<td class="no obsolete" data-browser="edge118">No</td>
+<td class="no obsolete" data-browser="edge119">No</td>
+<td class="no obsolete" data-browser="edge120">No</td>
+<td class="no obsolete" data-browser="edge121">No</td>
+<td class="no obsolete" data-browser="edge122">No</td>
+<td class="no obsolete" data-browser="edge123">No</td>
+<td class="no obsolete" data-browser="edge124">No</td>
+<td class="no obsolete" data-browser="edge125">No</td>
+<td class="no" data-browser="edge126">No</td>
+<td class="no unstable" data-browser="edge127">No</td>
+<td class="unknown obsolete" data-browser="safari15_6">?</td>
+<td class="unknown obsolete" data-browser="safari16_6">?</td>
+<td class="unknown obsolete" data-browser="safari17">?</td>
+<td class="unknown obsolete" data-browser="safari17_1">?</td>
+<td class="unknown obsolete" data-browser="safari17_2">?</td>
+<td class="unknown obsolete" data-browser="safari17_3">?</td>
+<td class="unknown obsolete" data-browser="safari17_4">?</td>
+<td class="unknown" data-browser="safari17_5">?</td>
+<td class="unknown unstable" data-browser="safaritp">?</td>
+<td class="unknown unstable" data-browser="webkit">?</td>
+<td class="no obsolete" data-browser="opera88">No</td>
+<td class="no obsolete" data-browser="opera89">No</td>
+<td class="no obsolete" data-browser="opera90">No</td>
+<td class="no obsolete" data-browser="opera91">No</td>
+<td class="no obsolete" data-browser="opera92">No</td>
+<td class="no obsolete" data-browser="opera93">No</td>
+<td class="no obsolete" data-browser="opera94">No</td>
+<td class="no obsolete" data-browser="opera95">No</td>
+<td class="no obsolete" data-browser="opera96">No</td>
+<td class="no obsolete" data-browser="opera97">No</td>
+<td class="no" data-browser="opera98">No</td>
+<td class="no unstable" data-browser="opera99">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
+<td class="no obsolete" data-browser="rhino1_7_14">No</td>
+<td class="no obsolete" data-browser="rhino1_7_15">No</td>
+<td class="unknown obsolete" data-browser="phantom2_1">?</td>
+<td class="unknown obsolete" data-browser="node0_4">?</td>
+<td class="unknown obsolete" data-browser="node0_6">?</td>
+<td class="unknown obsolete" data-browser="node0_8">?</td>
+<td class="unknown obsolete" data-browser="node0_10">?</td>
+<td class="unknown obsolete" data-browser="node0_12">?</td>
+<td class="no obsolete" data-browser="node14_6">No</td>
+<td class="no obsolete" data-browser="node16_0">No</td>
+<td class="no obsolete" data-browser="node16_9">No</td>
+<td class="no" data-browser="node16_11">No</td>
+<td class="no obsolete" data-browser="node17_0">No</td>
+<td class="no obsolete" data-browser="node17_2">No</td>
+<td class="no obsolete" data-browser="node18_0">No</td>
+<td class="no" data-browser="node18_3">No</td>
+<td class="no obsolete" data-browser="node19_0">No</td>
+<td class="no obsolete" data-browser="node19_2">No</td>
+<td class="no" data-browser="node20_0">No</td>
+<td class="no obsolete" data-browser="node21_0">No</td>
+<td class="no" data-browser="node22_0">No</td>
+<td class="no obsolete" data-browser="duktape2_6">No</td>
+<td class="no" data-browser="duktape2_7">No</td>
+<td class="unknown obsolete" data-browser="graalvm19">?</td>
+<td class="unknown obsolete" data-browser="graalvm19_3_6">?</td>
+<td class="unknown obsolete" data-browser="graalvm20">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_1">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_3">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_3_1">?</td>
+<td class="unknown obsolete" data-browser="graalvm21">?</td>
+<td class="no" data-browser="graalvm21_3_3">No</td>
+<td class="no" data-browser="graalvm22_2">No</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="deno1_33">No</td>
+<td class="no obsolete" data-browser="deno1_34">No</td>
+<td class="no obsolete" data-browser="deno1_35">No</td>
+<td class="no" data-browser="deno1_36">No</td>
+<td class="unknown obsolete" data-browser="android4_4">?</td>
+<td class="unknown obsolete" data-browser="android4_4_3">?</td>
+<td class="unknown obsolete" data-browser="ios12_2">?</td>
+<td class="unknown obsolete" data-browser="ios13_4">?</td>
+<td class="unknown obsolete" data-browser="ios14_5">?</td>
+<td class="unknown obsolete" data-browser="ios16">?</td>
+<td class="unknown obsolete" data-browser="ios16_1">?</td>
+<td class="unknown obsolete" data-browser="ios16_2">?</td>
+<td class="unknown obsolete" data-browser="ios16_3">?</td>
+<td class="unknown obsolete" data-browser="ios16_4">?</td>
+<td class="unknown obsolete" data-browser="ios16_5">?</td>
+<td class="unknown obsolete" data-browser="ios16_6">?</td>
+<td class="unknown" data-browser="ios17">?</td>
+<td class="no obsolete" data-browser="samsung19">No</td>
+<td class="no obsolete" data-browser="samsung20">No</td>
+<td class="no obsolete" data-browser="samsung21">No</td>
+<td class="no" data-browser="samsung22">No</td>
+<td class="no obsolete" data-browser="opera_mobile72">No</td>
+<td class="no obsolete" data-browser="opera_mobile73">No</td>
+<td class="no obsolete" data-browser="opera_mobile74">No</td>
+<td class="no obsolete" data-browser="opera_mobile75">No</td>
+<td class="no obsolete" data-browser="opera_mobile76">No</td>
+<td class="no" data-browser="opera_mobile77">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
+</tr>
+<tr class="subtest" data-parent="Async_Iterator_Helpers" id="test-Async_Iterator_Helpers_AsyncIterator.prototype.map"><td><span><a class="anchor" href="#test-Async_Iterator_Helpers_AsyncIterator.prototype.map">&#xA7;</a>AsyncIterator.prototype.map</span><script data-source="
+async function toArray(iterator) {
+  const result = [];
+  for await (const it of iterator) result.push(it);
+  return result;
+}
+
+toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it =&gt; {
+  if (it.join() === &apos;1,4,9&apos;) asyncTestPassed();
+});
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("47");try{return Function("asyncTestPassed","\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray(async function*() { yield * [1, 2, 3] }().map(it => it * it)).then(it => {\n  if (it.join() === '1,4,9') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("47");return Function("asyncTestPassed","'use strict';"+"\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray(async function*() { yield * [1, 2, 3] }().map(it => it * it)).then(it => {\n  if (it.join() === '1,4,9') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+</script></td>
+<td class="unknown obsolete" data-browser="tr">?</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
+<td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20210808">?</td>
+<td class="unknown obsolete" data-browser="closure20210906">?</td>
+<td class="unknown obsolete" data-browser="closure20211006">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220719">?</td>
+<td class="unknown" data-browser="closure20230228">?</td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes" data-browser="typescript5_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="no obsolete" data-browser="firefox102">No</td>
+<td class="no obsolete" data-browser="firefox114">No</td>
+<td class="no" data-browser="firefox115">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no flagged obsolete" data-browser="firefox117">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox118">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox119">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox120">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox121">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox122">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox123">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox124">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox125">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox126">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged" data-browser="firefox127">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox128">Flag<a href="#ff-async-iterator-helpers-note"><sup>[11]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox129">Flag<a href="#ff-async-iterator-helpers-note"><sup>[11]</sup></a></td>
+<td class="unknown obsolete" data-browser="opera12_10">?</td>
+<td class="no obsolete" data-browser="chrome115">No</td>
+<td class="no obsolete" data-browser="chrome116">No</td>
+<td class="no obsolete" data-browser="chrome117">No</td>
+<td class="no obsolete" data-browser="chrome118">No</td>
+<td class="no obsolete" data-browser="chrome119">No</td>
+<td class="no obsolete" data-browser="chrome120">No</td>
+<td class="no obsolete" data-browser="chrome121">No</td>
+<td class="no obsolete" data-browser="chrome122">No</td>
+<td class="no obsolete" data-browser="chrome123">No</td>
+<td class="no obsolete" data-browser="chrome124">No</td>
+<td class="no obsolete" data-browser="chrome125">No</td>
+<td class="no" data-browser="chrome126">No</td>
+<td class="no unstable" data-browser="chrome127">No</td>
+<td class="no obsolete" data-browser="edge18">No</td>
+<td class="no obsolete" data-browser="edge115">No</td>
+<td class="no obsolete" data-browser="edge116">No</td>
+<td class="no obsolete" data-browser="edge117">No</td>
+<td class="no obsolete" data-browser="edge118">No</td>
+<td class="no obsolete" data-browser="edge119">No</td>
+<td class="no obsolete" data-browser="edge120">No</td>
+<td class="no obsolete" data-browser="edge121">No</td>
+<td class="no obsolete" data-browser="edge122">No</td>
+<td class="no obsolete" data-browser="edge123">No</td>
+<td class="no obsolete" data-browser="edge124">No</td>
+<td class="no obsolete" data-browser="edge125">No</td>
+<td class="no" data-browser="edge126">No</td>
+<td class="no unstable" data-browser="edge127">No</td>
+<td class="unknown obsolete" data-browser="safari15_6">?</td>
+<td class="unknown obsolete" data-browser="safari16_6">?</td>
+<td class="unknown obsolete" data-browser="safari17">?</td>
+<td class="unknown obsolete" data-browser="safari17_1">?</td>
+<td class="unknown obsolete" data-browser="safari17_2">?</td>
+<td class="unknown obsolete" data-browser="safari17_3">?</td>
+<td class="unknown obsolete" data-browser="safari17_4">?</td>
+<td class="unknown" data-browser="safari17_5">?</td>
+<td class="unknown unstable" data-browser="safaritp">?</td>
+<td class="unknown unstable" data-browser="webkit">?</td>
+<td class="no obsolete" data-browser="opera88">No</td>
+<td class="no obsolete" data-browser="opera89">No</td>
+<td class="no obsolete" data-browser="opera90">No</td>
+<td class="no obsolete" data-browser="opera91">No</td>
+<td class="no obsolete" data-browser="opera92">No</td>
+<td class="no obsolete" data-browser="opera93">No</td>
+<td class="no obsolete" data-browser="opera94">No</td>
+<td class="no obsolete" data-browser="opera95">No</td>
+<td class="no obsolete" data-browser="opera96">No</td>
+<td class="no obsolete" data-browser="opera97">No</td>
+<td class="no" data-browser="opera98">No</td>
+<td class="no unstable" data-browser="opera99">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
+<td class="no obsolete" data-browser="rhino1_7_14">No</td>
+<td class="no obsolete" data-browser="rhino1_7_15">No</td>
+<td class="unknown obsolete" data-browser="phantom2_1">?</td>
+<td class="unknown obsolete" data-browser="node0_4">?</td>
+<td class="unknown obsolete" data-browser="node0_6">?</td>
+<td class="unknown obsolete" data-browser="node0_8">?</td>
+<td class="unknown obsolete" data-browser="node0_10">?</td>
+<td class="unknown obsolete" data-browser="node0_12">?</td>
+<td class="no obsolete" data-browser="node14_6">No</td>
+<td class="no obsolete" data-browser="node16_0">No</td>
+<td class="no obsolete" data-browser="node16_9">No</td>
+<td class="no" data-browser="node16_11">No</td>
+<td class="no obsolete" data-browser="node17_0">No</td>
+<td class="no obsolete" data-browser="node17_2">No</td>
+<td class="no obsolete" data-browser="node18_0">No</td>
+<td class="no" data-browser="node18_3">No</td>
+<td class="no obsolete" data-browser="node19_0">No</td>
+<td class="no obsolete" data-browser="node19_2">No</td>
+<td class="no" data-browser="node20_0">No</td>
+<td class="no obsolete" data-browser="node21_0">No</td>
+<td class="no" data-browser="node22_0">No</td>
+<td class="no obsolete" data-browser="duktape2_6">No</td>
+<td class="no" data-browser="duktape2_7">No</td>
+<td class="unknown obsolete" data-browser="graalvm19">?</td>
+<td class="unknown obsolete" data-browser="graalvm19_3_6">?</td>
+<td class="unknown obsolete" data-browser="graalvm20">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_1">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_3">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_3_1">?</td>
+<td class="unknown obsolete" data-browser="graalvm21">?</td>
+<td class="no" data-browser="graalvm21_3_3">No</td>
+<td class="no" data-browser="graalvm22_2">No</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="deno1_33">No</td>
+<td class="no obsolete" data-browser="deno1_34">No</td>
+<td class="no obsolete" data-browser="deno1_35">No</td>
+<td class="no" data-browser="deno1_36">No</td>
+<td class="unknown obsolete" data-browser="android4_4">?</td>
+<td class="unknown obsolete" data-browser="android4_4_3">?</td>
+<td class="unknown obsolete" data-browser="ios12_2">?</td>
+<td class="unknown obsolete" data-browser="ios13_4">?</td>
+<td class="unknown obsolete" data-browser="ios14_5">?</td>
+<td class="unknown obsolete" data-browser="ios16">?</td>
+<td class="unknown obsolete" data-browser="ios16_1">?</td>
+<td class="unknown obsolete" data-browser="ios16_2">?</td>
+<td class="unknown obsolete" data-browser="ios16_3">?</td>
+<td class="unknown obsolete" data-browser="ios16_4">?</td>
+<td class="unknown obsolete" data-browser="ios16_5">?</td>
+<td class="unknown obsolete" data-browser="ios16_6">?</td>
+<td class="unknown" data-browser="ios17">?</td>
+<td class="no obsolete" data-browser="samsung19">No</td>
+<td class="no obsolete" data-browser="samsung20">No</td>
+<td class="no obsolete" data-browser="samsung21">No</td>
+<td class="no" data-browser="samsung22">No</td>
+<td class="no obsolete" data-browser="opera_mobile72">No</td>
+<td class="no obsolete" data-browser="opera_mobile73">No</td>
+<td class="no obsolete" data-browser="opera_mobile74">No</td>
+<td class="no obsolete" data-browser="opera_mobile75">No</td>
+<td class="no obsolete" data-browser="opera_mobile76">No</td>
+<td class="no" data-browser="opera_mobile77">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
+</tr>
+<tr class="subtest" data-parent="Async_Iterator_Helpers" id="test-Async_Iterator_Helpers_AsyncIterator.prototype.reduce"><td><span><a class="anchor" href="#test-Async_Iterator_Helpers_AsyncIterator.prototype.reduce">&#xA7;</a>AsyncIterator.prototype.reduce</span><script data-source="
+(async function*() { yield * [1, 2, 3] })().reduce((a, b) =&gt; a + b).then(it =&gt; {
+  if (it === 6) asyncTestPassed();
+});
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("48");try{return Function("asyncTestPassed","\n(async function*() { yield * [1, 2, 3] })().reduce((a, b) => a + b).then(it => {\n  if (it === 6) asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("48");return Function("asyncTestPassed","'use strict';"+"\n(async function*() { yield * [1, 2, 3] })().reduce((a, b) => a + b).then(it => {\n  if (it === 6) asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+</script></td>
+<td class="unknown obsolete" data-browser="tr">?</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
+<td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20210808">?</td>
+<td class="unknown obsolete" data-browser="closure20210906">?</td>
+<td class="unknown obsolete" data-browser="closure20211006">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220719">?</td>
+<td class="unknown" data-browser="closure20230228">?</td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes" data-browser="typescript5_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="no obsolete" data-browser="firefox102">No</td>
+<td class="no obsolete" data-browser="firefox114">No</td>
+<td class="no" data-browser="firefox115">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no flagged obsolete" data-browser="firefox117">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox118">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox119">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox120">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox121">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox122">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox123">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox124">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox125">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox126">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged" data-browser="firefox127">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox128">Flag<a href="#ff-async-iterator-helpers-note"><sup>[11]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox129">Flag<a href="#ff-async-iterator-helpers-note"><sup>[11]</sup></a></td>
+<td class="unknown obsolete" data-browser="opera12_10">?</td>
+<td class="no obsolete" data-browser="chrome115">No</td>
+<td class="no obsolete" data-browser="chrome116">No</td>
+<td class="no obsolete" data-browser="chrome117">No</td>
+<td class="no obsolete" data-browser="chrome118">No</td>
+<td class="no obsolete" data-browser="chrome119">No</td>
+<td class="no obsolete" data-browser="chrome120">No</td>
+<td class="no obsolete" data-browser="chrome121">No</td>
+<td class="no obsolete" data-browser="chrome122">No</td>
+<td class="no obsolete" data-browser="chrome123">No</td>
+<td class="no obsolete" data-browser="chrome124">No</td>
+<td class="no obsolete" data-browser="chrome125">No</td>
+<td class="no" data-browser="chrome126">No</td>
+<td class="no unstable" data-browser="chrome127">No</td>
+<td class="no obsolete" data-browser="edge18">No</td>
+<td class="no obsolete" data-browser="edge115">No</td>
+<td class="no obsolete" data-browser="edge116">No</td>
+<td class="no obsolete" data-browser="edge117">No</td>
+<td class="no obsolete" data-browser="edge118">No</td>
+<td class="no obsolete" data-browser="edge119">No</td>
+<td class="no obsolete" data-browser="edge120">No</td>
+<td class="no obsolete" data-browser="edge121">No</td>
+<td class="no obsolete" data-browser="edge122">No</td>
+<td class="no obsolete" data-browser="edge123">No</td>
+<td class="no obsolete" data-browser="edge124">No</td>
+<td class="no obsolete" data-browser="edge125">No</td>
+<td class="no" data-browser="edge126">No</td>
+<td class="no unstable" data-browser="edge127">No</td>
+<td class="unknown obsolete" data-browser="safari15_6">?</td>
+<td class="unknown obsolete" data-browser="safari16_6">?</td>
+<td class="unknown obsolete" data-browser="safari17">?</td>
+<td class="unknown obsolete" data-browser="safari17_1">?</td>
+<td class="unknown obsolete" data-browser="safari17_2">?</td>
+<td class="unknown obsolete" data-browser="safari17_3">?</td>
+<td class="unknown obsolete" data-browser="safari17_4">?</td>
+<td class="unknown" data-browser="safari17_5">?</td>
+<td class="unknown unstable" data-browser="safaritp">?</td>
+<td class="unknown unstable" data-browser="webkit">?</td>
+<td class="no obsolete" data-browser="opera88">No</td>
+<td class="no obsolete" data-browser="opera89">No</td>
+<td class="no obsolete" data-browser="opera90">No</td>
+<td class="no obsolete" data-browser="opera91">No</td>
+<td class="no obsolete" data-browser="opera92">No</td>
+<td class="no obsolete" data-browser="opera93">No</td>
+<td class="no obsolete" data-browser="opera94">No</td>
+<td class="no obsolete" data-browser="opera95">No</td>
+<td class="no obsolete" data-browser="opera96">No</td>
+<td class="no obsolete" data-browser="opera97">No</td>
+<td class="no" data-browser="opera98">No</td>
+<td class="no unstable" data-browser="opera99">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
+<td class="no obsolete" data-browser="rhino1_7_14">No</td>
+<td class="no obsolete" data-browser="rhino1_7_15">No</td>
+<td class="unknown obsolete" data-browser="phantom2_1">?</td>
+<td class="unknown obsolete" data-browser="node0_4">?</td>
+<td class="unknown obsolete" data-browser="node0_6">?</td>
+<td class="unknown obsolete" data-browser="node0_8">?</td>
+<td class="unknown obsolete" data-browser="node0_10">?</td>
+<td class="unknown obsolete" data-browser="node0_12">?</td>
+<td class="no obsolete" data-browser="node14_6">No</td>
+<td class="no obsolete" data-browser="node16_0">No</td>
+<td class="no obsolete" data-browser="node16_9">No</td>
+<td class="no" data-browser="node16_11">No</td>
+<td class="no obsolete" data-browser="node17_0">No</td>
+<td class="no obsolete" data-browser="node17_2">No</td>
+<td class="no obsolete" data-browser="node18_0">No</td>
+<td class="no" data-browser="node18_3">No</td>
+<td class="no obsolete" data-browser="node19_0">No</td>
+<td class="no obsolete" data-browser="node19_2">No</td>
+<td class="no" data-browser="node20_0">No</td>
+<td class="no obsolete" data-browser="node21_0">No</td>
+<td class="no" data-browser="node22_0">No</td>
+<td class="no obsolete" data-browser="duktape2_6">No</td>
+<td class="no" data-browser="duktape2_7">No</td>
+<td class="unknown obsolete" data-browser="graalvm19">?</td>
+<td class="unknown obsolete" data-browser="graalvm19_3_6">?</td>
+<td class="unknown obsolete" data-browser="graalvm20">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_1">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_3">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_3_1">?</td>
+<td class="unknown obsolete" data-browser="graalvm21">?</td>
+<td class="no" data-browser="graalvm21_3_3">No</td>
+<td class="no" data-browser="graalvm22_2">No</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="deno1_33">No</td>
+<td class="no obsolete" data-browser="deno1_34">No</td>
+<td class="no obsolete" data-browser="deno1_35">No</td>
+<td class="no" data-browser="deno1_36">No</td>
+<td class="unknown obsolete" data-browser="android4_4">?</td>
+<td class="unknown obsolete" data-browser="android4_4_3">?</td>
+<td class="unknown obsolete" data-browser="ios12_2">?</td>
+<td class="unknown obsolete" data-browser="ios13_4">?</td>
+<td class="unknown obsolete" data-browser="ios14_5">?</td>
+<td class="unknown obsolete" data-browser="ios16">?</td>
+<td class="unknown obsolete" data-browser="ios16_1">?</td>
+<td class="unknown obsolete" data-browser="ios16_2">?</td>
+<td class="unknown obsolete" data-browser="ios16_3">?</td>
+<td class="unknown obsolete" data-browser="ios16_4">?</td>
+<td class="unknown obsolete" data-browser="ios16_5">?</td>
+<td class="unknown obsolete" data-browser="ios16_6">?</td>
+<td class="unknown" data-browser="ios17">?</td>
+<td class="no obsolete" data-browser="samsung19">No</td>
+<td class="no obsolete" data-browser="samsung20">No</td>
+<td class="no obsolete" data-browser="samsung21">No</td>
+<td class="no" data-browser="samsung22">No</td>
+<td class="no obsolete" data-browser="opera_mobile72">No</td>
+<td class="no obsolete" data-browser="opera_mobile73">No</td>
+<td class="no obsolete" data-browser="opera_mobile74">No</td>
+<td class="no obsolete" data-browser="opera_mobile75">No</td>
+<td class="no obsolete" data-browser="opera_mobile76">No</td>
+<td class="no" data-browser="opera_mobile77">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
+</tr>
+<tr class="subtest" data-parent="Async_Iterator_Helpers" id="test-Async_Iterator_Helpers_AsyncIterator.prototype.some"><td><span><a class="anchor" href="#test-Async_Iterator_Helpers_AsyncIterator.prototype.some">&#xA7;</a>AsyncIterator.prototype.some</span><script data-source="
+(async function*() { yield * [1, 2, 3] })().some(it =&gt; typeof it === &apos;number&apos;).then(it =&gt; {
+  if (it === true) asyncTestPassed();
+});
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("49");try{return Function("asyncTestPassed","\n(async function*() { yield * [1, 2, 3] })().some(it => typeof it === 'number').then(it => {\n  if (it === true) asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("49");return Function("asyncTestPassed","'use strict';"+"\n(async function*() { yield * [1, 2, 3] })().some(it => typeof it === 'number').then(it => {\n  if (it === true) asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+</script></td>
+<td class="unknown obsolete" data-browser="tr">?</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
+<td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20210808">?</td>
+<td class="unknown obsolete" data-browser="closure20210906">?</td>
+<td class="unknown obsolete" data-browser="closure20211006">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220719">?</td>
+<td class="unknown" data-browser="closure20230228">?</td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes" data-browser="typescript5_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="no obsolete" data-browser="firefox102">No</td>
+<td class="no obsolete" data-browser="firefox114">No</td>
+<td class="no" data-browser="firefox115">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no flagged obsolete" data-browser="firefox117">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox118">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox119">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox120">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox121">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox122">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox123">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox124">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox125">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox126">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged" data-browser="firefox127">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox128">Flag<a href="#ff-async-iterator-helpers-note"><sup>[11]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox129">Flag<a href="#ff-async-iterator-helpers-note"><sup>[11]</sup></a></td>
+<td class="unknown obsolete" data-browser="opera12_10">?</td>
+<td class="no obsolete" data-browser="chrome115">No</td>
+<td class="no obsolete" data-browser="chrome116">No</td>
+<td class="no obsolete" data-browser="chrome117">No</td>
+<td class="no obsolete" data-browser="chrome118">No</td>
+<td class="no obsolete" data-browser="chrome119">No</td>
+<td class="no obsolete" data-browser="chrome120">No</td>
+<td class="no obsolete" data-browser="chrome121">No</td>
+<td class="no obsolete" data-browser="chrome122">No</td>
+<td class="no obsolete" data-browser="chrome123">No</td>
+<td class="no obsolete" data-browser="chrome124">No</td>
+<td class="no obsolete" data-browser="chrome125">No</td>
+<td class="no" data-browser="chrome126">No</td>
+<td class="no unstable" data-browser="chrome127">No</td>
+<td class="no obsolete" data-browser="edge18">No</td>
+<td class="no obsolete" data-browser="edge115">No</td>
+<td class="no obsolete" data-browser="edge116">No</td>
+<td class="no obsolete" data-browser="edge117">No</td>
+<td class="no obsolete" data-browser="edge118">No</td>
+<td class="no obsolete" data-browser="edge119">No</td>
+<td class="no obsolete" data-browser="edge120">No</td>
+<td class="no obsolete" data-browser="edge121">No</td>
+<td class="no obsolete" data-browser="edge122">No</td>
+<td class="no obsolete" data-browser="edge123">No</td>
+<td class="no obsolete" data-browser="edge124">No</td>
+<td class="no obsolete" data-browser="edge125">No</td>
+<td class="no" data-browser="edge126">No</td>
+<td class="no unstable" data-browser="edge127">No</td>
+<td class="unknown obsolete" data-browser="safari15_6">?</td>
+<td class="unknown obsolete" data-browser="safari16_6">?</td>
+<td class="unknown obsolete" data-browser="safari17">?</td>
+<td class="unknown obsolete" data-browser="safari17_1">?</td>
+<td class="unknown obsolete" data-browser="safari17_2">?</td>
+<td class="unknown obsolete" data-browser="safari17_3">?</td>
+<td class="unknown obsolete" data-browser="safari17_4">?</td>
+<td class="unknown" data-browser="safari17_5">?</td>
+<td class="unknown unstable" data-browser="safaritp">?</td>
+<td class="unknown unstable" data-browser="webkit">?</td>
+<td class="no obsolete" data-browser="opera88">No</td>
+<td class="no obsolete" data-browser="opera89">No</td>
+<td class="no obsolete" data-browser="opera90">No</td>
+<td class="no obsolete" data-browser="opera91">No</td>
+<td class="no obsolete" data-browser="opera92">No</td>
+<td class="no obsolete" data-browser="opera93">No</td>
+<td class="no obsolete" data-browser="opera94">No</td>
+<td class="no obsolete" data-browser="opera95">No</td>
+<td class="no obsolete" data-browser="opera96">No</td>
+<td class="no obsolete" data-browser="opera97">No</td>
+<td class="no" data-browser="opera98">No</td>
+<td class="no unstable" data-browser="opera99">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
+<td class="no obsolete" data-browser="rhino1_7_14">No</td>
+<td class="no obsolete" data-browser="rhino1_7_15">No</td>
+<td class="unknown obsolete" data-browser="phantom2_1">?</td>
+<td class="unknown obsolete" data-browser="node0_4">?</td>
+<td class="unknown obsolete" data-browser="node0_6">?</td>
+<td class="unknown obsolete" data-browser="node0_8">?</td>
+<td class="unknown obsolete" data-browser="node0_10">?</td>
+<td class="unknown obsolete" data-browser="node0_12">?</td>
+<td class="no obsolete" data-browser="node14_6">No</td>
+<td class="no obsolete" data-browser="node16_0">No</td>
+<td class="no obsolete" data-browser="node16_9">No</td>
+<td class="no" data-browser="node16_11">No</td>
+<td class="no obsolete" data-browser="node17_0">No</td>
+<td class="no obsolete" data-browser="node17_2">No</td>
+<td class="no obsolete" data-browser="node18_0">No</td>
+<td class="no" data-browser="node18_3">No</td>
+<td class="no obsolete" data-browser="node19_0">No</td>
+<td class="no obsolete" data-browser="node19_2">No</td>
+<td class="no" data-browser="node20_0">No</td>
+<td class="no obsolete" data-browser="node21_0">No</td>
+<td class="no" data-browser="node22_0">No</td>
+<td class="no obsolete" data-browser="duktape2_6">No</td>
+<td class="no" data-browser="duktape2_7">No</td>
+<td class="unknown obsolete" data-browser="graalvm19">?</td>
+<td class="unknown obsolete" data-browser="graalvm19_3_6">?</td>
+<td class="unknown obsolete" data-browser="graalvm20">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_1">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_3">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_3_1">?</td>
+<td class="unknown obsolete" data-browser="graalvm21">?</td>
+<td class="no" data-browser="graalvm21_3_3">No</td>
+<td class="no" data-browser="graalvm22_2">No</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="deno1_33">No</td>
+<td class="no obsolete" data-browser="deno1_34">No</td>
+<td class="no obsolete" data-browser="deno1_35">No</td>
+<td class="no" data-browser="deno1_36">No</td>
+<td class="unknown obsolete" data-browser="android4_4">?</td>
+<td class="unknown obsolete" data-browser="android4_4_3">?</td>
+<td class="unknown obsolete" data-browser="ios12_2">?</td>
+<td class="unknown obsolete" data-browser="ios13_4">?</td>
+<td class="unknown obsolete" data-browser="ios14_5">?</td>
+<td class="unknown obsolete" data-browser="ios16">?</td>
+<td class="unknown obsolete" data-browser="ios16_1">?</td>
+<td class="unknown obsolete" data-browser="ios16_2">?</td>
+<td class="unknown obsolete" data-browser="ios16_3">?</td>
+<td class="unknown obsolete" data-browser="ios16_4">?</td>
+<td class="unknown obsolete" data-browser="ios16_5">?</td>
+<td class="unknown obsolete" data-browser="ios16_6">?</td>
+<td class="unknown" data-browser="ios17">?</td>
+<td class="no obsolete" data-browser="samsung19">No</td>
+<td class="no obsolete" data-browser="samsung20">No</td>
+<td class="no obsolete" data-browser="samsung21">No</td>
+<td class="no" data-browser="samsung22">No</td>
+<td class="no obsolete" data-browser="opera_mobile72">No</td>
+<td class="no obsolete" data-browser="opera_mobile73">No</td>
+<td class="no obsolete" data-browser="opera_mobile74">No</td>
+<td class="no obsolete" data-browser="opera_mobile75">No</td>
+<td class="no obsolete" data-browser="opera_mobile76">No</td>
+<td class="no" data-browser="opera_mobile77">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
+</tr>
+<tr class="subtest" data-parent="Async_Iterator_Helpers" id="test-Async_Iterator_Helpers_AsyncIterator.prototype.take"><td><span><a class="anchor" href="#test-Async_Iterator_Helpers_AsyncIterator.prototype.take">&#xA7;</a>AsyncIterator.prototype.take</span><script data-source="
+async function toArray(iterator) {
+  const result = [];
+  for await (const it of iterator) result.push(it);
+  return result;
+}
+
+toArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it =&gt; {
+  if (it.join() === &apos;1,2&apos;) asyncTestPassed();
+});
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("50");try{return Function("asyncTestPassed","\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it => {\n  if (it.join() === '1,2') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("50");return Function("asyncTestPassed","'use strict';"+"\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it => {\n  if (it.join() === '1,2') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+</script></td>
+<td class="unknown obsolete" data-browser="tr">?</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
+<td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20210808">?</td>
+<td class="unknown obsolete" data-browser="closure20210906">?</td>
+<td class="unknown obsolete" data-browser="closure20211006">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220719">?</td>
+<td class="unknown" data-browser="closure20230228">?</td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes" data-browser="typescript5_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="no obsolete" data-browser="firefox102">No</td>
+<td class="no obsolete" data-browser="firefox114">No</td>
+<td class="no" data-browser="firefox115">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no flagged obsolete" data-browser="firefox117">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox118">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox119">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox120">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox121">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox122">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox123">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox124">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox125">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox126">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged" data-browser="firefox127">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox128">Flag<a href="#ff-async-iterator-helpers-note"><sup>[11]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox129">Flag<a href="#ff-async-iterator-helpers-note"><sup>[11]</sup></a></td>
+<td class="unknown obsolete" data-browser="opera12_10">?</td>
+<td class="no obsolete" data-browser="chrome115">No</td>
+<td class="no obsolete" data-browser="chrome116">No</td>
+<td class="no obsolete" data-browser="chrome117">No</td>
+<td class="no obsolete" data-browser="chrome118">No</td>
+<td class="no obsolete" data-browser="chrome119">No</td>
+<td class="no obsolete" data-browser="chrome120">No</td>
+<td class="no obsolete" data-browser="chrome121">No</td>
+<td class="no obsolete" data-browser="chrome122">No</td>
+<td class="no obsolete" data-browser="chrome123">No</td>
+<td class="no obsolete" data-browser="chrome124">No</td>
+<td class="no obsolete" data-browser="chrome125">No</td>
+<td class="no" data-browser="chrome126">No</td>
+<td class="no unstable" data-browser="chrome127">No</td>
+<td class="no obsolete" data-browser="edge18">No</td>
+<td class="no obsolete" data-browser="edge115">No</td>
+<td class="no obsolete" data-browser="edge116">No</td>
+<td class="no obsolete" data-browser="edge117">No</td>
+<td class="no obsolete" data-browser="edge118">No</td>
+<td class="no obsolete" data-browser="edge119">No</td>
+<td class="no obsolete" data-browser="edge120">No</td>
+<td class="no obsolete" data-browser="edge121">No</td>
+<td class="no obsolete" data-browser="edge122">No</td>
+<td class="no obsolete" data-browser="edge123">No</td>
+<td class="no obsolete" data-browser="edge124">No</td>
+<td class="no obsolete" data-browser="edge125">No</td>
+<td class="no" data-browser="edge126">No</td>
+<td class="no unstable" data-browser="edge127">No</td>
+<td class="unknown obsolete" data-browser="safari15_6">?</td>
+<td class="unknown obsolete" data-browser="safari16_6">?</td>
+<td class="unknown obsolete" data-browser="safari17">?</td>
+<td class="unknown obsolete" data-browser="safari17_1">?</td>
+<td class="unknown obsolete" data-browser="safari17_2">?</td>
+<td class="unknown obsolete" data-browser="safari17_3">?</td>
+<td class="unknown obsolete" data-browser="safari17_4">?</td>
+<td class="unknown" data-browser="safari17_5">?</td>
+<td class="unknown unstable" data-browser="safaritp">?</td>
+<td class="unknown unstable" data-browser="webkit">?</td>
+<td class="no obsolete" data-browser="opera88">No</td>
+<td class="no obsolete" data-browser="opera89">No</td>
+<td class="no obsolete" data-browser="opera90">No</td>
+<td class="no obsolete" data-browser="opera91">No</td>
+<td class="no obsolete" data-browser="opera92">No</td>
+<td class="no obsolete" data-browser="opera93">No</td>
+<td class="no obsolete" data-browser="opera94">No</td>
+<td class="no obsolete" data-browser="opera95">No</td>
+<td class="no obsolete" data-browser="opera96">No</td>
+<td class="no obsolete" data-browser="opera97">No</td>
+<td class="no" data-browser="opera98">No</td>
+<td class="no unstable" data-browser="opera99">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
+<td class="no obsolete" data-browser="rhino1_7_14">No</td>
+<td class="no obsolete" data-browser="rhino1_7_15">No</td>
+<td class="unknown obsolete" data-browser="phantom2_1">?</td>
+<td class="unknown obsolete" data-browser="node0_4">?</td>
+<td class="unknown obsolete" data-browser="node0_6">?</td>
+<td class="unknown obsolete" data-browser="node0_8">?</td>
+<td class="unknown obsolete" data-browser="node0_10">?</td>
+<td class="unknown obsolete" data-browser="node0_12">?</td>
+<td class="no obsolete" data-browser="node14_6">No</td>
+<td class="no obsolete" data-browser="node16_0">No</td>
+<td class="no obsolete" data-browser="node16_9">No</td>
+<td class="no" data-browser="node16_11">No</td>
+<td class="no obsolete" data-browser="node17_0">No</td>
+<td class="no obsolete" data-browser="node17_2">No</td>
+<td class="no obsolete" data-browser="node18_0">No</td>
+<td class="no" data-browser="node18_3">No</td>
+<td class="no obsolete" data-browser="node19_0">No</td>
+<td class="no obsolete" data-browser="node19_2">No</td>
+<td class="no" data-browser="node20_0">No</td>
+<td class="no obsolete" data-browser="node21_0">No</td>
+<td class="no" data-browser="node22_0">No</td>
+<td class="no obsolete" data-browser="duktape2_6">No</td>
+<td class="no" data-browser="duktape2_7">No</td>
+<td class="unknown obsolete" data-browser="graalvm19">?</td>
+<td class="unknown obsolete" data-browser="graalvm19_3_6">?</td>
+<td class="unknown obsolete" data-browser="graalvm20">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_1">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_3">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_3_1">?</td>
+<td class="unknown obsolete" data-browser="graalvm21">?</td>
+<td class="no" data-browser="graalvm21_3_3">No</td>
+<td class="no" data-browser="graalvm22_2">No</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="deno1_33">No</td>
+<td class="no obsolete" data-browser="deno1_34">No</td>
+<td class="no obsolete" data-browser="deno1_35">No</td>
+<td class="no" data-browser="deno1_36">No</td>
+<td class="unknown obsolete" data-browser="android4_4">?</td>
+<td class="unknown obsolete" data-browser="android4_4_3">?</td>
+<td class="unknown obsolete" data-browser="ios12_2">?</td>
+<td class="unknown obsolete" data-browser="ios13_4">?</td>
+<td class="unknown obsolete" data-browser="ios14_5">?</td>
+<td class="unknown obsolete" data-browser="ios16">?</td>
+<td class="unknown obsolete" data-browser="ios16_1">?</td>
+<td class="unknown obsolete" data-browser="ios16_2">?</td>
+<td class="unknown obsolete" data-browser="ios16_3">?</td>
+<td class="unknown obsolete" data-browser="ios16_4">?</td>
+<td class="unknown obsolete" data-browser="ios16_5">?</td>
+<td class="unknown obsolete" data-browser="ios16_6">?</td>
+<td class="unknown" data-browser="ios17">?</td>
+<td class="no obsolete" data-browser="samsung19">No</td>
+<td class="no obsolete" data-browser="samsung20">No</td>
+<td class="no obsolete" data-browser="samsung21">No</td>
+<td class="no" data-browser="samsung22">No</td>
+<td class="no obsolete" data-browser="opera_mobile72">No</td>
+<td class="no obsolete" data-browser="opera_mobile73">No</td>
+<td class="no obsolete" data-browser="opera_mobile74">No</td>
+<td class="no obsolete" data-browser="opera_mobile75">No</td>
+<td class="no obsolete" data-browser="opera_mobile76">No</td>
+<td class="no" data-browser="opera_mobile77">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
+</tr>
+<tr class="subtest" data-parent="Async_Iterator_Helpers" id="test-Async_Iterator_Helpers_AsyncIterator.prototype.toArray"><td><span><a class="anchor" href="#test-Async_Iterator_Helpers_AsyncIterator.prototype.toArray">&#xA7;</a>AsyncIterator.prototype.toArray</span><script data-source="
+(async function*() { yield * [1, 2, 3] })().toArray().then(it =&gt; {
+  if (Array.isArray(it) &amp;&amp; it.join() === &apos;1,2,3&apos;) asyncTestPassed();
+});
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("51");try{return Function("asyncTestPassed","\n(async function*() { yield * [1, 2, 3] })().toArray().then(it => {\n  if (Array.isArray(it) && it.join() === '1,2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("51");return Function("asyncTestPassed","'use strict';"+"\n(async function*() { yield * [1, 2, 3] })().toArray().then(it => {\n  if (Array.isArray(it) && it.join() === '1,2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+</script></td>
+<td class="unknown obsolete" data-browser="tr">?</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
+<td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[6]</sup></a></td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20210808">?</td>
+<td class="unknown obsolete" data-browser="closure20210906">?</td>
+<td class="unknown obsolete" data-browser="closure20211006">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220719">?</td>
+<td class="unknown" data-browser="closure20230228">?</td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript4_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript5_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="yes" data-browser="typescript5_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[8]</sup></a></td>
+<td class="no obsolete" data-browser="firefox102">No</td>
+<td class="no obsolete" data-browser="firefox114">No</td>
+<td class="no" data-browser="firefox115">No</td>
+<td class="no obsolete" data-browser="firefox116">No</td>
+<td class="no flagged obsolete" data-browser="firefox117">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox118">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox119">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox120">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox121">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox122">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox123">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox124">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox125">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox126">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged" data-browser="firefox127">Flag<a href="#ff-iterator-helpers-note"><sup>[9]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox128">Flag<a href="#ff-async-iterator-helpers-note"><sup>[11]</sup></a></td>
+<td class="no flagged unstable" data-browser="firefox129">Flag<a href="#ff-async-iterator-helpers-note"><sup>[11]</sup></a></td>
+<td class="unknown obsolete" data-browser="opera12_10">?</td>
+<td class="no obsolete" data-browser="chrome115">No</td>
+<td class="no obsolete" data-browser="chrome116">No</td>
+<td class="no obsolete" data-browser="chrome117">No</td>
+<td class="no obsolete" data-browser="chrome118">No</td>
+<td class="no obsolete" data-browser="chrome119">No</td>
+<td class="no obsolete" data-browser="chrome120">No</td>
+<td class="no obsolete" data-browser="chrome121">No</td>
+<td class="no obsolete" data-browser="chrome122">No</td>
+<td class="no obsolete" data-browser="chrome123">No</td>
+<td class="no obsolete" data-browser="chrome124">No</td>
+<td class="no obsolete" data-browser="chrome125">No</td>
+<td class="no" data-browser="chrome126">No</td>
+<td class="no unstable" data-browser="chrome127">No</td>
+<td class="no obsolete" data-browser="edge18">No</td>
+<td class="no obsolete" data-browser="edge115">No</td>
+<td class="no obsolete" data-browser="edge116">No</td>
+<td class="no obsolete" data-browser="edge117">No</td>
+<td class="no obsolete" data-browser="edge118">No</td>
+<td class="no obsolete" data-browser="edge119">No</td>
+<td class="no obsolete" data-browser="edge120">No</td>
+<td class="no obsolete" data-browser="edge121">No</td>
+<td class="no obsolete" data-browser="edge122">No</td>
+<td class="no obsolete" data-browser="edge123">No</td>
+<td class="no obsolete" data-browser="edge124">No</td>
+<td class="no obsolete" data-browser="edge125">No</td>
+<td class="no" data-browser="edge126">No</td>
+<td class="no unstable" data-browser="edge127">No</td>
+<td class="unknown obsolete" data-browser="safari15_6">?</td>
+<td class="unknown obsolete" data-browser="safari16_6">?</td>
+<td class="unknown obsolete" data-browser="safari17">?</td>
+<td class="unknown obsolete" data-browser="safari17_1">?</td>
+<td class="unknown obsolete" data-browser="safari17_2">?</td>
+<td class="unknown obsolete" data-browser="safari17_3">?</td>
+<td class="unknown obsolete" data-browser="safari17_4">?</td>
+<td class="unknown" data-browser="safari17_5">?</td>
+<td class="unknown unstable" data-browser="safaritp">?</td>
+<td class="unknown unstable" data-browser="webkit">?</td>
+<td class="no obsolete" data-browser="opera88">No</td>
+<td class="no obsolete" data-browser="opera89">No</td>
+<td class="no obsolete" data-browser="opera90">No</td>
+<td class="no obsolete" data-browser="opera91">No</td>
+<td class="no obsolete" data-browser="opera92">No</td>
+<td class="no obsolete" data-browser="opera93">No</td>
+<td class="no obsolete" data-browser="opera94">No</td>
+<td class="no obsolete" data-browser="opera95">No</td>
+<td class="no obsolete" data-browser="opera96">No</td>
+<td class="no obsolete" data-browser="opera97">No</td>
+<td class="no" data-browser="opera98">No</td>
+<td class="no unstable" data-browser="opera99">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
+<td class="no obsolete" data-browser="rhino1_7_14">No</td>
+<td class="no obsolete" data-browser="rhino1_7_15">No</td>
+<td class="unknown obsolete" data-browser="phantom2_1">?</td>
+<td class="unknown obsolete" data-browser="node0_4">?</td>
+<td class="unknown obsolete" data-browser="node0_6">?</td>
+<td class="unknown obsolete" data-browser="node0_8">?</td>
+<td class="unknown obsolete" data-browser="node0_10">?</td>
+<td class="unknown obsolete" data-browser="node0_12">?</td>
+<td class="no obsolete" data-browser="node14_6">No</td>
+<td class="no obsolete" data-browser="node16_0">No</td>
+<td class="no obsolete" data-browser="node16_9">No</td>
+<td class="no" data-browser="node16_11">No</td>
+<td class="no obsolete" data-browser="node17_0">No</td>
+<td class="no obsolete" data-browser="node17_2">No</td>
+<td class="no obsolete" data-browser="node18_0">No</td>
+<td class="no" data-browser="node18_3">No</td>
+<td class="no obsolete" data-browser="node19_0">No</td>
+<td class="no obsolete" data-browser="node19_2">No</td>
+<td class="no" data-browser="node20_0">No</td>
+<td class="no obsolete" data-browser="node21_0">No</td>
+<td class="no" data-browser="node22_0">No</td>
+<td class="no obsolete" data-browser="duktape2_6">No</td>
+<td class="no" data-browser="duktape2_7">No</td>
+<td class="unknown obsolete" data-browser="graalvm19">?</td>
+<td class="unknown obsolete" data-browser="graalvm19_3_6">?</td>
+<td class="unknown obsolete" data-browser="graalvm20">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_1">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_3">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_3_1">?</td>
+<td class="unknown obsolete" data-browser="graalvm21">?</td>
+<td class="no" data-browser="graalvm21_3_3">No</td>
+<td class="no" data-browser="graalvm22_2">No</td>
+<td class="no" data-browser="hermes0_12_0">No</td>
+<td class="no obsolete" data-browser="deno1_33">No</td>
+<td class="no obsolete" data-browser="deno1_34">No</td>
+<td class="no obsolete" data-browser="deno1_35">No</td>
+<td class="no" data-browser="deno1_36">No</td>
+<td class="unknown obsolete" data-browser="android4_4">?</td>
+<td class="unknown obsolete" data-browser="android4_4_3">?</td>
+<td class="unknown obsolete" data-browser="ios12_2">?</td>
+<td class="unknown obsolete" data-browser="ios13_4">?</td>
+<td class="unknown obsolete" data-browser="ios14_5">?</td>
+<td class="unknown obsolete" data-browser="ios16">?</td>
+<td class="unknown obsolete" data-browser="ios16_1">?</td>
+<td class="unknown obsolete" data-browser="ios16_2">?</td>
+<td class="unknown obsolete" data-browser="ios16_3">?</td>
+<td class="unknown obsolete" data-browser="ios16_4">?</td>
+<td class="unknown obsolete" data-browser="ios16_5">?</td>
+<td class="unknown obsolete" data-browser="ios16_6">?</td>
+<td class="unknown" data-browser="ios17">?</td>
+<td class="no obsolete" data-browser="samsung19">No</td>
+<td class="no obsolete" data-browser="samsung20">No</td>
+<td class="no obsolete" data-browser="samsung21">No</td>
+<td class="no" data-browser="samsung22">No</td>
+<td class="no obsolete" data-browser="opera_mobile72">No</td>
+<td class="no obsolete" data-browser="opera_mobile73">No</td>
+<td class="no obsolete" data-browser="opera_mobile74">No</td>
+<td class="no obsolete" data-browser="opera_mobile75">No</td>
+<td class="no obsolete" data-browser="opera_mobile76">No</td>
+<td class="no" data-browser="opera_mobile77">No</td>
+<td class="no" data-browser="reactnative0_70_3">No</td>
+</tr>
+<tr class="subtest" data-parent="Async_Iterator_Helpers" id="test-Async_Iterator_Helpers_AsyncIterator.prototype[@@toStringTag]"><td><span><a class="anchor" href="#test-Async_Iterator_Helpers_AsyncIterator.prototype[@@toStringTag]">&#xA7;</a>AsyncIterator.prototype[@@toStringTag]</span><script data-source="
+return AsyncIterator.prototype[Symbol.toStringTag] === &apos;AsyncIterator&apos;;
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("52");try{return Function("asyncTestPassed","\nreturn AsyncIterator.prototype[Symbol.toStringTag] === 'AsyncIterator';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("52");return Function("asyncTestPassed","'use strict';"+"\nreturn AsyncIterator.prototype[Symbol.toStringTag] === 'AsyncIterator';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -8414,7 +8564,7 @@ return !Array.isTemplateObject([])
     </table>
     <div id="footnotes">
       <!-- FOOTNOTES -->
-    <p id="harmony-flag-old-note">  <sup>[1]</sup> Flagged features have to be enabled via <code>--harmony</code> flag</p><p id="harmony-flag-note">  <sup>[2]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="graalvm-node-mode-note">  <sup>[3]</sup> Executed in Node.js/JVM mode via <code>graalvm/bin/node --jvm</code>.</p><p id="graalvm-js-intl-mode-note">  <sup>[4]</sup> Executed using <code>js --js.intl-402</code>.</p><p id="babel-decorators-legacy-note">  <sup>[5]</sup> Babel 6 still has no official support decorators, but you can use <a href="https://github.com/loganfsmyth/babel-plugin-transform-decorators-legacy">this plugin</a>.</p><p id="babel-core-js-note">  <sup>[6]</sup> This feature is supported when using Babel with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="typescript-es6-note">  <sup>[7]</sup> TypeScript&apos;s compiler will accept code using this feature if the <code>--target ES6</code> flag is set, but passes it through unmodified and does not supply a runtime polyfill.</p><p id="typescript-core-js-note">  <sup>[8]</sup> This feature is supported when using TypeScript with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="ff-shadow-realm-note">  <sup>[9]</sup> The feature has to be enabled via <code>javascript.options.experimental.shadow_realms</code> setting under <code>about:config</code>.</p></div>
+    <p id="harmony-flag-old-note">  <sup>[1]</sup> Flagged features have to be enabled via <code>--harmony</code> flag</p><p id="harmony-flag-note">  <sup>[2]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="graalvm-node-mode-note">  <sup>[3]</sup> Executed in Node.js/JVM mode via <code>graalvm/bin/node --jvm</code>.</p><p id="graalvm-js-intl-mode-note">  <sup>[4]</sup> Executed using <code>js --js.intl-402</code>.</p><p id="babel-decorators-legacy-note">  <sup>[5]</sup> Babel 6 still has no official support decorators, but you can use <a href="https://github.com/loganfsmyth/babel-plugin-transform-decorators-legacy">this plugin</a>.</p><p id="babel-core-js-note">  <sup>[6]</sup> This feature is supported when using Babel with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="typescript-es6-note">  <sup>[7]</sup> TypeScript&apos;s compiler will accept code using this feature if the <code>--target ES6</code> flag is set, but passes it through unmodified and does not supply a runtime polyfill.</p><p id="typescript-core-js-note">  <sup>[8]</sup> This feature is supported when using TypeScript with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="ff-iterator-helpers-note">  <sup>[9]</sup> The feature is only available on Nightly builds, and has to be enabled via <code>javascript.options.experimental.iterator_helpers</code> setting under <code>about:config</code>.</p><p id="ff-shadow-realm-note">  <sup>[10]</sup> The feature has to be enabled via <code>javascript.options.experimental.shadow_realms</code> setting under <code>about:config</code>.</p><p id="ff-async-iterator-helpers-note">  <sup>[11]</sup> The feature is only available on Nightly builds, and has to be enabled via <code>javascript.options.experimental.async_iterator_helpers</code> setting under <code>about:config</code>.</p></div>
   </div>
   <pre class="info-tooltip" style="display:none"></pre>
 </body>


### PR DESCRIPTION
The async iterator helpers was split in its own document, this patch reflects that.
Also updating Firefox results.