### PR TITLE
Add missing "array by copy" tests, fix browser results and MDN links

### DIFF
--- a/data-es2016plus.js
+++ b/data-es2016plus.js
@@ -7006,7 +7006,8 @@ exports.tests = [
     spec: 'https://github.com/tc39/proposal-change-array-by-copy',
     subtests: [
       {
-        name: "Array.prototype.toReversed",
+        name: "Array.prototype.toReversed()",
+        mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toReversed',
         exec: function () {/*
           var arr = [1, 2, 3];
           return arr.toReversed()[0] === 3 && arr[0] === 1;
@@ -7015,22 +7016,19 @@ exports.tests = [
           babel7corejs3: babel.corejs,
           typescript3_2corejs3: typescript.corejs,
           ie11: false,
+          chrome94: false,
           chrome109: false,
           chrome110: true,
-          edge109: false,
-          edge110: true,
-          firefox114: false,
+          firefox45: false,
+          firefox95: {val: "flagged", note_id: "fx-change-array-by-copy", note_html: 'The feature has to be enabled via --enable-change-array-by-copy flag'},
           firefox115: true,
-          firefox102: false,
           safari15_5: false,
           safari16: true,
-          node16_11: false,
-          node18_3: false,
-          node20_0: true,
         }
       },
       {
-        name: "Array.prototype.toSorted",
+        name: "Array.prototype.toSorted()",
+        mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toSorted',
         exec: function () {/*
           var arr = ['C', 'A', 'B'];
           return arr.toSorted()[0] === 'A' && arr[0] === 'C';
@@ -7039,22 +7037,19 @@ exports.tests = [
           babel7corejs3: babel.corejs,
           typescript3_2corejs3: typescript.corejs,
           ie11: false,
+          chrome94: false,
           chrome109: false,
           chrome110: true,
-          edge109: false,
-          edge110: true,
-          firefox114: false,
+          firefox45: false,
+          firefox95: {val: "flagged", note_id: "fx-change-array-by-copy"},
           firefox115: true,
-          firefox102: false,
           safari15_5: false,
           safari16: true,
-          node16_11: false,
-          node18_3: false,
-          node20_0: true,
         }
       },
       {
-        name: "Array.prototype.toSpliced",
+        name: "Array.prototype.toSpliced()",
+        mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toSpliced',
         exec: function () {/*
           var arr = ['A', 'C'];
           return arr.toSpliced(1, 0, 'B')[1] === 'B' && arr[1] === 'C';
@@ -7063,22 +7058,19 @@ exports.tests = [
           babel7corejs3: babel.corejs,
           typescript3_2corejs3: typescript.corejs,
           ie11: false,
+          chrome94: false,
           chrome109: false,
           chrome110: true,
-          edge109: false,
-          edge110: true,
-          firefox114: false,
+          firefox45: false,
+          firefox95: {val: "flagged", note_id: "fx-change-array-by-copy"},
           firefox115: true,
-          firefox102: false,
           safari15_5: false,
           safari16: true,
-          node16_11: false,
-          node18_3: false,
-          node20_0: true,
         }
       },
       {
-        name: "Array.prototype.with",
+        name: "Array.prototype.with()",
+        mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/with',
         exec: function () {/*
           var arr = ['A', 'X', 'C'];
           return arr.with(1, 'B')[1] === 'B' && arr[1] === 'X';
@@ -7087,20 +7079,73 @@ exports.tests = [
           babel7corejs3: babel.corejs,
           typescript3_2corejs3: typescript.corejs,
           ie11: false,
+          chrome94: false,
           chrome109: false,
           chrome110: true,
-          edge109: false,
-          edge110: true,
-          firefox114: false,
+          firefox45: false,
+          firefox95: {val: "flagged", note_id: "fx-change-array-by-copy"},
           firefox115: true,
-          firefox102: false,
           safari15_5: false,
           safari16: true,
-          node16_11: false,
-          node18_3: false,
-          node20_0: true,
         }
-      }
+      },
+      {
+        name: "TypedArray.prototype.toReversed()",
+        mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/toReversed',
+        exec: function () {/*
+          var arr = new Uint8Array([1, 2, 3]);
+          return arr.toReversed()[0] == 3 && arr[0] == 1;
+        */},
+        res: {
+          ie11: false,
+          chrome94: false,
+          chrome109: false,
+          chrome110: true,
+          firefox45: false,
+          firefox95: {val: "flagged", note_id: "fx-change-array-by-copy"},
+          firefox115: true,
+          safari15_5: false,
+          safari16: true,
+        }
+      },
+      {
+        name: "TypedArray.prototype.toSorted()",
+        mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/toSorted',
+        exec: function () {/*
+          var arr = new Uint8Array([3, 1, 2]);
+          return arr.toSorted()[0] == 1 && arr[0] == 3;
+        */},
+        res: {
+          ie11: false,
+          chrome94: false,
+          chrome109: false,
+          chrome110: true,
+          firefox45: false,
+          firefox95: {val: "flagged", note_id: "fx-change-array-by-copy"},
+          firefox115: true,
+          safari15_5: false,
+          safari16: true,
+        }
+      },
+      {
+        name: "TypedArray.prototype.with()",
+        mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/with',
+        exec: function () {/*
+          var arr = new Uint8Array([1, 0, 2]);
+          return arr.with(1, 2)[1] == 2 && arr[1] == 0;
+        */},
+        res: {
+          ie11: false,
+          chrome94: false,
+          chrome109: false,
+          chrome110: true,
+          firefox45: false,
+          firefox95: {val: "flagged", note_id: "fx-change-array-by-copy"},
+          firefox115: true,
+          safari15_5: false,
+          safari16: true,
+        }
+      },
     ]
   },
   {

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -37802,161 +37802,161 @@ try {
 <td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Change_Array_by_copy"><span><a class="anchor" href="#test-Change_Array_by_copy">&#xA7;</a><a href="https://github.com/tc39/proposal-change-array-by-copy">Change Array by copy</a></span></td>
-<td class="tally obsolete" data-browser="tr" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/4</td>
-<td class="tally" data-browser="babel7corejs3" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="closure20210808" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="closure20210906" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="closure20211006" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="closure20211107" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="closure20220502" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="closure20220719" data-tally="0">0/4</td>
-<td class="tally" data-browser="closure20230228" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="typescript3_9corejs3" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="typescript4_9corejs3" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="typescript5_2corejs3" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="typescript5_3corejs3" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="typescript5_4corejs3" data-tally="1">4/4</td>
-<td class="tally" data-browser="typescript5_5corejs3" data-tally="1">4/4</td>
-<td class="tally" data-browser="es7shim" data-tally="0">0/4</td>
-<td class="tally" data-browser="ie11" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="firefox102" data-tally="0">0/4</td>
-<td class="tally" data-browser="firefox115" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="firefox117" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="firefox118" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="firefox119" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="firefox120" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="firefox121" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="firefox122" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="firefox123" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="firefox124" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="firefox125" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="firefox126" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="firefox127" data-tally="1">4/4</td>
-<td class="tally" data-browser="firefox128" data-tally="1">4/4</td>
-<td class="tally" data-browser="firefox129" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="firefox130" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="firefox131" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="chrome115" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="chrome116" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="chrome117" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="chrome118" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="chrome119" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="chrome120" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="chrome121" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="chrome122" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="chrome123" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="chrome124" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="chrome125" data-tally="1">4/4</td>
-<td class="tally" data-browser="chrome126" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="chrome127" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="edge18" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="edge115" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="edge116" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="edge117" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="edge118" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="edge119" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="edge120" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="edge121" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="edge122" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="edge123" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="edge124" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="edge125" data-tally="1">4/4</td>
-<td class="tally" data-browser="edge126" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="edge127" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="safari15_6" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="safari16_6" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="safari17" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="safari17_1" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="safari17_2" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="safari17_3" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="safari17_4" data-tally="1">4/4</td>
-<td class="tally" data-browser="safari17_5" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="safaritp" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="webkit" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera88" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="opera89" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="opera90" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="opera91" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="opera92" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="opera93" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="opera94" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="opera95" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="opera96" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera97" data-tally="1">4/4</td>
-<td class="tally" data-browser="opera98" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="opera99" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="rhino1_7_15" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="node0_4" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="node0_6" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="node0_8" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="node0_10" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="node0_12" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="node14_6" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="node16_0" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="node16_9" data-tally="0">0/4</td>
-<td class="tally" data-browser="node16_11" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="node17_0" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="node17_2" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="node18_0" data-tally="0">0/4</td>
-<td class="tally" data-browser="node18_3" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="node19_0" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="node19_2" data-tally="0">0/4</td>
-<td class="tally" data-browser="node20_0" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="node21_0" data-tally="1">4/4</td>
-<td class="tally" data-browser="node22_0" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="duktape2_6" data-tally="0">0/4</td>
-<td class="tally" data-browser="duktape2_7" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="jerryscript2_3_0" data-tally="0">0/4</td>
-<td class="tally" data-browser="jerryscript2_4_0" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="graalvm19" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="graalvm19_3_6" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="graalvm20" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="graalvm20_1" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="graalvm20_3" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="graalvm20_3_1" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="graalvm21" data-tally="0">0/4</td>
-<td class="tally" data-browser="graalvm21_3_3" data-tally="0">0/4</td>
-<td class="tally" data-browser="graalvm22_2" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="hermes0_7_0" data-tally="0">0/4</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="deno1_33" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="deno1_34" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="deno1_35" data-tally="1">4/4</td>
-<td class="tally" data-browser="deno1_36" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="android4_4" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ios12_2" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ios13_4" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ios14_5" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ios16" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="ios16_1" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="ios16_2" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="ios16_3" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="ios16_4" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="ios16_5" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="ios16_6" data-tally="1">4/4</td>
-<td class="tally" data-browser="ios17" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="samsung19" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="samsung20" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="samsung21" data-tally="1">4/4</td>
-<td class="tally" data-browser="samsung22" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera_mobile72" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="opera_mobile73" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="opera_mobile74" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera_mobile75" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera_mobile76" data-tally="1">4/4</td>
-<td class="tally" data-browser="opera_mobile77" data-tally="1">4/4</td>
-<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="tr" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/7</td>
+<td class="tally" data-browser="babel7corejs3" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
+<td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20210808" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20210906" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20211006" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20211107" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20220502" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20220719" data-tally="0">0/7</td>
+<td class="tally" data-browser="closure20230228" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="typescript3_9corejs3" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
+<td class="tally obsolete" data-browser="typescript4_9corejs3" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
+<td class="tally obsolete" data-browser="typescript5_2corejs3" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
+<td class="tally obsolete" data-browser="typescript5_3corejs3" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
+<td class="tally obsolete" data-browser="typescript5_4corejs3" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
+<td class="tally" data-browser="typescript5_5corejs3" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
+<td class="tally" data-browser="es7shim" data-tally="0">0/7</td>
+<td class="tally" data-browser="ie11" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="firefox102" data-tally="0" data-flagged-tally="1">0/7</td>
+<td class="tally" data-browser="firefox115" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="firefox117" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="firefox118" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="firefox119" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="firefox120" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="firefox121" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="firefox122" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="firefox123" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="firefox124" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="firefox125" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="firefox126" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="firefox127" data-tally="1">7/7</td>
+<td class="tally" data-browser="firefox128" data-tally="1">7/7</td>
+<td class="tally" data-browser="firefox129" data-tally="1">7/7</td>
+<td class="tally unstable" data-browser="firefox130" data-tally="1">7/7</td>
+<td class="tally unstable" data-browser="firefox131" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="chrome115" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="chrome116" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="chrome117" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="chrome118" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="chrome119" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="chrome120" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="chrome121" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="chrome122" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="chrome123" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="chrome124" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="chrome125" data-tally="1">7/7</td>
+<td class="tally" data-browser="chrome126" data-tally="1">7/7</td>
+<td class="tally unstable" data-browser="chrome127" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="edge18" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="edge115" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="edge116" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="edge117" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="edge118" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="edge119" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="edge120" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="edge121" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="edge122" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="edge123" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="edge124" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="edge125" data-tally="1">7/7</td>
+<td class="tally" data-browser="edge126" data-tally="1">7/7</td>
+<td class="tally unstable" data-browser="edge127" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="safari15_6" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="safari16_6" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="safari17" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="safari17_1" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="safari17_2" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="safari17_3" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="safari17_4" data-tally="1">7/7</td>
+<td class="tally" data-browser="safari17_5" data-tally="1">7/7</td>
+<td class="tally unstable" data-browser="safaritp" data-tally="1">7/7</td>
+<td class="tally unstable" data-browser="webkit" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="opera88" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="opera89" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="opera90" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="opera91" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="opera92" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="opera93" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="opera94" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="opera95" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="opera96" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="opera97" data-tally="1">7/7</td>
+<td class="tally" data-browser="opera98" data-tally="1">7/7</td>
+<td class="tally unstable" data-browser="opera99" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="rhino1_7_15" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="node0_4" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="node0_6" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="node0_8" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="node0_10" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="node0_12" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="node14_6" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="node16_0" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="node16_9" data-tally="0">0/7</td>
+<td class="tally" data-browser="node16_11" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="node17_0" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="node17_2" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="node18_0" data-tally="0">0/7</td>
+<td class="tally" data-browser="node18_3" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="node19_0" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="node19_2" data-tally="0">0/7</td>
+<td class="tally" data-browser="node20_0" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="node21_0" data-tally="1">7/7</td>
+<td class="tally" data-browser="node22_0" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="duktape2_6" data-tally="0">0/7</td>
+<td class="tally" data-browser="duktape2_7" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="jerryscript2_3_0" data-tally="0">0/7</td>
+<td class="tally" data-browser="jerryscript2_4_0" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="graalvm19" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="graalvm19_3_6" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="graalvm20" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="graalvm20_1" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="graalvm20_3" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="graalvm20_3_1" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="graalvm21" data-tally="0">0/7</td>
+<td class="tally" data-browser="graalvm21_3_3" data-tally="0">0/7</td>
+<td class="tally" data-browser="graalvm22_2" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="hermes0_7_0" data-tally="0">0/7</td>
+<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="deno1_33" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="deno1_34" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="deno1_35" data-tally="1">7/7</td>
+<td class="tally" data-browser="deno1_36" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="android4_4" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="ios12_2" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="ios13_4" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="ios14_5" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="ios16" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="ios16_1" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="ios16_2" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="ios16_3" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="ios16_4" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="ios16_5" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="ios16_6" data-tally="1">7/7</td>
+<td class="tally" data-browser="ios17" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="samsung19" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="samsung20" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="samsung21" data-tally="1">7/7</td>
+<td class="tally" data-browser="samsung22" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="opera_mobile72" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="opera_mobile73" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="opera_mobile74" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="opera_mobile75" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="opera_mobile76" data-tally="1">7/7</td>
+<td class="tally" data-browser="opera_mobile77" data-tally="1">7/7</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/7</td>
 </tr>
-<tr class="subtest" data-parent="Change_Array_by_copy" id="test-Change_Array_by_copy_Array.prototype.toReversed"><td><span><a class="anchor" href="#test-Change_Array_by_copy_Array.prototype.toReversed">&#xA7;</a>Array.prototype.toReversed</span><script data-source="
+<tr class="subtest" data-parent="Change_Array_by_copy" id="test-Change_Array_by_copy_Array.prototype.toReversed()_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toReversed_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Change_Array_by_copy_Array.prototype.toReversed()_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toReversed_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Array.prototype.toReversed() <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toReversed" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var arr = [1, 2, 3];
 return arr.toReversed()[0] === 3 &amp;&amp; arr[0] === 1;
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("234");try{return Function("asyncTestPassed","\nvar arr = [1, 2, 3];\nreturn arr.toReversed()[0] === 3 && arr[0] === 1;\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("234");return Function("asyncTestPassed","'use strict';"+"\nvar arr = [1, 2, 3];\nreturn arr.toReversed()[0] === 3 && arr[0] === 1;\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
@@ -37982,7 +37982,7 @@ return arr.toReversed()[0] === 3 &amp;&amp; arr[0] === 1;
 <td class="yes" data-browser="typescript5_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox102">No</td>
+<td class="no flagged obsolete" data-browser="firefox102">Flag<a href="#fx-change-array-by-copy-note"><sup>[34]</sup></a></td>
 <td class="yes" data-browser="firefox115">Yes</td>
 <td class="yes obsolete" data-browser="firefox117">Yes</td>
 <td class="yes obsolete" data-browser="firefox118">Yes</td>
@@ -38037,13 +38037,13 @@ return arr.toReversed()[0] === 3 &amp;&amp; arr[0] === 1;
 <td class="yes" data-browser="safari17_5">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="unknown obsolete" data-browser="opera88">?</td>
-<td class="unknown obsolete" data-browser="opera89">?</td>
-<td class="unknown obsolete" data-browser="opera90">?</td>
-<td class="unknown obsolete" data-browser="opera91">?</td>
-<td class="unknown obsolete" data-browser="opera92">?</td>
-<td class="unknown obsolete" data-browser="opera93">?</td>
-<td class="unknown obsolete" data-browser="opera94">?</td>
+<td class="no obsolete" data-browser="opera88">No</td>
+<td class="no obsolete" data-browser="opera89">No</td>
+<td class="no obsolete" data-browser="opera90">No</td>
+<td class="no obsolete" data-browser="opera91">No</td>
+<td class="no obsolete" data-browser="opera92">No</td>
+<td class="no obsolete" data-browser="opera93">No</td>
+<td class="no obsolete" data-browser="opera94">No</td>
 <td class="no obsolete" data-browser="opera95">No</td>
 <td class="yes obsolete" data-browser="opera96">Yes</td>
 <td class="yes obsolete" data-browser="opera97">Yes</td>
@@ -38062,12 +38062,12 @@ return arr.toReversed()[0] === 3 &amp;&amp; arr[0] === 1;
 <td class="unknown obsolete" data-browser="node16_0">?</td>
 <td class="unknown obsolete" data-browser="node16_9">?</td>
 <td class="no" data-browser="node16_11">No</td>
-<td class="unknown obsolete" data-browser="node17_0">?</td>
-<td class="unknown obsolete" data-browser="node17_2">?</td>
-<td class="unknown obsolete" data-browser="node18_0">?</td>
+<td class="no obsolete" data-browser="node17_0">No</td>
+<td class="no obsolete" data-browser="node17_2">No</td>
+<td class="no obsolete" data-browser="node18_0">No</td>
 <td class="no" data-browser="node18_3">No</td>
-<td class="unknown obsolete" data-browser="node19_0">?</td>
-<td class="unknown obsolete" data-browser="node19_2">?</td>
+<td class="no obsolete" data-browser="node19_0">No</td>
+<td class="no obsolete" data-browser="node19_2">No</td>
 <td class="yes" data-browser="node20_0">Yes</td>
 <td class="yes obsolete" data-browser="node21_0">Yes</td>
 <td class="yes" data-browser="node22_0">Yes</td>
@@ -38103,19 +38103,19 @@ return arr.toReversed()[0] === 3 &amp;&amp; arr[0] === 1;
 <td class="yes obsolete" data-browser="ios16_5">Yes</td>
 <td class="yes obsolete" data-browser="ios16_6">Yes</td>
 <td class="yes" data-browser="ios17">Yes</td>
-<td class="unknown obsolete" data-browser="samsung19">?</td>
-<td class="unknown obsolete" data-browser="samsung20">?</td>
+<td class="no obsolete" data-browser="samsung19">No</td>
+<td class="no obsolete" data-browser="samsung20">No</td>
 <td class="yes obsolete" data-browser="samsung21">Yes</td>
 <td class="yes" data-browser="samsung22">Yes</td>
-<td class="unknown obsolete" data-browser="opera_mobile72">?</td>
-<td class="unknown obsolete" data-browser="opera_mobile73">?</td>
+<td class="no obsolete" data-browser="opera_mobile72">No</td>
+<td class="no obsolete" data-browser="opera_mobile73">No</td>
 <td class="yes obsolete" data-browser="opera_mobile74">Yes</td>
 <td class="yes obsolete" data-browser="opera_mobile75">Yes</td>
 <td class="yes obsolete" data-browser="opera_mobile76">Yes</td>
 <td class="yes" data-browser="opera_mobile77">Yes</td>
 <td class="unknown" data-browser="reactnative0_70_3">?</td>
 </tr>
-<tr class="subtest" data-parent="Change_Array_by_copy" id="test-Change_Array_by_copy_Array.prototype.toSorted"><td><span><a class="anchor" href="#test-Change_Array_by_copy_Array.prototype.toSorted">&#xA7;</a>Array.prototype.toSorted</span><script data-source="
+<tr class="subtest" data-parent="Change_Array_by_copy" id="test-Change_Array_by_copy_Array.prototype.toSorted()_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toSorted_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Change_Array_by_copy_Array.prototype.toSorted()_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toSorted_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Array.prototype.toSorted() <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toSorted" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var arr = [&apos;C&apos;, &apos;A&apos;, &apos;B&apos;];
 return arr.toSorted()[0] === &apos;A&apos; &amp;&amp; arr[0] === &apos;C&apos;;
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("235");try{return Function("asyncTestPassed","\nvar arr = ['C', 'A', 'B'];\nreturn arr.toSorted()[0] === 'A' && arr[0] === 'C';\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("235");return Function("asyncTestPassed","'use strict';"+"\nvar arr = ['C', 'A', 'B'];\nreturn arr.toSorted()[0] === 'A' && arr[0] === 'C';\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
@@ -38141,7 +38141,7 @@ return arr.toSorted()[0] === &apos;A&apos; &amp;&amp; arr[0] === &apos;C&apos;;
 <td class="yes" data-browser="typescript5_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox102">No</td>
+<td class="no flagged obsolete" data-browser="firefox102">Flag<a href="#fx-change-array-by-copy-note"><sup>[34]</sup></a></td>
 <td class="yes" data-browser="firefox115">Yes</td>
 <td class="yes obsolete" data-browser="firefox117">Yes</td>
 <td class="yes obsolete" data-browser="firefox118">Yes</td>
@@ -38196,13 +38196,13 @@ return arr.toSorted()[0] === &apos;A&apos; &amp;&amp; arr[0] === &apos;C&apos;;
 <td class="yes" data-browser="safari17_5">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="unknown obsolete" data-browser="opera88">?</td>
-<td class="unknown obsolete" data-browser="opera89">?</td>
-<td class="unknown obsolete" data-browser="opera90">?</td>
-<td class="unknown obsolete" data-browser="opera91">?</td>
-<td class="unknown obsolete" data-browser="opera92">?</td>
-<td class="unknown obsolete" data-browser="opera93">?</td>
-<td class="unknown obsolete" data-browser="opera94">?</td>
+<td class="no obsolete" data-browser="opera88">No</td>
+<td class="no obsolete" data-browser="opera89">No</td>
+<td class="no obsolete" data-browser="opera90">No</td>
+<td class="no obsolete" data-browser="opera91">No</td>
+<td class="no obsolete" data-browser="opera92">No</td>
+<td class="no obsolete" data-browser="opera93">No</td>
+<td class="no obsolete" data-browser="opera94">No</td>
 <td class="no obsolete" data-browser="opera95">No</td>
 <td class="yes obsolete" data-browser="opera96">Yes</td>
 <td class="yes obsolete" data-browser="opera97">Yes</td>
@@ -38221,12 +38221,12 @@ return arr.toSorted()[0] === &apos;A&apos; &amp;&amp; arr[0] === &apos;C&apos;;
 <td class="unknown obsolete" data-browser="node16_0">?</td>
 <td class="unknown obsolete" data-browser="node16_9">?</td>
 <td class="no" data-browser="node16_11">No</td>
-<td class="unknown obsolete" data-browser="node17_0">?</td>
-<td class="unknown obsolete" data-browser="node17_2">?</td>
-<td class="unknown obsolete" data-browser="node18_0">?</td>
+<td class="no obsolete" data-browser="node17_0">No</td>
+<td class="no obsolete" data-browser="node17_2">No</td>
+<td class="no obsolete" data-browser="node18_0">No</td>
 <td class="no" data-browser="node18_3">No</td>
-<td class="unknown obsolete" data-browser="node19_0">?</td>
-<td class="unknown obsolete" data-browser="node19_2">?</td>
+<td class="no obsolete" data-browser="node19_0">No</td>
+<td class="no obsolete" data-browser="node19_2">No</td>
 <td class="yes" data-browser="node20_0">Yes</td>
 <td class="yes obsolete" data-browser="node21_0">Yes</td>
 <td class="yes" data-browser="node22_0">Yes</td>
@@ -38262,19 +38262,19 @@ return arr.toSorted()[0] === &apos;A&apos; &amp;&amp; arr[0] === &apos;C&apos;;
 <td class="yes obsolete" data-browser="ios16_5">Yes</td>
 <td class="yes obsolete" data-browser="ios16_6">Yes</td>
 <td class="yes" data-browser="ios17">Yes</td>
-<td class="unknown obsolete" data-browser="samsung19">?</td>
-<td class="unknown obsolete" data-browser="samsung20">?</td>
+<td class="no obsolete" data-browser="samsung19">No</td>
+<td class="no obsolete" data-browser="samsung20">No</td>
 <td class="yes obsolete" data-browser="samsung21">Yes</td>
 <td class="yes" data-browser="samsung22">Yes</td>
-<td class="unknown obsolete" data-browser="opera_mobile72">?</td>
-<td class="unknown obsolete" data-browser="opera_mobile73">?</td>
+<td class="no obsolete" data-browser="opera_mobile72">No</td>
+<td class="no obsolete" data-browser="opera_mobile73">No</td>
 <td class="yes obsolete" data-browser="opera_mobile74">Yes</td>
 <td class="yes obsolete" data-browser="opera_mobile75">Yes</td>
 <td class="yes obsolete" data-browser="opera_mobile76">Yes</td>
 <td class="yes" data-browser="opera_mobile77">Yes</td>
 <td class="unknown" data-browser="reactnative0_70_3">?</td>
 </tr>
-<tr class="subtest" data-parent="Change_Array_by_copy" id="test-Change_Array_by_copy_Array.prototype.toSpliced"><td><span><a class="anchor" href="#test-Change_Array_by_copy_Array.prototype.toSpliced">&#xA7;</a>Array.prototype.toSpliced</span><script data-source="
+<tr class="subtest" data-parent="Change_Array_by_copy" id="test-Change_Array_by_copy_Array.prototype.toSpliced()_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toSpliced_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Change_Array_by_copy_Array.prototype.toSpliced()_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toSpliced_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Array.prototype.toSpliced() <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toSpliced" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var arr = [&apos;A&apos;, &apos;C&apos;];
 return arr.toSpliced(1, 0, &apos;B&apos;)[1] === &apos;B&apos; &amp;&amp; arr[1] === &apos;C&apos;;
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("236");try{return Function("asyncTestPassed","\nvar arr = ['A', 'C'];\nreturn arr.toSpliced(1, 0, 'B')[1] === 'B' && arr[1] === 'C';\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("236");return Function("asyncTestPassed","'use strict';"+"\nvar arr = ['A', 'C'];\nreturn arr.toSpliced(1, 0, 'B')[1] === 'B' && arr[1] === 'C';\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
@@ -38300,7 +38300,7 @@ return arr.toSpliced(1, 0, &apos;B&apos;)[1] === &apos;B&apos; &amp;&amp; arr[1]
 <td class="yes" data-browser="typescript5_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox102">No</td>
+<td class="no flagged obsolete" data-browser="firefox102">Flag<a href="#fx-change-array-by-copy-note"><sup>[34]</sup></a></td>
 <td class="yes" data-browser="firefox115">Yes</td>
 <td class="yes obsolete" data-browser="firefox117">Yes</td>
 <td class="yes obsolete" data-browser="firefox118">Yes</td>
@@ -38355,13 +38355,13 @@ return arr.toSpliced(1, 0, &apos;B&apos;)[1] === &apos;B&apos; &amp;&amp; arr[1]
 <td class="yes" data-browser="safari17_5">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="unknown obsolete" data-browser="opera88">?</td>
-<td class="unknown obsolete" data-browser="opera89">?</td>
-<td class="unknown obsolete" data-browser="opera90">?</td>
-<td class="unknown obsolete" data-browser="opera91">?</td>
-<td class="unknown obsolete" data-browser="opera92">?</td>
-<td class="unknown obsolete" data-browser="opera93">?</td>
-<td class="unknown obsolete" data-browser="opera94">?</td>
+<td class="no obsolete" data-browser="opera88">No</td>
+<td class="no obsolete" data-browser="opera89">No</td>
+<td class="no obsolete" data-browser="opera90">No</td>
+<td class="no obsolete" data-browser="opera91">No</td>
+<td class="no obsolete" data-browser="opera92">No</td>
+<td class="no obsolete" data-browser="opera93">No</td>
+<td class="no obsolete" data-browser="opera94">No</td>
 <td class="no obsolete" data-browser="opera95">No</td>
 <td class="yes obsolete" data-browser="opera96">Yes</td>
 <td class="yes obsolete" data-browser="opera97">Yes</td>
@@ -38380,12 +38380,12 @@ return arr.toSpliced(1, 0, &apos;B&apos;)[1] === &apos;B&apos; &amp;&amp; arr[1]
 <td class="unknown obsolete" data-browser="node16_0">?</td>
 <td class="unknown obsolete" data-browser="node16_9">?</td>
 <td class="no" data-browser="node16_11">No</td>
-<td class="unknown obsolete" data-browser="node17_0">?</td>
-<td class="unknown obsolete" data-browser="node17_2">?</td>
-<td class="unknown obsolete" data-browser="node18_0">?</td>
+<td class="no obsolete" data-browser="node17_0">No</td>
+<td class="no obsolete" data-browser="node17_2">No</td>
+<td class="no obsolete" data-browser="node18_0">No</td>
 <td class="no" data-browser="node18_3">No</td>
-<td class="unknown obsolete" data-browser="node19_0">?</td>
-<td class="unknown obsolete" data-browser="node19_2">?</td>
+<td class="no obsolete" data-browser="node19_0">No</td>
+<td class="no obsolete" data-browser="node19_2">No</td>
 <td class="yes" data-browser="node20_0">Yes</td>
 <td class="yes obsolete" data-browser="node21_0">Yes</td>
 <td class="yes" data-browser="node22_0">Yes</td>
@@ -38421,19 +38421,19 @@ return arr.toSpliced(1, 0, &apos;B&apos;)[1] === &apos;B&apos; &amp;&amp; arr[1]
 <td class="yes obsolete" data-browser="ios16_5">Yes</td>
 <td class="yes obsolete" data-browser="ios16_6">Yes</td>
 <td class="yes" data-browser="ios17">Yes</td>
-<td class="unknown obsolete" data-browser="samsung19">?</td>
-<td class="unknown obsolete" data-browser="samsung20">?</td>
+<td class="no obsolete" data-browser="samsung19">No</td>
+<td class="no obsolete" data-browser="samsung20">No</td>
 <td class="yes obsolete" data-browser="samsung21">Yes</td>
 <td class="yes" data-browser="samsung22">Yes</td>
-<td class="unknown obsolete" data-browser="opera_mobile72">?</td>
-<td class="unknown obsolete" data-browser="opera_mobile73">?</td>
+<td class="no obsolete" data-browser="opera_mobile72">No</td>
+<td class="no obsolete" data-browser="opera_mobile73">No</td>
 <td class="yes obsolete" data-browser="opera_mobile74">Yes</td>
 <td class="yes obsolete" data-browser="opera_mobile75">Yes</td>
 <td class="yes obsolete" data-browser="opera_mobile76">Yes</td>
 <td class="yes" data-browser="opera_mobile77">Yes</td>
 <td class="unknown" data-browser="reactnative0_70_3">?</td>
 </tr>
-<tr class="subtest" data-parent="Change_Array_by_copy" id="test-Change_Array_by_copy_Array.prototype.with"><td><span><a class="anchor" href="#test-Change_Array_by_copy_Array.prototype.with">&#xA7;</a>Array.prototype.with</span><script data-source="
+<tr class="subtest" data-parent="Change_Array_by_copy" id="test-Change_Array_by_copy_Array.prototype.with()_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/with_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Change_Array_by_copy_Array.prototype.with()_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/with_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Array.prototype.with() <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/with" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var arr = [&apos;A&apos;, &apos;X&apos;, &apos;C&apos;];
 return arr.with(1, &apos;B&apos;)[1] === &apos;B&apos; &amp;&amp; arr[1] === &apos;X&apos;;
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("237");try{return Function("asyncTestPassed","\nvar arr = ['A', 'X', 'C'];\nreturn arr.with(1, 'B')[1] === 'B' && arr[1] === 'X';\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("237");return Function("asyncTestPassed","'use strict';"+"\nvar arr = ['A', 'X', 'C'];\nreturn arr.with(1, 'B')[1] === 'B' && arr[1] === 'X';\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
@@ -38459,7 +38459,7 @@ return arr.with(1, &apos;B&apos;)[1] === &apos;B&apos; &amp;&amp; arr[1] === &ap
 <td class="yes" data-browser="typescript5_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox102">No</td>
+<td class="no flagged obsolete" data-browser="firefox102">Flag<a href="#fx-change-array-by-copy-note"><sup>[34]</sup></a></td>
 <td class="yes" data-browser="firefox115">Yes</td>
 <td class="yes obsolete" data-browser="firefox117">Yes</td>
 <td class="yes obsolete" data-browser="firefox118">Yes</td>
@@ -38514,13 +38514,13 @@ return arr.with(1, &apos;B&apos;)[1] === &apos;B&apos; &amp;&amp; arr[1] === &ap
 <td class="yes" data-browser="safari17_5">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="unknown obsolete" data-browser="opera88">?</td>
-<td class="unknown obsolete" data-browser="opera89">?</td>
-<td class="unknown obsolete" data-browser="opera90">?</td>
-<td class="unknown obsolete" data-browser="opera91">?</td>
-<td class="unknown obsolete" data-browser="opera92">?</td>
-<td class="unknown obsolete" data-browser="opera93">?</td>
-<td class="unknown obsolete" data-browser="opera94">?</td>
+<td class="no obsolete" data-browser="opera88">No</td>
+<td class="no obsolete" data-browser="opera89">No</td>
+<td class="no obsolete" data-browser="opera90">No</td>
+<td class="no obsolete" data-browser="opera91">No</td>
+<td class="no obsolete" data-browser="opera92">No</td>
+<td class="no obsolete" data-browser="opera93">No</td>
+<td class="no obsolete" data-browser="opera94">No</td>
 <td class="no obsolete" data-browser="opera95">No</td>
 <td class="yes obsolete" data-browser="opera96">Yes</td>
 <td class="yes obsolete" data-browser="opera97">Yes</td>
@@ -38539,12 +38539,12 @@ return arr.with(1, &apos;B&apos;)[1] === &apos;B&apos; &amp;&amp; arr[1] === &ap
 <td class="unknown obsolete" data-browser="node16_0">?</td>
 <td class="unknown obsolete" data-browser="node16_9">?</td>
 <td class="no" data-browser="node16_11">No</td>
-<td class="unknown obsolete" data-browser="node17_0">?</td>
-<td class="unknown obsolete" data-browser="node17_2">?</td>
-<td class="unknown obsolete" data-browser="node18_0">?</td>
+<td class="no obsolete" data-browser="node17_0">No</td>
+<td class="no obsolete" data-browser="node17_2">No</td>
+<td class="no obsolete" data-browser="node18_0">No</td>
 <td class="no" data-browser="node18_3">No</td>
-<td class="unknown obsolete" data-browser="node19_0">?</td>
-<td class="unknown obsolete" data-browser="node19_2">?</td>
+<td class="no obsolete" data-browser="node19_0">No</td>
+<td class="no obsolete" data-browser="node19_2">No</td>
 <td class="yes" data-browser="node20_0">Yes</td>
 <td class="yes obsolete" data-browser="node21_0">Yes</td>
 <td class="yes" data-browser="node22_0">Yes</td>
@@ -38580,12 +38580,489 @@ return arr.with(1, &apos;B&apos;)[1] === &apos;B&apos; &amp;&amp; arr[1] === &ap
 <td class="yes obsolete" data-browser="ios16_5">Yes</td>
 <td class="yes obsolete" data-browser="ios16_6">Yes</td>
 <td class="yes" data-browser="ios17">Yes</td>
-<td class="unknown obsolete" data-browser="samsung19">?</td>
-<td class="unknown obsolete" data-browser="samsung20">?</td>
+<td class="no obsolete" data-browser="samsung19">No</td>
+<td class="no obsolete" data-browser="samsung20">No</td>
 <td class="yes obsolete" data-browser="samsung21">Yes</td>
 <td class="yes" data-browser="samsung22">Yes</td>
-<td class="unknown obsolete" data-browser="opera_mobile72">?</td>
-<td class="unknown obsolete" data-browser="opera_mobile73">?</td>
+<td class="no obsolete" data-browser="opera_mobile72">No</td>
+<td class="no obsolete" data-browser="opera_mobile73">No</td>
+<td class="yes obsolete" data-browser="opera_mobile74">Yes</td>
+<td class="yes obsolete" data-browser="opera_mobile75">Yes</td>
+<td class="yes obsolete" data-browser="opera_mobile76">Yes</td>
+<td class="yes" data-browser="opera_mobile77">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
+</tr>
+<tr class="subtest" data-parent="Change_Array_by_copy" id="test-Change_Array_by_copy_TypedArray.prototype.toReversed()_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/toReversed_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Change_Array_by_copy_TypedArray.prototype.toReversed()_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/toReversed_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>TypedArray.prototype.toReversed() <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/toReversed" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
+var arr = new Uint8Array([1, 2, 3]);
+return arr.toReversed()[0] == 3 &amp;&amp; arr[0] == 1;
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("238");try{return Function("asyncTestPassed","\nvar arr = new Uint8Array([1, 2, 3]);\nreturn arr.toReversed()[0] == 3 && arr[0] == 1;\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("238");return Function("asyncTestPassed","'use strict';"+"\nvar arr = new Uint8Array([1, 2, 3]);\nreturn arr.toReversed()[0] == 3 && arr[0] == 1;\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+</script></td>
+<td class="unknown obsolete" data-browser="tr">?</td>
+<td class="unknown obsolete" data-browser="babel6corejs2">?</td>
+<td class="unknown obsolete" data-browser="babel7corejs2">?</td>
+<td class="unknown" data-browser="babel7corejs3">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20210808">?</td>
+<td class="unknown obsolete" data-browser="closure20210906">?</td>
+<td class="unknown obsolete" data-browser="closure20211006">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220719">?</td>
+<td class="unknown" data-browser="closure20230228">?</td>
+<td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
+<td class="unknown obsolete" data-browser="typescript3_9corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript4_9corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript5_2corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript5_3corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript5_4corejs3">?</td>
+<td class="unknown" data-browser="typescript5_5corejs3">?</td>
+<td class="unknown" data-browser="es7shim">?</td>
+<td class="no" data-browser="ie11">No</td>
+<td class="no flagged obsolete" data-browser="firefox102">Flag<a href="#fx-change-array-by-copy-note"><sup>[34]</sup></a></td>
+<td class="yes" data-browser="firefox115">Yes</td>
+<td class="yes obsolete" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox118">Yes</td>
+<td class="yes obsolete" data-browser="firefox119">Yes</td>
+<td class="yes obsolete" data-browser="firefox120">Yes</td>
+<td class="yes obsolete" data-browser="firefox121">Yes</td>
+<td class="yes obsolete" data-browser="firefox122">Yes</td>
+<td class="yes obsolete" data-browser="firefox123">Yes</td>
+<td class="yes obsolete" data-browser="firefox124">Yes</td>
+<td class="yes obsolete" data-browser="firefox125">Yes</td>
+<td class="yes obsolete" data-browser="firefox126">Yes</td>
+<td class="yes obsolete" data-browser="firefox127">Yes</td>
+<td class="yes" data-browser="firefox128">Yes</td>
+<td class="yes" data-browser="firefox129">Yes</td>
+<td class="yes unstable" data-browser="firefox130">Yes</td>
+<td class="yes unstable" data-browser="firefox131">Yes</td>
+<td class="unknown obsolete" data-browser="opera12_10">?</td>
+<td class="yes obsolete" data-browser="chrome115">Yes</td>
+<td class="yes obsolete" data-browser="chrome116">Yes</td>
+<td class="yes obsolete" data-browser="chrome117">Yes</td>
+<td class="yes obsolete" data-browser="chrome118">Yes</td>
+<td class="yes obsolete" data-browser="chrome119">Yes</td>
+<td class="yes obsolete" data-browser="chrome120">Yes</td>
+<td class="yes obsolete" data-browser="chrome121">Yes</td>
+<td class="yes obsolete" data-browser="chrome122">Yes</td>
+<td class="yes obsolete" data-browser="chrome123">Yes</td>
+<td class="yes obsolete" data-browser="chrome124">Yes</td>
+<td class="yes obsolete" data-browser="chrome125">Yes</td>
+<td class="yes" data-browser="chrome126">Yes</td>
+<td class="yes unstable" data-browser="chrome127">Yes</td>
+<td class="no obsolete" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge115">Yes</td>
+<td class="yes obsolete" data-browser="edge116">Yes</td>
+<td class="yes obsolete" data-browser="edge117">Yes</td>
+<td class="yes obsolete" data-browser="edge118">Yes</td>
+<td class="yes obsolete" data-browser="edge119">Yes</td>
+<td class="yes obsolete" data-browser="edge120">Yes</td>
+<td class="yes obsolete" data-browser="edge121">Yes</td>
+<td class="yes obsolete" data-browser="edge122">Yes</td>
+<td class="yes obsolete" data-browser="edge123">Yes</td>
+<td class="yes obsolete" data-browser="edge124">Yes</td>
+<td class="yes obsolete" data-browser="edge125">Yes</td>
+<td class="yes" data-browser="edge126">Yes</td>
+<td class="yes unstable" data-browser="edge127">Yes</td>
+<td class="no obsolete" data-browser="safari15_6">No</td>
+<td class="yes obsolete" data-browser="safari16_6">Yes</td>
+<td class="yes obsolete" data-browser="safari17">Yes</td>
+<td class="yes obsolete" data-browser="safari17_1">Yes</td>
+<td class="yes obsolete" data-browser="safari17_2">Yes</td>
+<td class="yes obsolete" data-browser="safari17_3">Yes</td>
+<td class="yes obsolete" data-browser="safari17_4">Yes</td>
+<td class="yes" data-browser="safari17_5">Yes</td>
+<td class="yes unstable" data-browser="safaritp">Yes</td>
+<td class="yes unstable" data-browser="webkit">Yes</td>
+<td class="no obsolete" data-browser="opera88">No</td>
+<td class="no obsolete" data-browser="opera89">No</td>
+<td class="no obsolete" data-browser="opera90">No</td>
+<td class="no obsolete" data-browser="opera91">No</td>
+<td class="no obsolete" data-browser="opera92">No</td>
+<td class="no obsolete" data-browser="opera93">No</td>
+<td class="no obsolete" data-browser="opera94">No</td>
+<td class="no obsolete" data-browser="opera95">No</td>
+<td class="yes obsolete" data-browser="opera96">Yes</td>
+<td class="yes obsolete" data-browser="opera97">Yes</td>
+<td class="yes" data-browser="opera98">Yes</td>
+<td class="yes unstable" data-browser="opera99">Yes</td>
+<td class="unknown obsolete" data-browser="rhino1_7_13">?</td>
+<td class="unknown obsolete" data-browser="rhino1_7_14">?</td>
+<td class="unknown obsolete" data-browser="rhino1_7_15">?</td>
+<td class="unknown obsolete" data-browser="phantom2_1">?</td>
+<td class="unknown obsolete" data-browser="node0_4">?</td>
+<td class="unknown obsolete" data-browser="node0_6">?</td>
+<td class="unknown obsolete" data-browser="node0_8">?</td>
+<td class="unknown obsolete" data-browser="node0_10">?</td>
+<td class="unknown obsolete" data-browser="node0_12">?</td>
+<td class="unknown obsolete" data-browser="node14_6">?</td>
+<td class="unknown obsolete" data-browser="node16_0">?</td>
+<td class="unknown obsolete" data-browser="node16_9">?</td>
+<td class="no" data-browser="node16_11">No</td>
+<td class="no obsolete" data-browser="node17_0">No</td>
+<td class="no obsolete" data-browser="node17_2">No</td>
+<td class="no obsolete" data-browser="node18_0">No</td>
+<td class="no" data-browser="node18_3">No</td>
+<td class="no obsolete" data-browser="node19_0">No</td>
+<td class="no obsolete" data-browser="node19_2">No</td>
+<td class="yes" data-browser="node20_0">Yes</td>
+<td class="yes obsolete" data-browser="node21_0">Yes</td>
+<td class="yes" data-browser="node22_0">Yes</td>
+<td class="unknown obsolete" data-browser="duktape2_6">?</td>
+<td class="unknown" data-browser="duktape2_7">?</td>
+<td class="unknown obsolete" data-browser="jerryscript2_3_0">?</td>
+<td class="unknown" data-browser="jerryscript2_4_0">?</td>
+<td class="unknown obsolete" data-browser="graalvm19">?</td>
+<td class="unknown obsolete" data-browser="graalvm19_3_6">?</td>
+<td class="unknown obsolete" data-browser="graalvm20">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_1">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_3">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_3_1">?</td>
+<td class="unknown obsolete" data-browser="graalvm21">?</td>
+<td class="unknown" data-browser="graalvm21_3_3">?</td>
+<td class="unknown" data-browser="graalvm22_2">?</td>
+<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
+<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="yes obsolete" data-browser="deno1_33">Yes</td>
+<td class="yes obsolete" data-browser="deno1_34">Yes</td>
+<td class="yes obsolete" data-browser="deno1_35">Yes</td>
+<td class="yes" data-browser="deno1_36">Yes</td>
+<td class="unknown obsolete" data-browser="android4_4">?</td>
+<td class="unknown obsolete" data-browser="android4_4_3">?</td>
+<td class="unknown obsolete" data-browser="ios12_2">?</td>
+<td class="unknown obsolete" data-browser="ios13_4">?</td>
+<td class="unknown obsolete" data-browser="ios14_5">?</td>
+<td class="yes obsolete" data-browser="ios16">Yes</td>
+<td class="yes obsolete" data-browser="ios16_1">Yes</td>
+<td class="yes obsolete" data-browser="ios16_2">Yes</td>
+<td class="yes obsolete" data-browser="ios16_3">Yes</td>
+<td class="yes obsolete" data-browser="ios16_4">Yes</td>
+<td class="yes obsolete" data-browser="ios16_5">Yes</td>
+<td class="yes obsolete" data-browser="ios16_6">Yes</td>
+<td class="yes" data-browser="ios17">Yes</td>
+<td class="no obsolete" data-browser="samsung19">No</td>
+<td class="no obsolete" data-browser="samsung20">No</td>
+<td class="yes obsolete" data-browser="samsung21">Yes</td>
+<td class="yes" data-browser="samsung22">Yes</td>
+<td class="no obsolete" data-browser="opera_mobile72">No</td>
+<td class="no obsolete" data-browser="opera_mobile73">No</td>
+<td class="yes obsolete" data-browser="opera_mobile74">Yes</td>
+<td class="yes obsolete" data-browser="opera_mobile75">Yes</td>
+<td class="yes obsolete" data-browser="opera_mobile76">Yes</td>
+<td class="yes" data-browser="opera_mobile77">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
+</tr>
+<tr class="subtest" data-parent="Change_Array_by_copy" id="test-Change_Array_by_copy_TypedArray.prototype.toSorted()_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/toSorted_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Change_Array_by_copy_TypedArray.prototype.toSorted()_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/toSorted_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>TypedArray.prototype.toSorted() <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/toSorted" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
+var arr = new Uint8Array([3, 1, 2]);
+return arr.toSorted()[0] == 1 &amp;&amp; arr[0] == 3;
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("239");try{return Function("asyncTestPassed","\nvar arr = new Uint8Array([3, 1, 2]);\nreturn arr.toSorted()[0] == 1 && arr[0] == 3;\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("239");return Function("asyncTestPassed","'use strict';"+"\nvar arr = new Uint8Array([3, 1, 2]);\nreturn arr.toSorted()[0] == 1 && arr[0] == 3;\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+</script></td>
+<td class="unknown obsolete" data-browser="tr">?</td>
+<td class="unknown obsolete" data-browser="babel6corejs2">?</td>
+<td class="unknown obsolete" data-browser="babel7corejs2">?</td>
+<td class="unknown" data-browser="babel7corejs3">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20210808">?</td>
+<td class="unknown obsolete" data-browser="closure20210906">?</td>
+<td class="unknown obsolete" data-browser="closure20211006">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220719">?</td>
+<td class="unknown" data-browser="closure20230228">?</td>
+<td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
+<td class="unknown obsolete" data-browser="typescript3_9corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript4_9corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript5_2corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript5_3corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript5_4corejs3">?</td>
+<td class="unknown" data-browser="typescript5_5corejs3">?</td>
+<td class="unknown" data-browser="es7shim">?</td>
+<td class="no" data-browser="ie11">No</td>
+<td class="no flagged obsolete" data-browser="firefox102">Flag<a href="#fx-change-array-by-copy-note"><sup>[34]</sup></a></td>
+<td class="yes" data-browser="firefox115">Yes</td>
+<td class="yes obsolete" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox118">Yes</td>
+<td class="yes obsolete" data-browser="firefox119">Yes</td>
+<td class="yes obsolete" data-browser="firefox120">Yes</td>
+<td class="yes obsolete" data-browser="firefox121">Yes</td>
+<td class="yes obsolete" data-browser="firefox122">Yes</td>
+<td class="yes obsolete" data-browser="firefox123">Yes</td>
+<td class="yes obsolete" data-browser="firefox124">Yes</td>
+<td class="yes obsolete" data-browser="firefox125">Yes</td>
+<td class="yes obsolete" data-browser="firefox126">Yes</td>
+<td class="yes obsolete" data-browser="firefox127">Yes</td>
+<td class="yes" data-browser="firefox128">Yes</td>
+<td class="yes" data-browser="firefox129">Yes</td>
+<td class="yes unstable" data-browser="firefox130">Yes</td>
+<td class="yes unstable" data-browser="firefox131">Yes</td>
+<td class="unknown obsolete" data-browser="opera12_10">?</td>
+<td class="yes obsolete" data-browser="chrome115">Yes</td>
+<td class="yes obsolete" data-browser="chrome116">Yes</td>
+<td class="yes obsolete" data-browser="chrome117">Yes</td>
+<td class="yes obsolete" data-browser="chrome118">Yes</td>
+<td class="yes obsolete" data-browser="chrome119">Yes</td>
+<td class="yes obsolete" data-browser="chrome120">Yes</td>
+<td class="yes obsolete" data-browser="chrome121">Yes</td>
+<td class="yes obsolete" data-browser="chrome122">Yes</td>
+<td class="yes obsolete" data-browser="chrome123">Yes</td>
+<td class="yes obsolete" data-browser="chrome124">Yes</td>
+<td class="yes obsolete" data-browser="chrome125">Yes</td>
+<td class="yes" data-browser="chrome126">Yes</td>
+<td class="yes unstable" data-browser="chrome127">Yes</td>
+<td class="no obsolete" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge115">Yes</td>
+<td class="yes obsolete" data-browser="edge116">Yes</td>
+<td class="yes obsolete" data-browser="edge117">Yes</td>
+<td class="yes obsolete" data-browser="edge118">Yes</td>
+<td class="yes obsolete" data-browser="edge119">Yes</td>
+<td class="yes obsolete" data-browser="edge120">Yes</td>
+<td class="yes obsolete" data-browser="edge121">Yes</td>
+<td class="yes obsolete" data-browser="edge122">Yes</td>
+<td class="yes obsolete" data-browser="edge123">Yes</td>
+<td class="yes obsolete" data-browser="edge124">Yes</td>
+<td class="yes obsolete" data-browser="edge125">Yes</td>
+<td class="yes" data-browser="edge126">Yes</td>
+<td class="yes unstable" data-browser="edge127">Yes</td>
+<td class="no obsolete" data-browser="safari15_6">No</td>
+<td class="yes obsolete" data-browser="safari16_6">Yes</td>
+<td class="yes obsolete" data-browser="safari17">Yes</td>
+<td class="yes obsolete" data-browser="safari17_1">Yes</td>
+<td class="yes obsolete" data-browser="safari17_2">Yes</td>
+<td class="yes obsolete" data-browser="safari17_3">Yes</td>
+<td class="yes obsolete" data-browser="safari17_4">Yes</td>
+<td class="yes" data-browser="safari17_5">Yes</td>
+<td class="yes unstable" data-browser="safaritp">Yes</td>
+<td class="yes unstable" data-browser="webkit">Yes</td>
+<td class="no obsolete" data-browser="opera88">No</td>
+<td class="no obsolete" data-browser="opera89">No</td>
+<td class="no obsolete" data-browser="opera90">No</td>
+<td class="no obsolete" data-browser="opera91">No</td>
+<td class="no obsolete" data-browser="opera92">No</td>
+<td class="no obsolete" data-browser="opera93">No</td>
+<td class="no obsolete" data-browser="opera94">No</td>
+<td class="no obsolete" data-browser="opera95">No</td>
+<td class="yes obsolete" data-browser="opera96">Yes</td>
+<td class="yes obsolete" data-browser="opera97">Yes</td>
+<td class="yes" data-browser="opera98">Yes</td>
+<td class="yes unstable" data-browser="opera99">Yes</td>
+<td class="unknown obsolete" data-browser="rhino1_7_13">?</td>
+<td class="unknown obsolete" data-browser="rhino1_7_14">?</td>
+<td class="unknown obsolete" data-browser="rhino1_7_15">?</td>
+<td class="unknown obsolete" data-browser="phantom2_1">?</td>
+<td class="unknown obsolete" data-browser="node0_4">?</td>
+<td class="unknown obsolete" data-browser="node0_6">?</td>
+<td class="unknown obsolete" data-browser="node0_8">?</td>
+<td class="unknown obsolete" data-browser="node0_10">?</td>
+<td class="unknown obsolete" data-browser="node0_12">?</td>
+<td class="unknown obsolete" data-browser="node14_6">?</td>
+<td class="unknown obsolete" data-browser="node16_0">?</td>
+<td class="unknown obsolete" data-browser="node16_9">?</td>
+<td class="no" data-browser="node16_11">No</td>
+<td class="no obsolete" data-browser="node17_0">No</td>
+<td class="no obsolete" data-browser="node17_2">No</td>
+<td class="no obsolete" data-browser="node18_0">No</td>
+<td class="no" data-browser="node18_3">No</td>
+<td class="no obsolete" data-browser="node19_0">No</td>
+<td class="no obsolete" data-browser="node19_2">No</td>
+<td class="yes" data-browser="node20_0">Yes</td>
+<td class="yes obsolete" data-browser="node21_0">Yes</td>
+<td class="yes" data-browser="node22_0">Yes</td>
+<td class="unknown obsolete" data-browser="duktape2_6">?</td>
+<td class="unknown" data-browser="duktape2_7">?</td>
+<td class="unknown obsolete" data-browser="jerryscript2_3_0">?</td>
+<td class="unknown" data-browser="jerryscript2_4_0">?</td>
+<td class="unknown obsolete" data-browser="graalvm19">?</td>
+<td class="unknown obsolete" data-browser="graalvm19_3_6">?</td>
+<td class="unknown obsolete" data-browser="graalvm20">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_1">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_3">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_3_1">?</td>
+<td class="unknown obsolete" data-browser="graalvm21">?</td>
+<td class="unknown" data-browser="graalvm21_3_3">?</td>
+<td class="unknown" data-browser="graalvm22_2">?</td>
+<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
+<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="yes obsolete" data-browser="deno1_33">Yes</td>
+<td class="yes obsolete" data-browser="deno1_34">Yes</td>
+<td class="yes obsolete" data-browser="deno1_35">Yes</td>
+<td class="yes" data-browser="deno1_36">Yes</td>
+<td class="unknown obsolete" data-browser="android4_4">?</td>
+<td class="unknown obsolete" data-browser="android4_4_3">?</td>
+<td class="unknown obsolete" data-browser="ios12_2">?</td>
+<td class="unknown obsolete" data-browser="ios13_4">?</td>
+<td class="unknown obsolete" data-browser="ios14_5">?</td>
+<td class="yes obsolete" data-browser="ios16">Yes</td>
+<td class="yes obsolete" data-browser="ios16_1">Yes</td>
+<td class="yes obsolete" data-browser="ios16_2">Yes</td>
+<td class="yes obsolete" data-browser="ios16_3">Yes</td>
+<td class="yes obsolete" data-browser="ios16_4">Yes</td>
+<td class="yes obsolete" data-browser="ios16_5">Yes</td>
+<td class="yes obsolete" data-browser="ios16_6">Yes</td>
+<td class="yes" data-browser="ios17">Yes</td>
+<td class="no obsolete" data-browser="samsung19">No</td>
+<td class="no obsolete" data-browser="samsung20">No</td>
+<td class="yes obsolete" data-browser="samsung21">Yes</td>
+<td class="yes" data-browser="samsung22">Yes</td>
+<td class="no obsolete" data-browser="opera_mobile72">No</td>
+<td class="no obsolete" data-browser="opera_mobile73">No</td>
+<td class="yes obsolete" data-browser="opera_mobile74">Yes</td>
+<td class="yes obsolete" data-browser="opera_mobile75">Yes</td>
+<td class="yes obsolete" data-browser="opera_mobile76">Yes</td>
+<td class="yes" data-browser="opera_mobile77">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
+</tr>
+<tr class="subtest" data-parent="Change_Array_by_copy" id="test-Change_Array_by_copy_TypedArray.prototype.with()_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/with_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Change_Array_by_copy_TypedArray.prototype.with()_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/with_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>TypedArray.prototype.with() <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/with" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
+var arr = new Uint8Array([1, 0, 2]);
+return arr.with(1, 2)[1] == 2 &amp;&amp; arr[1] == 0;
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("240");try{return Function("asyncTestPassed","\nvar arr = new Uint8Array([1, 0, 2]);\nreturn arr.with(1, 2)[1] == 2 && arr[1] == 0;\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("240");return Function("asyncTestPassed","'use strict';"+"\nvar arr = new Uint8Array([1, 0, 2]);\nreturn arr.with(1, 2)[1] == 2 && arr[1] == 0;\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+</script></td>
+<td class="unknown obsolete" data-browser="tr">?</td>
+<td class="unknown obsolete" data-browser="babel6corejs2">?</td>
+<td class="unknown obsolete" data-browser="babel7corejs2">?</td>
+<td class="unknown" data-browser="babel7corejs3">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20210808">?</td>
+<td class="unknown obsolete" data-browser="closure20210906">?</td>
+<td class="unknown obsolete" data-browser="closure20211006">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220719">?</td>
+<td class="unknown" data-browser="closure20230228">?</td>
+<td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
+<td class="unknown obsolete" data-browser="typescript3_9corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript4_9corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript5_2corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript5_3corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript5_4corejs3">?</td>
+<td class="unknown" data-browser="typescript5_5corejs3">?</td>
+<td class="unknown" data-browser="es7shim">?</td>
+<td class="no" data-browser="ie11">No</td>
+<td class="no flagged obsolete" data-browser="firefox102">Flag<a href="#fx-change-array-by-copy-note"><sup>[34]</sup></a></td>
+<td class="yes" data-browser="firefox115">Yes</td>
+<td class="yes obsolete" data-browser="firefox117">Yes</td>
+<td class="yes obsolete" data-browser="firefox118">Yes</td>
+<td class="yes obsolete" data-browser="firefox119">Yes</td>
+<td class="yes obsolete" data-browser="firefox120">Yes</td>
+<td class="yes obsolete" data-browser="firefox121">Yes</td>
+<td class="yes obsolete" data-browser="firefox122">Yes</td>
+<td class="yes obsolete" data-browser="firefox123">Yes</td>
+<td class="yes obsolete" data-browser="firefox124">Yes</td>
+<td class="yes obsolete" data-browser="firefox125">Yes</td>
+<td class="yes obsolete" data-browser="firefox126">Yes</td>
+<td class="yes obsolete" data-browser="firefox127">Yes</td>
+<td class="yes" data-browser="firefox128">Yes</td>
+<td class="yes" data-browser="firefox129">Yes</td>
+<td class="yes unstable" data-browser="firefox130">Yes</td>
+<td class="yes unstable" data-browser="firefox131">Yes</td>
+<td class="unknown obsolete" data-browser="opera12_10">?</td>
+<td class="yes obsolete" data-browser="chrome115">Yes</td>
+<td class="yes obsolete" data-browser="chrome116">Yes</td>
+<td class="yes obsolete" data-browser="chrome117">Yes</td>
+<td class="yes obsolete" data-browser="chrome118">Yes</td>
+<td class="yes obsolete" data-browser="chrome119">Yes</td>
+<td class="yes obsolete" data-browser="chrome120">Yes</td>
+<td class="yes obsolete" data-browser="chrome121">Yes</td>
+<td class="yes obsolete" data-browser="chrome122">Yes</td>
+<td class="yes obsolete" data-browser="chrome123">Yes</td>
+<td class="yes obsolete" data-browser="chrome124">Yes</td>
+<td class="yes obsolete" data-browser="chrome125">Yes</td>
+<td class="yes" data-browser="chrome126">Yes</td>
+<td class="yes unstable" data-browser="chrome127">Yes</td>
+<td class="no obsolete" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge115">Yes</td>
+<td class="yes obsolete" data-browser="edge116">Yes</td>
+<td class="yes obsolete" data-browser="edge117">Yes</td>
+<td class="yes obsolete" data-browser="edge118">Yes</td>
+<td class="yes obsolete" data-browser="edge119">Yes</td>
+<td class="yes obsolete" data-browser="edge120">Yes</td>
+<td class="yes obsolete" data-browser="edge121">Yes</td>
+<td class="yes obsolete" data-browser="edge122">Yes</td>
+<td class="yes obsolete" data-browser="edge123">Yes</td>
+<td class="yes obsolete" data-browser="edge124">Yes</td>
+<td class="yes obsolete" data-browser="edge125">Yes</td>
+<td class="yes" data-browser="edge126">Yes</td>
+<td class="yes unstable" data-browser="edge127">Yes</td>
+<td class="no obsolete" data-browser="safari15_6">No</td>
+<td class="yes obsolete" data-browser="safari16_6">Yes</td>
+<td class="yes obsolete" data-browser="safari17">Yes</td>
+<td class="yes obsolete" data-browser="safari17_1">Yes</td>
+<td class="yes obsolete" data-browser="safari17_2">Yes</td>
+<td class="yes obsolete" data-browser="safari17_3">Yes</td>
+<td class="yes obsolete" data-browser="safari17_4">Yes</td>
+<td class="yes" data-browser="safari17_5">Yes</td>
+<td class="yes unstable" data-browser="safaritp">Yes</td>
+<td class="yes unstable" data-browser="webkit">Yes</td>
+<td class="no obsolete" data-browser="opera88">No</td>
+<td class="no obsolete" data-browser="opera89">No</td>
+<td class="no obsolete" data-browser="opera90">No</td>
+<td class="no obsolete" data-browser="opera91">No</td>
+<td class="no obsolete" data-browser="opera92">No</td>
+<td class="no obsolete" data-browser="opera93">No</td>
+<td class="no obsolete" data-browser="opera94">No</td>
+<td class="no obsolete" data-browser="opera95">No</td>
+<td class="yes obsolete" data-browser="opera96">Yes</td>
+<td class="yes obsolete" data-browser="opera97">Yes</td>
+<td class="yes" data-browser="opera98">Yes</td>
+<td class="yes unstable" data-browser="opera99">Yes</td>
+<td class="unknown obsolete" data-browser="rhino1_7_13">?</td>
+<td class="unknown obsolete" data-browser="rhino1_7_14">?</td>
+<td class="unknown obsolete" data-browser="rhino1_7_15">?</td>
+<td class="unknown obsolete" data-browser="phantom2_1">?</td>
+<td class="unknown obsolete" data-browser="node0_4">?</td>
+<td class="unknown obsolete" data-browser="node0_6">?</td>
+<td class="unknown obsolete" data-browser="node0_8">?</td>
+<td class="unknown obsolete" data-browser="node0_10">?</td>
+<td class="unknown obsolete" data-browser="node0_12">?</td>
+<td class="unknown obsolete" data-browser="node14_6">?</td>
+<td class="unknown obsolete" data-browser="node16_0">?</td>
+<td class="unknown obsolete" data-browser="node16_9">?</td>
+<td class="no" data-browser="node16_11">No</td>
+<td class="no obsolete" data-browser="node17_0">No</td>
+<td class="no obsolete" data-browser="node17_2">No</td>
+<td class="no obsolete" data-browser="node18_0">No</td>
+<td class="no" data-browser="node18_3">No</td>
+<td class="no obsolete" data-browser="node19_0">No</td>
+<td class="no obsolete" data-browser="node19_2">No</td>
+<td class="yes" data-browser="node20_0">Yes</td>
+<td class="yes obsolete" data-browser="node21_0">Yes</td>
+<td class="yes" data-browser="node22_0">Yes</td>
+<td class="unknown obsolete" data-browser="duktape2_6">?</td>
+<td class="unknown" data-browser="duktape2_7">?</td>
+<td class="unknown obsolete" data-browser="jerryscript2_3_0">?</td>
+<td class="unknown" data-browser="jerryscript2_4_0">?</td>
+<td class="unknown obsolete" data-browser="graalvm19">?</td>
+<td class="unknown obsolete" data-browser="graalvm19_3_6">?</td>
+<td class="unknown obsolete" data-browser="graalvm20">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_1">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_3">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_3_1">?</td>
+<td class="unknown obsolete" data-browser="graalvm21">?</td>
+<td class="unknown" data-browser="graalvm21_3_3">?</td>
+<td class="unknown" data-browser="graalvm22_2">?</td>
+<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
+<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="yes obsolete" data-browser="deno1_33">Yes</td>
+<td class="yes obsolete" data-browser="deno1_34">Yes</td>
+<td class="yes obsolete" data-browser="deno1_35">Yes</td>
+<td class="yes" data-browser="deno1_36">Yes</td>
+<td class="unknown obsolete" data-browser="android4_4">?</td>
+<td class="unknown obsolete" data-browser="android4_4_3">?</td>
+<td class="unknown obsolete" data-browser="ios12_2">?</td>
+<td class="unknown obsolete" data-browser="ios13_4">?</td>
+<td class="unknown obsolete" data-browser="ios14_5">?</td>
+<td class="yes obsolete" data-browser="ios16">Yes</td>
+<td class="yes obsolete" data-browser="ios16_1">Yes</td>
+<td class="yes obsolete" data-browser="ios16_2">Yes</td>
+<td class="yes obsolete" data-browser="ios16_3">Yes</td>
+<td class="yes obsolete" data-browser="ios16_4">Yes</td>
+<td class="yes obsolete" data-browser="ios16_5">Yes</td>
+<td class="yes obsolete" data-browser="ios16_6">Yes</td>
+<td class="yes" data-browser="ios17">Yes</td>
+<td class="no obsolete" data-browser="samsung19">No</td>
+<td class="no obsolete" data-browser="samsung20">No</td>
+<td class="yes obsolete" data-browser="samsung21">Yes</td>
+<td class="yes" data-browser="samsung22">Yes</td>
+<td class="no obsolete" data-browser="opera_mobile72">No</td>
+<td class="no obsolete" data-browser="opera_mobile73">No</td>
 <td class="yes obsolete" data-browser="opera_mobile74">Yes</td>
 <td class="yes obsolete" data-browser="opera_mobile75">Yes</td>
 <td class="yes obsolete" data-browser="opera_mobile76">Yes</td>
@@ -38752,7 +39229,7 @@ return arr.with(1, &apos;B&apos;)[1] === &apos;B&apos; &amp;&amp; arr[1] === &ap
 <tr class="subtest" data-parent="RegExp_`v`_flag" id="test-RegExp_`v`_flag_set_notations"><td><span><a class="anchor" href="#test-RegExp_`v`_flag_set_notations">&#xA7;</a>set notations</span><script data-source="
 return /[\p{ASCII}&amp;&amp;\p{Decimal_Number}]/v.test(&quot;0&quot;)
 &amp;&amp; /[\p{Any}--[\x01-\u{10ffff}]]/v.test(&quot;\0&quot;)
-        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("239");try{return Function("asyncTestPassed","\nreturn /[\\p{ASCII}&&\\p{Decimal_Number}]/v.test(\"0\")\n&& /[\\p{Any}--[\\x01-\\u{10ffff}]]/v.test(\"\\0\")\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("239");return Function("asyncTestPassed","'use strict';"+"\nreturn /[\\p{ASCII}&&\\p{Decimal_Number}]/v.test(\"0\")\n&& /[\\p{Any}--[\\x01-\\u{10ffff}]]/v.test(\"\\0\")\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("242");try{return Function("asyncTestPassed","\nreturn /[\\p{ASCII}&&\\p{Decimal_Number}]/v.test(\"0\")\n&& /[\\p{Any}--[\\x01-\\u{10ffff}]]/v.test(\"\\0\")\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("242");return Function("asyncTestPassed","'use strict';"+"\nreturn /[\\p{ASCII}&&\\p{Decimal_Number}]/v.test(\"0\")\n&& /[\\p{Any}--[\\x01-\\u{10ffff}]]/v.test(\"\\0\")\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -38839,7 +39316,7 @@ return /[\p{ASCII}&amp;&amp;\p{Decimal_Number}]/v.test(&quot;0&quot;)
 <td class="unknown obsolete" data-browser="opera94">?</td>
 <td class="unknown obsolete" data-browser="opera95">?</td>
 <td class="no obsolete" data-browser="opera96">No</td>
-<td class="no flagged obsolete" data-browser="opera97">Flag<a href="#chrome-harmony-note"><sup>[34]</sup></a></td>
+<td class="no flagged obsolete" data-browser="opera97">Flag<a href="#chrome-harmony-note"><sup>[35]</sup></a></td>
 <td class="yes" data-browser="opera98">Yes</td>
 <td class="yes unstable" data-browser="opera99">Yes</td>
 <td class="unknown obsolete" data-browser="rhino1_7_13">?</td>
@@ -38899,7 +39376,7 @@ return /[\p{ASCII}&amp;&amp;\p{Decimal_Number}]/v.test(&quot;0&quot;)
 <td class="unknown obsolete" data-browser="samsung19">?</td>
 <td class="unknown obsolete" data-browser="samsung20">?</td>
 <td class="no obsolete" data-browser="samsung21">No</td>
-<td class="no flagged" data-browser="samsung22">Flag<a href="#chrome-harmony-note"><sup>[34]</sup></a></td>
+<td class="no flagged" data-browser="samsung22">Flag<a href="#chrome-harmony-note"><sup>[35]</sup></a></td>
 <td class="unknown obsolete" data-browser="opera_mobile72">?</td>
 <td class="unknown obsolete" data-browser="opera_mobile73">?</td>
 <td class="no obsolete" data-browser="opera_mobile74">No</td>
@@ -38911,7 +39388,7 @@ return /[\p{ASCII}&amp;&amp;\p{Decimal_Number}]/v.test(&quot;0&quot;)
 <tr class="subtest" data-parent="RegExp_`v`_flag" id="test-RegExp_`v`_flag_properties_of_Strings"><td><span><a class="anchor" href="#test-RegExp_`v`_flag_properties_of_Strings">&#xA7;</a>properties of Strings</span><script data-source="
 return /^\p{Emoji_Keycap_Sequence}$/v.test(&quot;*\uFE0F\u20E3&quot;)
 &amp;&amp; !/^\p{Emoji_Keycap_Sequence}$/v.test(&quot;*&quot;);
-        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("240");try{return Function("asyncTestPassed","\nreturn /^\\p{Emoji_Keycap_Sequence}$/v.test(\"*\\uFE0F\\u20E3\")\n&& !/^\\p{Emoji_Keycap_Sequence}$/v.test(\"*\");\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("240");return Function("asyncTestPassed","'use strict';"+"\nreturn /^\\p{Emoji_Keycap_Sequence}$/v.test(\"*\\uFE0F\\u20E3\")\n&& !/^\\p{Emoji_Keycap_Sequence}$/v.test(\"*\");\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("243");try{return Function("asyncTestPassed","\nreturn /^\\p{Emoji_Keycap_Sequence}$/v.test(\"*\\uFE0F\\u20E3\")\n&& !/^\\p{Emoji_Keycap_Sequence}$/v.test(\"*\");\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("243");return Function("asyncTestPassed","'use strict';"+"\nreturn /^\\p{Emoji_Keycap_Sequence}$/v.test(\"*\\uFE0F\\u20E3\")\n&& !/^\\p{Emoji_Keycap_Sequence}$/v.test(\"*\");\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -38998,7 +39475,7 @@ return /^\p{Emoji_Keycap_Sequence}$/v.test(&quot;*\uFE0F\u20E3&quot;)
 <td class="unknown obsolete" data-browser="opera94">?</td>
 <td class="unknown obsolete" data-browser="opera95">?</td>
 <td class="no obsolete" data-browser="opera96">No</td>
-<td class="no flagged obsolete" data-browser="opera97">Flag<a href="#chrome-harmony-note"><sup>[34]</sup></a></td>
+<td class="no flagged obsolete" data-browser="opera97">Flag<a href="#chrome-harmony-note"><sup>[35]</sup></a></td>
 <td class="yes" data-browser="opera98">Yes</td>
 <td class="yes unstable" data-browser="opera99">Yes</td>
 <td class="unknown obsolete" data-browser="rhino1_7_13">?</td>
@@ -39058,7 +39535,7 @@ return /^\p{Emoji_Keycap_Sequence}$/v.test(&quot;*\uFE0F\u20E3&quot;)
 <td class="unknown obsolete" data-browser="samsung19">?</td>
 <td class="unknown obsolete" data-browser="samsung20">?</td>
 <td class="no obsolete" data-browser="samsung21">No</td>
-<td class="no flagged" data-browser="samsung22">Flag<a href="#chrome-harmony-note"><sup>[34]</sup></a></td>
+<td class="no flagged" data-browser="samsung22">Flag<a href="#chrome-harmony-note"><sup>[35]</sup></a></td>
 <td class="unknown obsolete" data-browser="opera_mobile72">?</td>
 <td class="unknown obsolete" data-browser="opera_mobile73">?</td>
 <td class="no obsolete" data-browser="opera_mobile74">No</td>
@@ -39069,7 +39546,7 @@ return /^\p{Emoji_Keycap_Sequence}$/v.test(&quot;*\uFE0F\u20E3&quot;)
 </tr>
 <tr class="subtest" data-parent="RegExp_`v`_flag" id="test-RegExp_`v`_flag_constructor_supports_it"><td><span><a class="anchor" href="#test-RegExp_`v`_flag_constructor_supports_it">&#xA7;</a>constructor supports it</span><script data-source="
 return new RegExp(&apos;a&apos;, &apos;v&apos;) instanceof RegExp;
-        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("241");try{return Function("asyncTestPassed","\nreturn new RegExp('a', 'v') instanceof RegExp;\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("241");return Function("asyncTestPassed","'use strict';"+"\nreturn new RegExp('a', 'v') instanceof RegExp;\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("244");try{return Function("asyncTestPassed","\nreturn new RegExp('a', 'v') instanceof RegExp;\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("244");return Function("asyncTestPassed","'use strict';"+"\nreturn new RegExp('a', 'v') instanceof RegExp;\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -39156,7 +39633,7 @@ return new RegExp(&apos;a&apos;, &apos;v&apos;) instanceof RegExp;
 <td class="unknown obsolete" data-browser="opera94">?</td>
 <td class="unknown obsolete" data-browser="opera95">?</td>
 <td class="no obsolete" data-browser="opera96">No</td>
-<td class="no flagged obsolete" data-browser="opera97">Flag<a href="#chrome-harmony-note"><sup>[34]</sup></a></td>
+<td class="no flagged obsolete" data-browser="opera97">Flag<a href="#chrome-harmony-note"><sup>[35]</sup></a></td>
 <td class="yes" data-browser="opera98">Yes</td>
 <td class="yes unstable" data-browser="opera99">Yes</td>
 <td class="unknown obsolete" data-browser="rhino1_7_13">?</td>
@@ -39216,7 +39693,7 @@ return new RegExp(&apos;a&apos;, &apos;v&apos;) instanceof RegExp;
 <td class="unknown obsolete" data-browser="samsung19">?</td>
 <td class="unknown obsolete" data-browser="samsung20">?</td>
 <td class="no obsolete" data-browser="samsung21">No</td>
-<td class="no flagged" data-browser="samsung22">Flag<a href="#chrome-harmony-note"><sup>[34]</sup></a></td>
+<td class="no flagged" data-browser="samsung22">Flag<a href="#chrome-harmony-note"><sup>[35]</sup></a></td>
 <td class="unknown obsolete" data-browser="opera_mobile72">?</td>
 <td class="unknown obsolete" data-browser="opera_mobile73">?</td>
 <td class="no obsolete" data-browser="opera_mobile74">No</td>
@@ -39230,7 +39707,7 @@ var flags = [];
 var p = new Proxy({}, { get: function(o, k) { flags.push(k); return o[k]; }});
 Object.getOwnPropertyDescriptor(RegExp.prototype, &apos;flags&apos;).get.call(p);
 return flags.indexOf(&quot;unicodeSets&quot;) !== -1;
-        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("242");try{return Function("asyncTestPassed","\nvar flags = [];\nvar p = new Proxy({}, { get: function(o, k) { flags.push(k); return o[k]; }});\nObject.getOwnPropertyDescriptor(RegExp.prototype, 'flags').get.call(p);\nreturn flags.indexOf(\"unicodeSets\") !== -1;\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("242");return Function("asyncTestPassed","'use strict';"+"\nvar flags = [];\nvar p = new Proxy({}, { get: function(o, k) { flags.push(k); return o[k]; }});\nObject.getOwnPropertyDescriptor(RegExp.prototype, 'flags').get.call(p);\nreturn flags.indexOf(\"unicodeSets\") !== -1;\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("245");try{return Function("asyncTestPassed","\nvar flags = [];\nvar p = new Proxy({}, { get: function(o, k) { flags.push(k); return o[k]; }});\nObject.getOwnPropertyDescriptor(RegExp.prototype, 'flags').get.call(p);\nreturn flags.indexOf(\"unicodeSets\") !== -1;\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("245");return Function("asyncTestPassed","'use strict';"+"\nvar flags = [];\nvar p = new Proxy({}, { get: function(o, k) { flags.push(k); return o[k]; }});\nObject.getOwnPropertyDescriptor(RegExp.prototype, 'flags').get.call(p);\nreturn flags.indexOf(\"unicodeSets\") !== -1;\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -39317,7 +39794,7 @@ return flags.indexOf(&quot;unicodeSets&quot;) !== -1;
 <td class="unknown obsolete" data-browser="opera94">?</td>
 <td class="unknown obsolete" data-browser="opera95">?</td>
 <td class="no obsolete" data-browser="opera96">No</td>
-<td class="no flagged obsolete" data-browser="opera97">Flag<a href="#chrome-harmony-note"><sup>[34]</sup></a></td>
+<td class="no flagged obsolete" data-browser="opera97">Flag<a href="#chrome-harmony-note"><sup>[35]</sup></a></td>
 <td class="yes" data-browser="opera98">Yes</td>
 <td class="yes unstable" data-browser="opera99">Yes</td>
 <td class="unknown obsolete" data-browser="rhino1_7_13">?</td>
@@ -39377,7 +39854,7 @@ return flags.indexOf(&quot;unicodeSets&quot;) !== -1;
 <td class="unknown obsolete" data-browser="samsung19">?</td>
 <td class="unknown obsolete" data-browser="samsung20">?</td>
 <td class="no obsolete" data-browser="samsung21">No</td>
-<td class="no flagged" data-browser="samsung22">Flag<a href="#chrome-harmony-note"><sup>[34]</sup></a></td>
+<td class="no flagged" data-browser="samsung22">Flag<a href="#chrome-harmony-note"><sup>[35]</sup></a></td>
 <td class="unknown obsolete" data-browser="opera_mobile72">?</td>
 <td class="unknown obsolete" data-browser="opera_mobile73">?</td>
 <td class="no obsolete" data-browser="opera_mobile74">No</td>
@@ -39388,7 +39865,7 @@ return flags.indexOf(&quot;unicodeSets&quot;) !== -1;
 </tr>
 <tr class="subtest" data-parent="RegExp_`v`_flag" id="test-RegExp_`v`_flag_Unicode_15.1"><td><span><a class="anchor" href="#test-RegExp_`v`_flag_Unicode_15.1">&#xA7;</a>Unicode 15.1</span><script data-source="
 return /^\p{RGI_Emoji}$/v.test(&quot;&#x1F426;&#x200D;&#x1F525;&quot;);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("243");try{return Function("asyncTestPassed","\nreturn /^\\p{RGI_Emoji}$/v.test(\"🐦‍🔥\");\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("243");return Function("asyncTestPassed","'use strict';"+"\nreturn /^\\p{RGI_Emoji}$/v.test(\"🐦‍🔥\");\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("246");try{return Function("asyncTestPassed","\nreturn /^\\p{RGI_Emoji}$/v.test(\"🐦‍🔥\");\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("246");return Function("asyncTestPassed","'use strict';"+"\nreturn /^\\p{RGI_Emoji}$/v.test(\"🐦‍🔥\");\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -39704,7 +40181,7 @@ const buffer1 = new Uint8Array([1, 2]).buffer;
 const buffer2 = buffer1.transfer();
 return buffer1.byteLength === 0
   &amp;&amp; buffer2.byteLength === 2;
-        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("245");try{return Function("asyncTestPassed","\nconst buffer1 = new Uint8Array([1, 2]).buffer;\nconst buffer2 = buffer1.transfer();\nreturn buffer1.byteLength === 0\n  && buffer2.byteLength === 2;\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("245");return Function("asyncTestPassed","'use strict';"+"\nconst buffer1 = new Uint8Array([1, 2]).buffer;\nconst buffer2 = buffer1.transfer();\nreturn buffer1.byteLength === 0\n  && buffer2.byteLength === 2;\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("248");try{return Function("asyncTestPassed","\nconst buffer1 = new Uint8Array([1, 2]).buffer;\nconst buffer2 = buffer1.transfer();\nreturn buffer1.byteLength === 0\n  && buffer2.byteLength === 2;\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("248");return Function("asyncTestPassed","'use strict';"+"\nconst buffer1 = new Uint8Array([1, 2]).buffer;\nconst buffer2 = buffer1.transfer();\nreturn buffer1.byteLength === 0\n  && buffer2.byteLength === 2;\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -39729,11 +40206,11 @@ return buffer1.byteLength === 0
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="firefox102">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no flagged obsolete" data-browser="firefox117">Flag<a href="#firefox-arraybuffer-note"><sup>[35]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox118">Flag<a href="#firefox-arraybuffer-note"><sup>[35]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox119">Flag<a href="#firefox-arraybuffer-note"><sup>[35]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox120">Flag<a href="#firefox-arraybuffer-note"><sup>[35]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox121">Flag<a href="#firefox-arraybuffer-note"><sup>[35]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox117">Flag<a href="#firefox-arraybuffer-note"><sup>[36]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox118">Flag<a href="#firefox-arraybuffer-note"><sup>[36]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox119">Flag<a href="#firefox-arraybuffer-note"><sup>[36]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox120">Flag<a href="#firefox-arraybuffer-note"><sup>[36]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox121">Flag<a href="#firefox-arraybuffer-note"><sup>[36]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox122">Yes</td>
 <td class="yes obsolete" data-browser="firefox123">Yes</td>
 <td class="yes obsolete" data-browser="firefox124">Yes</td>
@@ -39865,7 +40342,7 @@ const buffer1 = new ArrayBuffer(1024);
 const buffer2 = buffer1.realloc(256);
 return buffer1.byteLength === 0
   &amp;&amp; buffer2.byteLength === 256;
-        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("246");try{return Function("asyncTestPassed","\nconst buffer1 = new ArrayBuffer(1024);\nconst buffer2 = buffer1.realloc(256);\nreturn buffer1.byteLength === 0\n  && buffer2.byteLength === 256;\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("246");return Function("asyncTestPassed","'use strict';"+"\nconst buffer1 = new ArrayBuffer(1024);\nconst buffer2 = buffer1.realloc(256);\nreturn buffer1.byteLength === 0\n  && buffer2.byteLength === 256;\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("249");try{return Function("asyncTestPassed","\nconst buffer1 = new ArrayBuffer(1024);\nconst buffer2 = buffer1.realloc(256);\nreturn buffer1.byteLength === 0\n  && buffer2.byteLength === 256;\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("249");return Function("asyncTestPassed","'use strict';"+"\nconst buffer1 = new ArrayBuffer(1024);\nconst buffer2 = buffer1.realloc(256);\nreturn buffer1.byteLength === 0\n  && buffer2.byteLength === 256;\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -40025,7 +40502,7 @@ return buffer1.byteLength === 0
 </tr>
 <tr significance="0.125"><td id="test-Duplicate_named_capturing_groups"><span><a class="anchor" href="#test-Duplicate_named_capturing_groups">&#xA7;</a><a href="https://github.com/tc39/proposal-duplicate-named-capturing-groups">Duplicate named capturing groups</a></span><script data-source="
 return /(?&lt;year&gt;[0-9]{4})-[0-9]{2}|[0-9]{2}-(?&lt;year&gt;[0-9]{4})/.test(&quot;12-1995&quot;);
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("247");try{return Function("asyncTestPassed","\nreturn /(?<year>[0-9]{4})-[0-9]{2}|[0-9]{2}-(?<year>[0-9]{4})/.test(\"12-1995\");\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("247");return Function("asyncTestPassed","'use strict';"+"\nreturn /(?<year>[0-9]{4})-[0-9]{2}|[0-9]{2}-(?<year>[0-9]{4})/.test(\"12-1995\");\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("250");try{return Function("asyncTestPassed","\nreturn /(?<year>[0-9]{4})-[0-9]{2}|[0-9]{2}-(?<year>[0-9]{4})/.test(\"12-1995\");\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("250");return Function("asyncTestPassed","'use strict';"+"\nreturn /(?<year>[0-9]{4})-[0-9]{2}|[0-9]{2}-(?<year>[0-9]{4})/.test(\"12-1995\");\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -40341,7 +40818,7 @@ var set = new Set([1, 2, 3]).intersection(new Set([2, 3, 4]));
 return set.size === 2
   &amp;&amp; set.has(2)
   &amp;&amp; set.has(3);
-        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("249");try{return Function("asyncTestPassed","\nvar set = new Set([1, 2, 3]).intersection(new Set([2, 3, 4]));\nreturn set.size === 2\n  && set.has(2)\n  && set.has(3);\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("249");return Function("asyncTestPassed","'use strict';"+"\nvar set = new Set([1, 2, 3]).intersection(new Set([2, 3, 4]));\nreturn set.size === 2\n  && set.has(2)\n  && set.has(3);\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("252");try{return Function("asyncTestPassed","\nvar set = new Set([1, 2, 3]).intersection(new Set([2, 3, 4]));\nreturn set.size === 2\n  && set.has(2)\n  && set.has(3);\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("252");return Function("asyncTestPassed","'use strict';"+"\nvar set = new Set([1, 2, 3]).intersection(new Set([2, 3, 4]));\nreturn set.size === 2\n  && set.has(2)\n  && set.has(3);\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -40367,15 +40844,15 @@ return set.size === 2
 <td class="no obsolete" data-browser="firefox102">No</td>
 <td class="no" data-browser="firefox115">No</td>
 <td class="no obsolete" data-browser="firefox117">No</td>
-<td class="no flagged obsolete" data-browser="firefox118">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox119">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox120">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox121">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox122">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox123">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox124">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox125">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox126">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox118">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox119">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox120">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox121">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox122">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox123">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox124">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox125">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox126">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox127">Yes</td>
 <td class="yes" data-browser="firefox128">Yes</td>
 <td class="yes" data-browser="firefox129">Yes</td>
@@ -40464,8 +40941,8 @@ return set.size === 2
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no obsolete" data-browser="graalvm20_3_1">No</td>
 <td class="no obsolete" data-browser="graalvm21">No</td>
-<td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[37]</sup></a></td>
-<td class="no flagged" data-browser="graalvm22_2">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[38]</sup></a></td>
+<td class="no flagged" data-browser="graalvm22_2">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[38]</sup></a></td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
 <td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_33">No</td>
@@ -40503,7 +40980,7 @@ return set.size === 3
   &amp;&amp; set.has(1)
   &amp;&amp; set.has(2)
   &amp;&amp; set.has(3);
-        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("250");try{return Function("asyncTestPassed","\nvar set = new Set([1, 2]).union(new Set([2, 3]));\nreturn set.size === 3\n  && set.has(1)\n  && set.has(2)\n  && set.has(3);\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("250");return Function("asyncTestPassed","'use strict';"+"\nvar set = new Set([1, 2]).union(new Set([2, 3]));\nreturn set.size === 3\n  && set.has(1)\n  && set.has(2)\n  && set.has(3);\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("253");try{return Function("asyncTestPassed","\nvar set = new Set([1, 2]).union(new Set([2, 3]));\nreturn set.size === 3\n  && set.has(1)\n  && set.has(2)\n  && set.has(3);\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("253");return Function("asyncTestPassed","'use strict';"+"\nvar set = new Set([1, 2]).union(new Set([2, 3]));\nreturn set.size === 3\n  && set.has(1)\n  && set.has(2)\n  && set.has(3);\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -40529,15 +41006,15 @@ return set.size === 3
 <td class="no obsolete" data-browser="firefox102">No</td>
 <td class="no" data-browser="firefox115">No</td>
 <td class="no obsolete" data-browser="firefox117">No</td>
-<td class="no flagged obsolete" data-browser="firefox118">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox119">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox120">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox121">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox122">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox123">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox124">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox125">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox126">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox118">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox119">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox120">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox121">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox122">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox123">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox124">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox125">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox126">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox127">Yes</td>
 <td class="yes" data-browser="firefox128">Yes</td>
 <td class="yes" data-browser="firefox129">Yes</td>
@@ -40626,8 +41103,8 @@ return set.size === 3
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no obsolete" data-browser="graalvm20_3_1">No</td>
 <td class="no obsolete" data-browser="graalvm21">No</td>
-<td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[37]</sup></a></td>
-<td class="no flagged" data-browser="graalvm22_2">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[38]</sup></a></td>
+<td class="no flagged" data-browser="graalvm22_2">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[38]</sup></a></td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
 <td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_33">No</td>
@@ -40664,7 +41141,7 @@ var set = new Set([1, 2, 3]).difference(new Set([3, 4]));
 return set.size === 2
   &amp;&amp; set.has(1)
   &amp;&amp; set.has(2);
-        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("251");try{return Function("asyncTestPassed","\nvar set = new Set([1, 2, 3]).difference(new Set([3, 4]));\nreturn set.size === 2\n  && set.has(1)\n  && set.has(2);\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("251");return Function("asyncTestPassed","'use strict';"+"\nvar set = new Set([1, 2, 3]).difference(new Set([3, 4]));\nreturn set.size === 2\n  && set.has(1)\n  && set.has(2);\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("254");try{return Function("asyncTestPassed","\nvar set = new Set([1, 2, 3]).difference(new Set([3, 4]));\nreturn set.size === 2\n  && set.has(1)\n  && set.has(2);\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("254");return Function("asyncTestPassed","'use strict';"+"\nvar set = new Set([1, 2, 3]).difference(new Set([3, 4]));\nreturn set.size === 2\n  && set.has(1)\n  && set.has(2);\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -40690,15 +41167,15 @@ return set.size === 2
 <td class="no obsolete" data-browser="firefox102">No</td>
 <td class="no" data-browser="firefox115">No</td>
 <td class="no obsolete" data-browser="firefox117">No</td>
-<td class="no flagged obsolete" data-browser="firefox118">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox119">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox120">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox121">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox122">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox123">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox124">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox125">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox126">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox118">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox119">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox120">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox121">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox122">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox123">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox124">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox125">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox126">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox127">Yes</td>
 <td class="yes" data-browser="firefox128">Yes</td>
 <td class="yes" data-browser="firefox129">Yes</td>
@@ -40787,8 +41264,8 @@ return set.size === 2
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no obsolete" data-browser="graalvm20_3_1">No</td>
 <td class="no obsolete" data-browser="graalvm21">No</td>
-<td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[37]</sup></a></td>
-<td class="no flagged" data-browser="graalvm22_2">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[38]</sup></a></td>
+<td class="no flagged" data-browser="graalvm22_2">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[38]</sup></a></td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
 <td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_33">No</td>
@@ -40825,7 +41302,7 @@ var set = new Set([1, 2]).symmetricDifference(new Set([2, 3]));
 return set.size === 2
   &amp;&amp; set.has(1)
   &amp;&amp; set.has(3);
-        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("252");try{return Function("asyncTestPassed","\nvar set = new Set([1, 2]).symmetricDifference(new Set([2, 3]));\nreturn set.size === 2\n  && set.has(1)\n  && set.has(3);\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("252");return Function("asyncTestPassed","'use strict';"+"\nvar set = new Set([1, 2]).symmetricDifference(new Set([2, 3]));\nreturn set.size === 2\n  && set.has(1)\n  && set.has(3);\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("255");try{return Function("asyncTestPassed","\nvar set = new Set([1, 2]).symmetricDifference(new Set([2, 3]));\nreturn set.size === 2\n  && set.has(1)\n  && set.has(3);\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("255");return Function("asyncTestPassed","'use strict';"+"\nvar set = new Set([1, 2]).symmetricDifference(new Set([2, 3]));\nreturn set.size === 2\n  && set.has(1)\n  && set.has(3);\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -40851,15 +41328,15 @@ return set.size === 2
 <td class="no obsolete" data-browser="firefox102">No</td>
 <td class="no" data-browser="firefox115">No</td>
 <td class="no obsolete" data-browser="firefox117">No</td>
-<td class="no flagged obsolete" data-browser="firefox118">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox119">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox120">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox121">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox122">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox123">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox124">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox125">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox126">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox118">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox119">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox120">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox121">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox122">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox123">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox124">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox125">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox126">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox127">Yes</td>
 <td class="yes" data-browser="firefox128">Yes</td>
 <td class="yes" data-browser="firefox129">Yes</td>
@@ -40948,8 +41425,8 @@ return set.size === 2
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no obsolete" data-browser="graalvm20_3_1">No</td>
 <td class="no obsolete" data-browser="graalvm21">No</td>
-<td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[37]</sup></a></td>
-<td class="no flagged" data-browser="graalvm22_2">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[38]</sup></a></td>
+<td class="no flagged" data-browser="graalvm22_2">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[38]</sup></a></td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
 <td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_33">No</td>
@@ -40983,7 +41460,7 @@ return set.size === 2
 </tr>
 <tr class="subtest" data-parent="Set_methods" id="test-Set_methods_Set.prototype.isDisjointFrom()"><td><span><a class="anchor" href="#test-Set_methods_Set.prototype.isDisjointFrom()">&#xA7;</a>Set.prototype.isDisjointFrom()</span><script data-source="
 return new Set([1, 2, 3]).isDisjointFrom(new Set([4, 5, 6]));
-        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("253");try{return Function("asyncTestPassed","\nreturn new Set([1, 2, 3]).isDisjointFrom(new Set([4, 5, 6]));\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("253");return Function("asyncTestPassed","'use strict';"+"\nreturn new Set([1, 2, 3]).isDisjointFrom(new Set([4, 5, 6]));\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("256");try{return Function("asyncTestPassed","\nreturn new Set([1, 2, 3]).isDisjointFrom(new Set([4, 5, 6]));\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("256");return Function("asyncTestPassed","'use strict';"+"\nreturn new Set([1, 2, 3]).isDisjointFrom(new Set([4, 5, 6]));\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -41009,15 +41486,15 @@ return new Set([1, 2, 3]).isDisjointFrom(new Set([4, 5, 6]));
 <td class="no obsolete" data-browser="firefox102">No</td>
 <td class="no" data-browser="firefox115">No</td>
 <td class="no obsolete" data-browser="firefox117">No</td>
-<td class="no flagged obsolete" data-browser="firefox118">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox119">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox120">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox121">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox122">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox123">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox124">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox125">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox126">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox118">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox119">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox120">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox121">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox122">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox123">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox124">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox125">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox126">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox127">Yes</td>
 <td class="yes" data-browser="firefox128">Yes</td>
 <td class="yes" data-browser="firefox129">Yes</td>
@@ -41106,8 +41583,8 @@ return new Set([1, 2, 3]).isDisjointFrom(new Set([4, 5, 6]));
 <td class="no flagged obsolete" data-browser="graalvm20_3">Flag<a href="#graalvm-js-ecmascript-version-2021-note"><sup>[24]</sup></a></td>
 <td class="no flagged obsolete" data-browser="graalvm20_3_1">Flag<a href="#graalvm-js-ecmascript-version-2021-note"><sup>[24]</sup></a></td>
 <td class="no flagged obsolete" data-browser="graalvm21">Flag<a href="#graalvm-js-ecmascript-version-2021-note"><sup>[24]</sup></a></td>
-<td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[37]</sup></a></td>
-<td class="no flagged" data-browser="graalvm22_2">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[38]</sup></a></td>
+<td class="no flagged" data-browser="graalvm22_2">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[38]</sup></a></td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
 <td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_33">No</td>
@@ -41141,7 +41618,7 @@ return new Set([1, 2, 3]).isDisjointFrom(new Set([4, 5, 6]));
 </tr>
 <tr class="subtest" data-parent="Set_methods" id="test-Set_methods_Set.prototype.isSubsetOf()"><td><span><a class="anchor" href="#test-Set_methods_Set.prototype.isSubsetOf()">&#xA7;</a>Set.prototype.isSubsetOf()</span><script data-source="
 return new Set([1, 2, 3]).isSubsetOf(new Set([5, 4, 3, 2, 1]));
-        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("254");try{return Function("asyncTestPassed","\nreturn new Set([1, 2, 3]).isSubsetOf(new Set([5, 4, 3, 2, 1]));\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("254");return Function("asyncTestPassed","'use strict';"+"\nreturn new Set([1, 2, 3]).isSubsetOf(new Set([5, 4, 3, 2, 1]));\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("257");try{return Function("asyncTestPassed","\nreturn new Set([1, 2, 3]).isSubsetOf(new Set([5, 4, 3, 2, 1]));\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("257");return Function("asyncTestPassed","'use strict';"+"\nreturn new Set([1, 2, 3]).isSubsetOf(new Set([5, 4, 3, 2, 1]));\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -41167,15 +41644,15 @@ return new Set([1, 2, 3]).isSubsetOf(new Set([5, 4, 3, 2, 1]));
 <td class="no obsolete" data-browser="firefox102">No</td>
 <td class="no" data-browser="firefox115">No</td>
 <td class="no obsolete" data-browser="firefox117">No</td>
-<td class="no flagged obsolete" data-browser="firefox118">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox119">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox120">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox121">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox122">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox123">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox124">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox125">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox126">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox118">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox119">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox120">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox121">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox122">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox123">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox124">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox125">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox126">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox127">Yes</td>
 <td class="yes" data-browser="firefox128">Yes</td>
 <td class="yes" data-browser="firefox129">Yes</td>
@@ -41264,8 +41741,8 @@ return new Set([1, 2, 3]).isSubsetOf(new Set([5, 4, 3, 2, 1]));
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no obsolete" data-browser="graalvm20_3_1">No</td>
 <td class="no obsolete" data-browser="graalvm21">No</td>
-<td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[37]</sup></a></td>
-<td class="no flagged" data-browser="graalvm22_2">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[38]</sup></a></td>
+<td class="no flagged" data-browser="graalvm22_2">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[38]</sup></a></td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
 <td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_33">No</td>
@@ -41299,7 +41776,7 @@ return new Set([1, 2, 3]).isSubsetOf(new Set([5, 4, 3, 2, 1]));
 </tr>
 <tr class="subtest" data-parent="Set_methods" id="test-Set_methods_Set.prototype.isSupersetOf()"><td><span><a class="anchor" href="#test-Set_methods_Set.prototype.isSupersetOf()">&#xA7;</a>Set.prototype.isSupersetOf()</span><script data-source="
 return new Set([5, 4, 3, 2, 1]).isSupersetOf(new Set([1, 2, 3]));
-        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("255");try{return Function("asyncTestPassed","\nreturn new Set([5, 4, 3, 2, 1]).isSupersetOf(new Set([1, 2, 3]));\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("255");return Function("asyncTestPassed","'use strict';"+"\nreturn new Set([5, 4, 3, 2, 1]).isSupersetOf(new Set([1, 2, 3]));\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("258");try{return Function("asyncTestPassed","\nreturn new Set([5, 4, 3, 2, 1]).isSupersetOf(new Set([1, 2, 3]));\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("258");return Function("asyncTestPassed","'use strict';"+"\nreturn new Set([5, 4, 3, 2, 1]).isSupersetOf(new Set([1, 2, 3]));\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -41325,15 +41802,15 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf(new Set([1, 2, 3]));
 <td class="no obsolete" data-browser="firefox102">No</td>
 <td class="no" data-browser="firefox115">No</td>
 <td class="no obsolete" data-browser="firefox117">No</td>
-<td class="no flagged obsolete" data-browser="firefox118">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox119">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox120">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox121">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox122">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox123">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox124">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox125">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox126">Flag<a href="#ff-new-set-methods-note"><sup>[36]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox118">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox119">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox120">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox121">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox122">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox123">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox124">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox125">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox126">Flag<a href="#ff-new-set-methods-note"><sup>[37]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox127">Yes</td>
 <td class="yes" data-browser="firefox128">Yes</td>
 <td class="yes" data-browser="firefox129">Yes</td>
@@ -41422,8 +41899,8 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf(new Set([1, 2, 3]));
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no obsolete" data-browser="graalvm20_3_1">No</td>
 <td class="no obsolete" data-browser="graalvm21">No</td>
-<td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[37]</sup></a></td>
-<td class="no flagged" data-browser="graalvm22_2">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[37]</sup></a></td>
+<td class="no flagged" data-browser="graalvm21_3_3">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[38]</sup></a></td>
+<td class="no flagged" data-browser="graalvm22_2">Flag<a href="#graalvm-experimental-options-js-new-set-methods-note"><sup>[38]</sup></a></td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
 <td class="no" data-browser="hermes0_12_0">No</td>
 <td class="no obsolete" data-browser="deno1_33">No</td>
@@ -41459,7 +41936,7 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf(new Set([1, 2, 3]));
     </table>
     <div id="footnotes">
       <!-- FOOTNOTES -->
-    <p id="harmony-flag-old-note">  <sup>[1]</sup> Flagged features have to be enabled via <code>--harmony</code> flag</p><p id="harmony-flag-note">  <sup>[2]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="graalvm-node-mode-note">  <sup>[3]</sup> Executed in Node.js/JVM mode via <code>graalvm/bin/node --jvm</code>.</p><p id="graalvm-js-intl-mode-note">  <sup>[4]</sup> Executed using <code>js --js.intl-402</code>.</p><p id="babel-core-js-note">  <sup>[5]</sup> This feature is supported when using Babel with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="typescript-core-js-note">  <sup>[6]</sup> This feature is supported when using TypeScript with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="new-gen-fn-note">  <sup>[7]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#67-new--generatorfunction">TC39 meeting notes from July 28, 2015.</a></p><p id="gen-throw-note">  <sup>[8]</sup> <a href="https://github.com/tc39/ecma262/issues/293">&apos;Semantics of yield* in throw case&apos; GitHub issue in ECMA-262 repo.</a></p><p id="typescript-downlevel-iteration-note">  <sup>[9]</sup> Requires the <code>downlevelIteration</code> compile option.</p><p id="strict-fn-non-strict-params-note">  <sup>[10]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-29.md#611-the-scope-of-use-strict-with-respect-to-destructuring-in-parameter-lists">TC39 meeting notes from July 29, 2015.</a></p><p id="nested-rest-destruct-decl-note">  <sup>[11]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#66-bindingrestelement-should-allow-a-bindingpattern-ala-assignmentrestelement">TC39 meeting notes from July 28, 2015.</a></p><p id="nested-rest-destruct-params-note">  <sup>[12]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#66-bindingrestelement-should-allow-a-bindingpattern-ala-assignmentrestelement">TC39 meeting notes from July 28, 2015.</a></p><p id="proxy-enumerate-removed-note">  <sup>[13]</sup> <a href="https://github.com/tc39/ecma262/pull/367">&apos;Normative: Remove [[Enumerate]] and associated reflective capabilities&apos; GitHub Pull Request in ECMA-262 repo.</a></p><p id="babel-regenerator-note">  <sup>[14]</sup> This feature requires native generators or <code>regenerator-runtime</code>, it&apos;s a part of <code>babel-polyfill</code> or <code>babel-runtime</code>.</p><p id="fx-shared-memory-cors-isolation-note">  <sup>[15]</sup> The feature is available with <a href="https://hacks.mozilla.org/2020/07/safely-reviving-shared-memory/">properly set CORS isolation headers</a> or via enabling <code>dom.postMessage.sharedArrayBuffer.bypassCOOP_COEP.insecure.enabled</code> setting under <code>about:config</code></p><p id="edg-shared-memory-spectre-note">  <sup>[16]</sup> The feature was temporarily disabled to mitigate the Meltdown and Spectre CPU bugs.</p><p id="sf-shared-memory-spectre-note">  <sup>[17]</sup> The feature was <a href="https://webkit.org/blog/8048/what-spectre-and-meltdown-mean-for-webkit/">temporarily disabled</a> to mitigate the Meltdown and Spectre CPU bugs.</p><p id="chrome-experimental-note">  <sup>[18]</sup> The feature has to be enabled via &quot;Experimental Javascript features&quot; setting under <code>about:flags</code></p><p id="closure-object-assign-note">  <sup>[19]</sup> Requires native support for <code>Object.assign</code></p><p id="typescript-es6-note">  <sup>[20]</sup> TypeScript&apos;s compiler will accept code using this feature if the <code>--target ES6</code> flag is set, but passes it through unmodified and does not supply a runtime polyfill.</p><p id="flatten-compat-issue-note">  <sup>[21]</sup> Name of <code>Array.prototype.flatten()</code> changed to <code>Array.prototype.flat()</code> due to <a href="https://github.com/tc39/proposal-flatMap/pull/56">web compatibility issues.</a></p><p id="graalvm-js-ecmascript-version-2020-note">  <sup>[22]</sup> Requires the <code>--js.ecmascript-version=2020</code> flag.</p><p id="chrome-string-prototype-replace-all-note">  <sup>[23]</sup> The feature is considered unstable, but can be enabled via <code>--js-flags=&quot;--harmony-string-replaceall&quot;</code> flag</p><p id="graalvm-js-ecmascript-version-2021-note">  <sup>[24]</sup> Requires the <code>--js.ecmascript-version=2021</code> flag.</p><p id="chrome-promise-any-note">  <sup>[25]</sup> Available behind the <a href="https://bugs.chromium.org/p/v8/issues/detail?id=9808"><code>--js-flags=&quot;--harmony-promise-any&quot;</code></a> flag in V8.</p><p id="chrome-weakrefs-note">  <sup>[26]</sup> Available behind the <a href="https://bugs.chromium.org/p/v8/issues/detail?id=8179"><code>--js-flags=&quot;--harmony-weak-refs --expose-gc&quot;</code></a> flag in V8.</p><p id="chrome-logical-assignment-note">  <sup>[27]</sup> Available behind the <a href="https://github.com/v8/v8/commit/b151d8db22be308738192497a68c2c7c0d8d4070"><code>--js-flags=&quot;--logical-assignment&quot;</code></a> flag in V8.</p><p id="graalvm-js-ecmascript-version-staging-note">  <sup>[28]</sup> Requires the <code>--js.ecmascript-version=staging</code> flag.</p><p id="closure-at-method-note">  <sup>[29]</sup> Requires native support for <code>Math.trunc</code></p><p id="graalvm-js-ecmascript-version-2022-note">  <sup>[30]</sup> Requires the <code>--js.ecmascript-version=2022</code> flag.</p><p id="safari-at-method-note">  <sup>[31]</sup> The feature has to be enabled via <code>jscOptions=--useAtMethod=true</code> flag.</p><p id="closure-typed-array-note">  <sup>[32]</sup> Requires native support for typed arrays</p><p id="ch-static-init-blocks-note">  <sup>[33]</sup> The feature has to be enabled via <code>harmony_class_static_blocks</code> flag.</p><p id="chrome-harmony-note">  <sup>[34]</sup> The feature has to be enabled via <code>--js-flags=&quot;--harmony&quot;</code> flag</p><p id="firefox-arraybuffer-note">  <sup>[35]</sup> The feature has to be enabled via <code>javascript.options.experimental.arraybuffer_transfer</code> setting under <code>about:config</code>.</p><p id="ff-new-set-methods-note">  <sup>[36]</sup> The feature has to be enabled via <code>javascript.options.experimental.new_set_methods</code> setting under <code>about:config</code>.</p><p id="graalvm-experimental-options-js-new-set-methods-note">  <sup>[37]</sup> Requires the <code>--experimental-options --js.new-set-methods</code> flags.</p></div>
+    <p id="harmony-flag-old-note">  <sup>[1]</sup> Flagged features have to be enabled via <code>--harmony</code> flag</p><p id="harmony-flag-note">  <sup>[2]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="graalvm-node-mode-note">  <sup>[3]</sup> Executed in Node.js/JVM mode via <code>graalvm/bin/node --jvm</code>.</p><p id="graalvm-js-intl-mode-note">  <sup>[4]</sup> Executed using <code>js --js.intl-402</code>.</p><p id="babel-core-js-note">  <sup>[5]</sup> This feature is supported when using Babel with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="typescript-core-js-note">  <sup>[6]</sup> This feature is supported when using TypeScript with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="new-gen-fn-note">  <sup>[7]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#67-new--generatorfunction">TC39 meeting notes from July 28, 2015.</a></p><p id="gen-throw-note">  <sup>[8]</sup> <a href="https://github.com/tc39/ecma262/issues/293">&apos;Semantics of yield* in throw case&apos; GitHub issue in ECMA-262 repo.</a></p><p id="typescript-downlevel-iteration-note">  <sup>[9]</sup> Requires the <code>downlevelIteration</code> compile option.</p><p id="strict-fn-non-strict-params-note">  <sup>[10]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-29.md#611-the-scope-of-use-strict-with-respect-to-destructuring-in-parameter-lists">TC39 meeting notes from July 29, 2015.</a></p><p id="nested-rest-destruct-decl-note">  <sup>[11]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#66-bindingrestelement-should-allow-a-bindingpattern-ala-assignmentrestelement">TC39 meeting notes from July 28, 2015.</a></p><p id="nested-rest-destruct-params-note">  <sup>[12]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#66-bindingrestelement-should-allow-a-bindingpattern-ala-assignmentrestelement">TC39 meeting notes from July 28, 2015.</a></p><p id="proxy-enumerate-removed-note">  <sup>[13]</sup> <a href="https://github.com/tc39/ecma262/pull/367">&apos;Normative: Remove [[Enumerate]] and associated reflective capabilities&apos; GitHub Pull Request in ECMA-262 repo.</a></p><p id="babel-regenerator-note">  <sup>[14]</sup> This feature requires native generators or <code>regenerator-runtime</code>, it&apos;s a part of <code>babel-polyfill</code> or <code>babel-runtime</code>.</p><p id="fx-shared-memory-cors-isolation-note">  <sup>[15]</sup> The feature is available with <a href="https://hacks.mozilla.org/2020/07/safely-reviving-shared-memory/">properly set CORS isolation headers</a> or via enabling <code>dom.postMessage.sharedArrayBuffer.bypassCOOP_COEP.insecure.enabled</code> setting under <code>about:config</code></p><p id="edg-shared-memory-spectre-note">  <sup>[16]</sup> The feature was temporarily disabled to mitigate the Meltdown and Spectre CPU bugs.</p><p id="sf-shared-memory-spectre-note">  <sup>[17]</sup> The feature was <a href="https://webkit.org/blog/8048/what-spectre-and-meltdown-mean-for-webkit/">temporarily disabled</a> to mitigate the Meltdown and Spectre CPU bugs.</p><p id="chrome-experimental-note">  <sup>[18]</sup> The feature has to be enabled via &quot;Experimental Javascript features&quot; setting under <code>about:flags</code></p><p id="closure-object-assign-note">  <sup>[19]</sup> Requires native support for <code>Object.assign</code></p><p id="typescript-es6-note">  <sup>[20]</sup> TypeScript&apos;s compiler will accept code using this feature if the <code>--target ES6</code> flag is set, but passes it through unmodified and does not supply a runtime polyfill.</p><p id="flatten-compat-issue-note">  <sup>[21]</sup> Name of <code>Array.prototype.flatten()</code> changed to <code>Array.prototype.flat()</code> due to <a href="https://github.com/tc39/proposal-flatMap/pull/56">web compatibility issues.</a></p><p id="graalvm-js-ecmascript-version-2020-note">  <sup>[22]</sup> Requires the <code>--js.ecmascript-version=2020</code> flag.</p><p id="chrome-string-prototype-replace-all-note">  <sup>[23]</sup> The feature is considered unstable, but can be enabled via <code>--js-flags=&quot;--harmony-string-replaceall&quot;</code> flag</p><p id="graalvm-js-ecmascript-version-2021-note">  <sup>[24]</sup> Requires the <code>--js.ecmascript-version=2021</code> flag.</p><p id="chrome-promise-any-note">  <sup>[25]</sup> Available behind the <a href="https://bugs.chromium.org/p/v8/issues/detail?id=9808"><code>--js-flags=&quot;--harmony-promise-any&quot;</code></a> flag in V8.</p><p id="chrome-weakrefs-note">  <sup>[26]</sup> Available behind the <a href="https://bugs.chromium.org/p/v8/issues/detail?id=8179"><code>--js-flags=&quot;--harmony-weak-refs --expose-gc&quot;</code></a> flag in V8.</p><p id="chrome-logical-assignment-note">  <sup>[27]</sup> Available behind the <a href="https://github.com/v8/v8/commit/b151d8db22be308738192497a68c2c7c0d8d4070"><code>--js-flags=&quot;--logical-assignment&quot;</code></a> flag in V8.</p><p id="graalvm-js-ecmascript-version-staging-note">  <sup>[28]</sup> Requires the <code>--js.ecmascript-version=staging</code> flag.</p><p id="closure-at-method-note">  <sup>[29]</sup> Requires native support for <code>Math.trunc</code></p><p id="graalvm-js-ecmascript-version-2022-note">  <sup>[30]</sup> Requires the <code>--js.ecmascript-version=2022</code> flag.</p><p id="safari-at-method-note">  <sup>[31]</sup> The feature has to be enabled via <code>jscOptions=--useAtMethod=true</code> flag.</p><p id="closure-typed-array-note">  <sup>[32]</sup> Requires native support for typed arrays</p><p id="ch-static-init-blocks-note">  <sup>[33]</sup> The feature has to be enabled via <code>harmony_class_static_blocks</code> flag.</p><p id="fx-change-array-by-copy-note">  <sup>[34]</sup> The feature has to be enabled via --enable-change-array-by-copy flag</p><p id="chrome-harmony-note">  <sup>[35]</sup> The feature has to be enabled via <code>--js-flags=&quot;--harmony&quot;</code> flag</p><p id="firefox-arraybuffer-note">  <sup>[36]</sup> The feature has to be enabled via <code>javascript.options.experimental.arraybuffer_transfer</code> setting under <code>about:config</code>.</p><p id="ff-new-set-methods-note">  <sup>[37]</sup> The feature has to be enabled via <code>javascript.options.experimental.new_set_methods</code> setting under <code>about:config</code>.</p><p id="graalvm-experimental-options-js-new-set-methods-note">  <sup>[38]</sup> Requires the <code>--experimental-options --js.new-set-methods</code> flags.</p></div>
   </div>
   <pre class="info-tooltip" style="display:none"></pre>
 </body>


### PR DESCRIPTION
- Adding missing `TypedArray` tests;
- Adding missing MDN liks;
- Adding missing Firefox results;
- Removing results that were inferred and not actually tested, according to the original merge discussion #1907;
