### PR TITLE
ES6: Fix regex tests that are missing new spec changes

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -12220,12 +12220,15 @@ exports.tests = [
         // RegExp.prototype.flags -> Get -> [[Get]]
         var expected = [];
         // Sorted alphabetically by shortname – "gimsuy".
+        if ('hasIndices' in RegExp.prototype) expected.push('hasIndices');
         if ('global' in RegExp.prototype) expected.push('global');
         if ('ignoreCase' in RegExp.prototype) expected.push('ignoreCase');
         if ('multiline' in RegExp.prototype) expected.push('multiline');
         if ('dotAll' in RegExp.prototype) expected.push('dotAll');
         if ('unicode' in RegExp.prototype) expected.push('unicode');
+        if ('unicodeSets' in RegExp.prototype) expected.push('unicodeSets');
         if ('sticky' in RegExp.prototype) expected.push('sticky');
+
         var actual = [];
         var p = new Proxy({}, { get: function(o, k) { actual.push(k); return o[k]; }});
         Object.getOwnPropertyDescriptor(RegExp.prototype, 'flags').get.call(p);
@@ -12320,7 +12323,8 @@ exports.tests = [
         RegExp.prototype[Symbol.match].call(p);
         p.global = true;
         RegExp.prototype[Symbol.match].call(p);
-        return get + '' === "global,exec,global,unicode,exec";
+        var str = get + '';
+        return str === "global,exec,global,unicode,exec" || str === 'flags,exec,flags,exec';
       */},
       res: {
         ie11: false,
@@ -12349,7 +12353,8 @@ exports.tests = [
         RegExp.prototype[Symbol.replace].call(p);
         p.global = true;
         RegExp.prototype[Symbol.replace].call(p);
-        return get + '' === "global,exec,global,unicode,exec";
+        var str = get + '';
+        return str === "global,exec,global,unicode,exec" || str === 'flags,exec,flags,exec';
       */},
       res: {
         ie11: false,


### PR DESCRIPTION
Some newly added flags, one because of an observable spec change in access patterns

Fixes #1894.