### PR TITLE
Fix the ArrayBuffer.prototype.transfer() tests

### DIFF
--- a/data-es2016plus.js
+++ b/data-es2016plus.js
@@ -7329,8 +7329,9 @@ exports.tests = [
           },
           firefox122: true,
           chrome70: false,
-          chrome126: true,
+          chrome114: true,
           safari12: false,
+          safari17_4: true,
           duktape2_0: false,
           graalvm21_3_3: false,
           hermes0_7_0: false,
@@ -7339,26 +7340,46 @@ exports.tests = [
         }
       },
       {
-        name: 'ArrayBuffer.prototype.realloc()',
+        name: 'ArrayBuffer.prototype.transferToFixedLength()',
+        mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/transferToFixedLength',
         exec: function () {/*
-          const buffer1 = new ArrayBuffer(1024);
-          const buffer2 = buffer1.realloc(256);
+          const buffer1 = new Uint8Array([1, 2]).buffer;
+          const buffer2 = buffer1.transferToFixedLength();
           return buffer1.byteLength === 0
-            && buffer2.byteLength === 256;
+            && buffer2.byteLength === 2;
         */},
         res: {
           ie11: false,
-          firefox10: false,
-          firefox52: false,
-          chrome70: false,
-          safari12: false,
-          duktape2_0: false,
-          graalvm21_3_3: false,
-          hermes0_7_0: false,
-          reactnative0_70_3: false,
-          rhino1_7_13: false
+          firefox115: false,
+          firefox117: {
+            val: 'flagged',
+            note_id: 'firefox-arraybuffer',
+          },
+          firefox122: true,
+          chrome114: true,
+          safari17_4: true,
         }
-      }
+      },
+      {
+        name: 'ArrayBuffer.prototype.detached',
+        mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/detached',
+        exec: function () {/*
+          const buffer1 = new Uint8Array([1, 2]).buffer;
+          const buffer2 = buffer1.transfer();
+          return buffer1.detached && !buffer2.detached;
+        */},
+        res: {
+          ie11: false,
+          firefox115: false,
+          firefox117: {
+            val: 'flagged',
+            note_id: 'firefox-arraybuffer',
+          },
+          firefox122: true,
+          chrome114: true,
+          safari17_4: true,
+        }
+      },
     ]
   },
   {

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -40838,161 +40838,161 @@ return /^\p{RGI_Emoji}$/v.test(&quot;&#x1F1E8;&#x1F1F6;&quot;);
 <td class="unknown" data-browser="reactnative0_70_3">?</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-ArrayBuffer.prototype.transfer"><span><a class="anchor" href="#test-ArrayBuffer.prototype.transfer">&#xA7;</a><a href="https://github.com/tc39/proposal-arraybuffer-transfer">ArrayBuffer.prototype.transfer</a></span></td>
-<td class="tally obsolete" data-browser="tr" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/2</td>
-<td class="tally" data-browser="babel7corejs3" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20210808" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20210906" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20211006" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20211107" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20220502" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20220719" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20230228" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="typescript3_9corejs3" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="typescript4_9corejs3" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="typescript5_3corejs3" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="typescript5_4corejs3" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="typescript5_5corejs3" data-tally="0">0/2</td>
-<td class="tally" data-browser="typescript5_6corejs3" data-tally="0">0/2</td>
-<td class="tally" data-browser="es7shim" data-tally="0">0/2</td>
-<td class="tally" data-browser="ie11" data-tally="0">0/2</td>
-<td class="tally" data-browser="firefox115" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="firefox118" data-tally="0" data-flagged-tally="0.5">0/2</td>
-<td class="tally obsolete" data-browser="firefox119" data-tally="0" data-flagged-tally="0.5">0/2</td>
-<td class="tally obsolete" data-browser="firefox120" data-tally="0" data-flagged-tally="0.5">0/2</td>
-<td class="tally obsolete" data-browser="firefox121" data-tally="0" data-flagged-tally="0.5">0/2</td>
-<td class="tally obsolete" data-browser="firefox122" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="firefox123" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="firefox124" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="firefox125" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="firefox126" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="firefox127" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally" data-browser="firefox128" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="firefox129" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="firefox130" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally" data-browser="firefox131" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally unstable" data-browser="firefox132" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally unstable" data-browser="firefox133" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="chrome119" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="chrome120" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="chrome121" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="chrome122" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="chrome123" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="chrome124" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="chrome125" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="chrome126" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="chrome127" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="chrome128" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally" data-browser="chrome129" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally unstable" data-browser="chrome130" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally unstable" data-browser="chrome131" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="edge18" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="edge118" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="edge119" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="edge120" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="edge121" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="edge122" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="edge123" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="edge124" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="edge125" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="edge126" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="edge127" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="edge128" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally" data-browser="edge129" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally unstable" data-browser="edge130" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="safari15_6" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="safari16_6" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="safari17" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="safari17_1" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="safari17_2" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="safari17_3" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="safari17_4" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="safari17_5" data-tally="0">0/2</td>
-<td class="tally" data-browser="safari17_6" data-tally="0">0/2</td>
-<td class="tally" data-browser="safari18" data-tally="0">0/2</td>
-<td class="tally unstable" data-browser="safaritp" data-tally="0">0/2</td>
-<td class="tally unstable" data-browser="webkit" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="opera102" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="opera103" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="opera104" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="opera105" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="opera106" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="opera107" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="opera108" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="opera109" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="opera110" data-tally="0">0/2</td>
-<td class="tally" data-browser="opera111" data-tally="0">0/2</td>
-<td class="tally unstable" data-browser="opera112" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="rhino1_7_15" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="node0_4" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="node0_6" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="node0_8" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="node0_10" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="node0_12" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="node14_6" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="node16_0" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="node16_9" data-tally="0">0/2</td>
-<td class="tally" data-browser="node16_11" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="node17_0" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="node17_2" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="node18_0" data-tally="0">0/2</td>
-<td class="tally" data-browser="node18_3" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="node19_0" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="node19_2" data-tally="0">0/2</td>
-<td class="tally" data-browser="node20_0" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="node21_0" data-tally="0">0/2</td>
-<td class="tally" data-browser="node22_0" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="duktape2_6" data-tally="0">0/2</td>
-<td class="tally" data-browser="duktape2_7" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="jerryscript2_3_0" data-tally="0">0/2</td>
-<td class="tally" data-browser="jerryscript2_4_0" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="graalvm19" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="graalvm19_3_6" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="graalvm20" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="graalvm20_1" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="graalvm20_3" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="graalvm20_3_1" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="graalvm21" data-tally="0">0/2</td>
-<td class="tally" data-browser="graalvm21_3_3" data-tally="0">0/2</td>
-<td class="tally" data-browser="graalvm22_2" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="hermes0_7_0" data-tally="0">0/2</td>
-<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="deno1_33" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="deno1_34" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="deno1_35" data-tally="0">0/2</td>
-<td class="tally" data-browser="deno1_36" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="android4_4" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ios12_2" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ios13_4" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ios14_5" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ios16_6" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ios17" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ios17_1" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ios17_2" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ios17_3" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ios17_4" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ios17_5" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="ios17_6" data-tally="0">0/2</td>
-<td class="tally" data-browser="ios18" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="samsung19" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="samsung20" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="samsung21" data-tally="0">0/2</td>
-<td class="tally" data-browser="samsung22" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="opera_mobile72" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="opera_mobile73" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="opera_mobile74" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="opera_mobile75" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="opera_mobile76" data-tally="0">0/2</td>
-<td class="tally" data-browser="opera_mobile77" data-tally="0">0/2</td>
-<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="tr" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/3</td>
+<td class="tally" data-browser="babel7corejs3" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="closure20210808" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="closure20210906" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="closure20211006" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="closure20211107" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="closure20220502" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="closure20220719" data-tally="0">0/3</td>
+<td class="tally" data-browser="closure20230228" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="typescript3_9corejs3" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="typescript4_9corejs3" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="typescript5_3corejs3" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="typescript5_4corejs3" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="typescript5_5corejs3" data-tally="0">0/3</td>
+<td class="tally" data-browser="typescript5_6corejs3" data-tally="0">0/3</td>
+<td class="tally" data-browser="es7shim" data-tally="0">0/3</td>
+<td class="tally" data-browser="ie11" data-tally="0">0/3</td>
+<td class="tally" data-browser="firefox115" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="firefox118" data-tally="0" data-flagged-tally="1">0/3</td>
+<td class="tally obsolete" data-browser="firefox119" data-tally="0" data-flagged-tally="1">0/3</td>
+<td class="tally obsolete" data-browser="firefox120" data-tally="0" data-flagged-tally="1">0/3</td>
+<td class="tally obsolete" data-browser="firefox121" data-tally="0" data-flagged-tally="1">0/3</td>
+<td class="tally obsolete" data-browser="firefox122" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="firefox123" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="firefox124" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="firefox125" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="firefox126" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="firefox127" data-tally="1">3/3</td>
+<td class="tally" data-browser="firefox128" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="firefox129" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="firefox130" data-tally="1">3/3</td>
+<td class="tally" data-browser="firefox131" data-tally="1">3/3</td>
+<td class="tally unstable" data-browser="firefox132" data-tally="1">3/3</td>
+<td class="tally unstable" data-browser="firefox133" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="chrome119" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="chrome120" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="chrome121" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="chrome122" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="chrome123" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="chrome124" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="chrome125" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="chrome126" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="chrome127" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="chrome128" data-tally="1">3/3</td>
+<td class="tally" data-browser="chrome129" data-tally="1">3/3</td>
+<td class="tally unstable" data-browser="chrome130" data-tally="1">3/3</td>
+<td class="tally unstable" data-browser="chrome131" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="edge18" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="edge118" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="edge119" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="edge120" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="edge121" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="edge122" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="edge123" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="edge124" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="edge125" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="edge126" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="edge127" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="edge128" data-tally="1">3/3</td>
+<td class="tally" data-browser="edge129" data-tally="1">3/3</td>
+<td class="tally unstable" data-browser="edge130" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="safari15_6" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="safari16_6" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="safari17" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="safari17_1" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="safari17_2" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="safari17_3" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="safari17_4" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="safari17_5" data-tally="1">3/3</td>
+<td class="tally" data-browser="safari17_6" data-tally="1">3/3</td>
+<td class="tally" data-browser="safari18" data-tally="1">3/3</td>
+<td class="tally unstable" data-browser="safaritp" data-tally="1">3/3</td>
+<td class="tally unstable" data-browser="webkit" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera102" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera103" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera104" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera105" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera106" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera107" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera108" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera109" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="opera110" data-tally="1">3/3</td>
+<td class="tally" data-browser="opera111" data-tally="1">3/3</td>
+<td class="tally unstable" data-browser="opera112" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="rhino1_7_15" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="node0_4" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="node0_6" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="node0_8" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="node0_10" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="node0_12" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="node14_6" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="node16_0" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="node16_9" data-tally="0">0/3</td>
+<td class="tally" data-browser="node16_11" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="node17_0" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="node17_2" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="node18_0" data-tally="0">0/3</td>
+<td class="tally" data-browser="node18_3" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="node19_0" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="node19_2" data-tally="0">0/3</td>
+<td class="tally" data-browser="node20_0" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="node21_0" data-tally="1">3/3</td>
+<td class="tally" data-browser="node22_0" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="duktape2_6" data-tally="0">0/3</td>
+<td class="tally" data-browser="duktape2_7" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="jerryscript2_3_0" data-tally="0">0/3</td>
+<td class="tally" data-browser="jerryscript2_4_0" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="graalvm19" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="graalvm19_3_6" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="graalvm20" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="graalvm20_1" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="graalvm20_3" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="graalvm20_3_1" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="graalvm21" data-tally="0">0/3</td>
+<td class="tally" data-browser="graalvm21_3_3" data-tally="0">0/3</td>
+<td class="tally" data-browser="graalvm22_2" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="hermes0_7_0" data-tally="0">0/3</td>
+<td class="tally" data-browser="hermes0_12_0" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="deno1_33" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="deno1_34" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="deno1_35" data-tally="1">3/3</td>
+<td class="tally" data-browser="deno1_36" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="android4_4" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="ios12_2" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="ios13_4" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="ios14_5" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="ios16_6" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="ios17" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="ios17_1" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="ios17_2" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="ios17_3" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="ios17_4" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="ios17_5" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="ios17_6" data-tally="1">3/3</td>
+<td class="tally" data-browser="ios18" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="samsung19" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="samsung20" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="samsung21" data-tally="0">0/3</td>
+<td class="tally" data-browser="samsung22" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="opera_mobile72" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="opera_mobile73" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="opera_mobile74" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="opera_mobile75" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="opera_mobile76" data-tally="1">3/3</td>
+<td class="tally" data-browser="opera_mobile77" data-tally="1">3/3</td>
+<td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/3</td>
 </tr>
 <tr class="subtest" data-parent="ArrayBuffer.prototype.transfer" id="test-ArrayBuffer.prototype.transfer_ArrayBuffer.prototype.transfer()_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/transfer_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-ArrayBuffer.prototype.transfer_ArrayBuffer.prototype.transfer()_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/transfer_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>ArrayBuffer.prototype.transfer() <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/transfer" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 const buffer1 = new Uint8Array([1, 2]).buffer;
@@ -41040,13 +41040,13 @@ return buffer1.byteLength === 0
 <td class="yes unstable" data-browser="firefox132">Yes</td>
 <td class="yes unstable" data-browser="firefox133">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome119">No</td>
-<td class="no obsolete" data-browser="chrome120">No</td>
-<td class="no obsolete" data-browser="chrome121">No</td>
-<td class="no obsolete" data-browser="chrome122">No</td>
-<td class="no obsolete" data-browser="chrome123">No</td>
-<td class="no obsolete" data-browser="chrome124">No</td>
-<td class="no obsolete" data-browser="chrome125">No</td>
+<td class="yes obsolete" data-browser="chrome119">Yes</td>
+<td class="yes obsolete" data-browser="chrome120">Yes</td>
+<td class="yes obsolete" data-browser="chrome121">Yes</td>
+<td class="yes obsolete" data-browser="chrome122">Yes</td>
+<td class="yes obsolete" data-browser="chrome123">Yes</td>
+<td class="yes obsolete" data-browser="chrome124">Yes</td>
+<td class="yes obsolete" data-browser="chrome125">Yes</td>
 <td class="yes obsolete" data-browser="chrome126">Yes</td>
 <td class="yes obsolete" data-browser="chrome127">Yes</td>
 <td class="yes obsolete" data-browser="chrome128">Yes</td>
@@ -41054,14 +41054,14 @@ return buffer1.byteLength === 0
 <td class="yes unstable" data-browser="chrome130">Yes</td>
 <td class="yes unstable" data-browser="chrome131">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
-<td class="no obsolete" data-browser="edge118">No</td>
-<td class="no obsolete" data-browser="edge119">No</td>
-<td class="no obsolete" data-browser="edge120">No</td>
-<td class="no obsolete" data-browser="edge121">No</td>
-<td class="no obsolete" data-browser="edge122">No</td>
-<td class="no obsolete" data-browser="edge123">No</td>
-<td class="no obsolete" data-browser="edge124">No</td>
-<td class="no obsolete" data-browser="edge125">No</td>
+<td class="yes obsolete" data-browser="edge118">Yes</td>
+<td class="yes obsolete" data-browser="edge119">Yes</td>
+<td class="yes obsolete" data-browser="edge120">Yes</td>
+<td class="yes obsolete" data-browser="edge121">Yes</td>
+<td class="yes obsolete" data-browser="edge122">Yes</td>
+<td class="yes obsolete" data-browser="edge123">Yes</td>
+<td class="yes obsolete" data-browser="edge124">Yes</td>
+<td class="yes obsolete" data-browser="edge125">Yes</td>
 <td class="yes obsolete" data-browser="edge126">Yes</td>
 <td class="yes obsolete" data-browser="edge127">Yes</td>
 <td class="yes obsolete" data-browser="edge128">Yes</td>
@@ -41073,22 +41073,22 @@ return buffer1.byteLength === 0
 <td class="no obsolete" data-browser="safari17_1">No</td>
 <td class="no obsolete" data-browser="safari17_2">No</td>
 <td class="no obsolete" data-browser="safari17_3">No</td>
-<td class="no obsolete" data-browser="safari17_4">No</td>
-<td class="no obsolete" data-browser="safari17_5">No</td>
-<td class="no" data-browser="safari17_6">No</td>
-<td class="no" data-browser="safari18">No</td>
-<td class="no unstable" data-browser="safaritp">No</td>
-<td class="no unstable" data-browser="webkit">No</td>
-<td class="no obsolete" data-browser="opera102">No</td>
-<td class="no obsolete" data-browser="opera103">No</td>
-<td class="no obsolete" data-browser="opera104">No</td>
-<td class="no obsolete" data-browser="opera105">No</td>
-<td class="no obsolete" data-browser="opera106">No</td>
-<td class="no obsolete" data-browser="opera107">No</td>
-<td class="no obsolete" data-browser="opera108">No</td>
-<td class="no obsolete" data-browser="opera109">No</td>
-<td class="no obsolete" data-browser="opera110">No</td>
-<td class="no" data-browser="opera111">No</td>
+<td class="yes obsolete" data-browser="safari17_4">Yes</td>
+<td class="yes obsolete" data-browser="safari17_5">Yes</td>
+<td class="yes" data-browser="safari17_6">Yes</td>
+<td class="yes" data-browser="safari18">Yes</td>
+<td class="yes unstable" data-browser="safaritp">Yes</td>
+<td class="yes unstable" data-browser="webkit">Yes</td>
+<td class="yes obsolete" data-browser="opera102">Yes</td>
+<td class="yes obsolete" data-browser="opera103">Yes</td>
+<td class="yes obsolete" data-browser="opera104">Yes</td>
+<td class="yes obsolete" data-browser="opera105">Yes</td>
+<td class="yes obsolete" data-browser="opera106">Yes</td>
+<td class="yes obsolete" data-browser="opera107">Yes</td>
+<td class="yes obsolete" data-browser="opera108">Yes</td>
+<td class="yes obsolete" data-browser="opera109">Yes</td>
+<td class="yes obsolete" data-browser="opera110">Yes</td>
+<td class="yes" data-browser="opera111">Yes</td>
 <td class="yes unstable" data-browser="opera112">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
@@ -41110,8 +41110,8 @@ return buffer1.byteLength === 0
 <td class="no obsolete" data-browser="node19_0">No</td>
 <td class="no obsolete" data-browser="node19_2">No</td>
 <td class="no" data-browser="node20_0">No</td>
-<td class="no obsolete" data-browser="node21_0">No</td>
-<td class="no" data-browser="node22_0">No</td>
+<td class="yes obsolete" data-browser="node21_0">Yes</td>
+<td class="yes" data-browser="node22_0">Yes</td>
 <td class="no obsolete" data-browser="duktape2_6">No</td>
 <td class="no" data-browser="duktape2_7">No</td>
 <td class="unknown obsolete" data-browser="jerryscript2_3_0">?</td>
@@ -41127,10 +41127,10 @@ return buffer1.byteLength === 0
 <td class="no" data-browser="graalvm22_2">No</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
 <td class="no" data-browser="hermes0_12_0">No</td>
-<td class="no obsolete" data-browser="deno1_33">No</td>
-<td class="no obsolete" data-browser="deno1_34">No</td>
-<td class="no obsolete" data-browser="deno1_35">No</td>
-<td class="no" data-browser="deno1_36">No</td>
+<td class="yes obsolete" data-browser="deno1_33">Yes</td>
+<td class="yes obsolete" data-browser="deno1_34">Yes</td>
+<td class="yes obsolete" data-browser="deno1_35">Yes</td>
+<td class="yes" data-browser="deno1_36">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="no obsolete" data-browser="ios12_2">No</td>
@@ -41141,10 +41141,10 @@ return buffer1.byteLength === 0
 <td class="no obsolete" data-browser="ios17_1">No</td>
 <td class="no obsolete" data-browser="ios17_2">No</td>
 <td class="no obsolete" data-browser="ios17_3">No</td>
-<td class="no obsolete" data-browser="ios17_4">No</td>
-<td class="no obsolete" data-browser="ios17_5">No</td>
-<td class="no obsolete" data-browser="ios17_6">No</td>
-<td class="no" data-browser="ios18">No</td>
+<td class="yes obsolete" data-browser="ios17_4">Yes</td>
+<td class="yes obsolete" data-browser="ios17_5">Yes</td>
+<td class="yes obsolete" data-browser="ios17_6">Yes</td>
+<td class="yes" data-browser="ios18">Yes</td>
 <td class="no obsolete" data-browser="samsung19">No</td>
 <td class="no obsolete" data-browser="samsung20">No</td>
 <td class="no obsolete" data-browser="samsung21">No</td>
@@ -41153,16 +41153,16 @@ return buffer1.byteLength === 0
 <td class="no obsolete" data-browser="opera_mobile73">No</td>
 <td class="no obsolete" data-browser="opera_mobile74">No</td>
 <td class="no obsolete" data-browser="opera_mobile75">No</td>
-<td class="no obsolete" data-browser="opera_mobile76">No</td>
-<td class="no" data-browser="opera_mobile77">No</td>
+<td class="yes obsolete" data-browser="opera_mobile76">Yes</td>
+<td class="yes" data-browser="opera_mobile77">Yes</td>
 <td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
-<tr class="subtest" data-parent="ArrayBuffer.prototype.transfer" id="test-ArrayBuffer.prototype.transfer_ArrayBuffer.prototype.realloc()"><td><span><a class="anchor" href="#test-ArrayBuffer.prototype.transfer_ArrayBuffer.prototype.realloc()">&#xA7;</a>ArrayBuffer.prototype.realloc()</span><script data-source="
-const buffer1 = new ArrayBuffer(1024);
-const buffer2 = buffer1.realloc(256);
+<tr class="subtest" data-parent="ArrayBuffer.prototype.transfer" id="test-ArrayBuffer.prototype.transfer_ArrayBuffer.prototype.transferToFixedLength()_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/transferToFixedLength_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-ArrayBuffer.prototype.transfer_ArrayBuffer.prototype.transferToFixedLength()_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/transferToFixedLength_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>ArrayBuffer.prototype.transferToFixedLength() <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/transferToFixedLength" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
+const buffer1 = new Uint8Array([1, 2]).buffer;
+const buffer2 = buffer1.transferToFixedLength();
 return buffer1.byteLength === 0
-  &amp;&amp; buffer2.byteLength === 256;
-        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("251");try{return Function("asyncTestPassed","\nconst buffer1 = new ArrayBuffer(1024);\nconst buffer2 = buffer1.realloc(256);\nreturn buffer1.byteLength === 0\n  && buffer2.byteLength === 256;\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("251");return Function("asyncTestPassed","'use strict';"+"\nconst buffer1 = new ArrayBuffer(1024);\nconst buffer2 = buffer1.realloc(256);\nreturn buffer1.byteLength === 0\n  && buffer2.byteLength === 256;\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  &amp;&amp; buffer2.byteLength === 2;
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("251");try{return Function("asyncTestPassed","\nconst buffer1 = new Uint8Array([1, 2]).buffer;\nconst buffer2 = buffer1.transferToFixedLength();\nreturn buffer1.byteLength === 0\n  && buffer2.byteLength === 2;\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("251");return Function("asyncTestPassed","'use strict';"+"\nconst buffer1 = new Uint8Array([1, 2]).buffer;\nconst buffer2 = buffer1.transferToFixedLength();\nreturn buffer1.byteLength === 0\n  && buffer2.byteLength === 2;\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -41186,97 +41186,97 @@ return buffer1.byteLength === 0
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no" data-browser="firefox115">No</td>
-<td class="no obsolete" data-browser="firefox118">No</td>
-<td class="no obsolete" data-browser="firefox119">No</td>
-<td class="no obsolete" data-browser="firefox120">No</td>
-<td class="no obsolete" data-browser="firefox121">No</td>
-<td class="no obsolete" data-browser="firefox122">No</td>
-<td class="no obsolete" data-browser="firefox123">No</td>
-<td class="no obsolete" data-browser="firefox124">No</td>
-<td class="no obsolete" data-browser="firefox125">No</td>
-<td class="no obsolete" data-browser="firefox126">No</td>
-<td class="no obsolete" data-browser="firefox127">No</td>
-<td class="no" data-browser="firefox128">No</td>
-<td class="no obsolete" data-browser="firefox129">No</td>
-<td class="no obsolete" data-browser="firefox130">No</td>
-<td class="no" data-browser="firefox131">No</td>
-<td class="no unstable" data-browser="firefox132">No</td>
-<td class="no unstable" data-browser="firefox133">No</td>
+<td class="no flagged obsolete" data-browser="firefox118">Flag<a href="#firefox-arraybuffer-note"><sup>[35]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox119">Flag<a href="#firefox-arraybuffer-note"><sup>[35]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox120">Flag<a href="#firefox-arraybuffer-note"><sup>[35]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox121">Flag<a href="#firefox-arraybuffer-note"><sup>[35]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox122">Yes</td>
+<td class="yes obsolete" data-browser="firefox123">Yes</td>
+<td class="yes obsolete" data-browser="firefox124">Yes</td>
+<td class="yes obsolete" data-browser="firefox125">Yes</td>
+<td class="yes obsolete" data-browser="firefox126">Yes</td>
+<td class="yes obsolete" data-browser="firefox127">Yes</td>
+<td class="yes" data-browser="firefox128">Yes</td>
+<td class="yes obsolete" data-browser="firefox129">Yes</td>
+<td class="yes obsolete" data-browser="firefox130">Yes</td>
+<td class="yes" data-browser="firefox131">Yes</td>
+<td class="yes unstable" data-browser="firefox132">Yes</td>
+<td class="yes unstable" data-browser="firefox133">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome119">No</td>
-<td class="no obsolete" data-browser="chrome120">No</td>
-<td class="no obsolete" data-browser="chrome121">No</td>
-<td class="no obsolete" data-browser="chrome122">No</td>
-<td class="no obsolete" data-browser="chrome123">No</td>
-<td class="no obsolete" data-browser="chrome124">No</td>
-<td class="no obsolete" data-browser="chrome125">No</td>
-<td class="no obsolete" data-browser="chrome126">No</td>
-<td class="no obsolete" data-browser="chrome127">No</td>
-<td class="no obsolete" data-browser="chrome128">No</td>
-<td class="no" data-browser="chrome129">No</td>
-<td class="no unstable" data-browser="chrome130">No</td>
-<td class="no unstable" data-browser="chrome131">No</td>
+<td class="yes obsolete" data-browser="chrome119">Yes</td>
+<td class="yes obsolete" data-browser="chrome120">Yes</td>
+<td class="yes obsolete" data-browser="chrome121">Yes</td>
+<td class="yes obsolete" data-browser="chrome122">Yes</td>
+<td class="yes obsolete" data-browser="chrome123">Yes</td>
+<td class="yes obsolete" data-browser="chrome124">Yes</td>
+<td class="yes obsolete" data-browser="chrome125">Yes</td>
+<td class="yes obsolete" data-browser="chrome126">Yes</td>
+<td class="yes obsolete" data-browser="chrome127">Yes</td>
+<td class="yes obsolete" data-browser="chrome128">Yes</td>
+<td class="yes" data-browser="chrome129">Yes</td>
+<td class="yes unstable" data-browser="chrome130">Yes</td>
+<td class="yes unstable" data-browser="chrome131">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
-<td class="no obsolete" data-browser="edge118">No</td>
-<td class="no obsolete" data-browser="edge119">No</td>
-<td class="no obsolete" data-browser="edge120">No</td>
-<td class="no obsolete" data-browser="edge121">No</td>
-<td class="no obsolete" data-browser="edge122">No</td>
-<td class="no obsolete" data-browser="edge123">No</td>
-<td class="no obsolete" data-browser="edge124">No</td>
-<td class="no obsolete" data-browser="edge125">No</td>
-<td class="no obsolete" data-browser="edge126">No</td>
-<td class="no obsolete" data-browser="edge127">No</td>
-<td class="no obsolete" data-browser="edge128">No</td>
-<td class="no" data-browser="edge129">No</td>
-<td class="no unstable" data-browser="edge130">No</td>
-<td class="no obsolete" data-browser="safari15_6">No</td>
-<td class="no obsolete" data-browser="safari16_6">No</td>
-<td class="no obsolete" data-browser="safari17">No</td>
-<td class="no obsolete" data-browser="safari17_1">No</td>
-<td class="no obsolete" data-browser="safari17_2">No</td>
-<td class="no obsolete" data-browser="safari17_3">No</td>
-<td class="no obsolete" data-browser="safari17_4">No</td>
-<td class="no obsolete" data-browser="safari17_5">No</td>
-<td class="no" data-browser="safari17_6">No</td>
-<td class="no" data-browser="safari18">No</td>
-<td class="no unstable" data-browser="safaritp">No</td>
-<td class="no unstable" data-browser="webkit">No</td>
-<td class="no obsolete" data-browser="opera102">No</td>
-<td class="no obsolete" data-browser="opera103">No</td>
-<td class="no obsolete" data-browser="opera104">No</td>
-<td class="no obsolete" data-browser="opera105">No</td>
-<td class="no obsolete" data-browser="opera106">No</td>
-<td class="no obsolete" data-browser="opera107">No</td>
-<td class="no obsolete" data-browser="opera108">No</td>
-<td class="no obsolete" data-browser="opera109">No</td>
-<td class="no obsolete" data-browser="opera110">No</td>
-<td class="no" data-browser="opera111">No</td>
-<td class="no unstable" data-browser="opera112">No</td>
-<td class="no obsolete" data-browser="rhino1_7_13">No</td>
-<td class="no obsolete" data-browser="rhino1_7_14">No</td>
-<td class="no obsolete" data-browser="rhino1_7_15">No</td>
+<td class="yes obsolete" data-browser="edge118">Yes</td>
+<td class="yes obsolete" data-browser="edge119">Yes</td>
+<td class="yes obsolete" data-browser="edge120">Yes</td>
+<td class="yes obsolete" data-browser="edge121">Yes</td>
+<td class="yes obsolete" data-browser="edge122">Yes</td>
+<td class="yes obsolete" data-browser="edge123">Yes</td>
+<td class="yes obsolete" data-browser="edge124">Yes</td>
+<td class="yes obsolete" data-browser="edge125">Yes</td>
+<td class="yes obsolete" data-browser="edge126">Yes</td>
+<td class="yes obsolete" data-browser="edge127">Yes</td>
+<td class="yes obsolete" data-browser="edge128">Yes</td>
+<td class="yes" data-browser="edge129">Yes</td>
+<td class="yes unstable" data-browser="edge130">Yes</td>
+<td class="unknown obsolete" data-browser="safari15_6">?</td>
+<td class="unknown obsolete" data-browser="safari16_6">?</td>
+<td class="unknown obsolete" data-browser="safari17">?</td>
+<td class="unknown obsolete" data-browser="safari17_1">?</td>
+<td class="unknown obsolete" data-browser="safari17_2">?</td>
+<td class="unknown obsolete" data-browser="safari17_3">?</td>
+<td class="yes obsolete" data-browser="safari17_4">Yes</td>
+<td class="yes obsolete" data-browser="safari17_5">Yes</td>
+<td class="yes" data-browser="safari17_6">Yes</td>
+<td class="yes" data-browser="safari18">Yes</td>
+<td class="yes unstable" data-browser="safaritp">Yes</td>
+<td class="yes unstable" data-browser="webkit">Yes</td>
+<td class="yes obsolete" data-browser="opera102">Yes</td>
+<td class="yes obsolete" data-browser="opera103">Yes</td>
+<td class="yes obsolete" data-browser="opera104">Yes</td>
+<td class="yes obsolete" data-browser="opera105">Yes</td>
+<td class="yes obsolete" data-browser="opera106">Yes</td>
+<td class="yes obsolete" data-browser="opera107">Yes</td>
+<td class="yes obsolete" data-browser="opera108">Yes</td>
+<td class="yes obsolete" data-browser="opera109">Yes</td>
+<td class="yes obsolete" data-browser="opera110">Yes</td>
+<td class="yes" data-browser="opera111">Yes</td>
+<td class="yes unstable" data-browser="opera112">Yes</td>
+<td class="unknown obsolete" data-browser="rhino1_7_13">?</td>
+<td class="unknown obsolete" data-browser="rhino1_7_14">?</td>
+<td class="unknown obsolete" data-browser="rhino1_7_15">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_4">?</td>
 <td class="unknown obsolete" data-browser="node0_6">?</td>
 <td class="unknown obsolete" data-browser="node0_8">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node14_6">No</td>
-<td class="no obsolete" data-browser="node16_0">No</td>
-<td class="no obsolete" data-browser="node16_9">No</td>
-<td class="no" data-browser="node16_11">No</td>
-<td class="no obsolete" data-browser="node17_0">No</td>
-<td class="no obsolete" data-browser="node17_2">No</td>
-<td class="no obsolete" data-browser="node18_0">No</td>
-<td class="no" data-browser="node18_3">No</td>
-<td class="no obsolete" data-browser="node19_0">No</td>
-<td class="no obsolete" data-browser="node19_2">No</td>
-<td class="no" data-browser="node20_0">No</td>
-<td class="no obsolete" data-browser="node21_0">No</td>
-<td class="no" data-browser="node22_0">No</td>
-<td class="no obsolete" data-browser="duktape2_6">No</td>
-<td class="no" data-browser="duktape2_7">No</td>
+<td class="unknown obsolete" data-browser="node14_6">?</td>
+<td class="unknown obsolete" data-browser="node16_0">?</td>
+<td class="unknown obsolete" data-browser="node16_9">?</td>
+<td class="unknown" data-browser="node16_11">?</td>
+<td class="unknown obsolete" data-browser="node17_0">?</td>
+<td class="unknown obsolete" data-browser="node17_2">?</td>
+<td class="unknown obsolete" data-browser="node18_0">?</td>
+<td class="unknown" data-browser="node18_3">?</td>
+<td class="unknown obsolete" data-browser="node19_0">?</td>
+<td class="unknown obsolete" data-browser="node19_2">?</td>
+<td class="unknown" data-browser="node20_0">?</td>
+<td class="yes obsolete" data-browser="node21_0">Yes</td>
+<td class="yes" data-browser="node22_0">Yes</td>
+<td class="unknown obsolete" data-browser="duktape2_6">?</td>
+<td class="unknown" data-browser="duktape2_7">?</td>
 <td class="unknown obsolete" data-browser="jerryscript2_3_0">?</td>
 <td class="unknown" data-browser="jerryscript2_4_0">?</td>
 <td class="unknown obsolete" data-browser="graalvm19">?</td>
@@ -41286,45 +41286,207 @@ return buffer1.byteLength === 0
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown obsolete" data-browser="graalvm20_3_1">?</td>
 <td class="unknown obsolete" data-browser="graalvm21">?</td>
-<td class="no" data-browser="graalvm21_3_3">No</td>
-<td class="no" data-browser="graalvm22_2">No</td>
-<td class="no obsolete" data-browser="hermes0_7_0">No</td>
-<td class="no" data-browser="hermes0_12_0">No</td>
-<td class="no obsolete" data-browser="deno1_33">No</td>
-<td class="no obsolete" data-browser="deno1_34">No</td>
-<td class="no obsolete" data-browser="deno1_35">No</td>
-<td class="no" data-browser="deno1_36">No</td>
+<td class="unknown" data-browser="graalvm21_3_3">?</td>
+<td class="unknown" data-browser="graalvm22_2">?</td>
+<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
+<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="yes obsolete" data-browser="deno1_33">Yes</td>
+<td class="yes obsolete" data-browser="deno1_34">Yes</td>
+<td class="yes obsolete" data-browser="deno1_35">Yes</td>
+<td class="yes" data-browser="deno1_36">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
-<td class="no obsolete" data-browser="ios12_2">No</td>
-<td class="no obsolete" data-browser="ios13_4">No</td>
-<td class="no obsolete" data-browser="ios14_5">No</td>
-<td class="no obsolete" data-browser="ios16_6">No</td>
-<td class="no obsolete" data-browser="ios17">No</td>
-<td class="no obsolete" data-browser="ios17_1">No</td>
-<td class="no obsolete" data-browser="ios17_2">No</td>
-<td class="no obsolete" data-browser="ios17_3">No</td>
-<td class="no obsolete" data-browser="ios17_4">No</td>
-<td class="no obsolete" data-browser="ios17_5">No</td>
-<td class="no obsolete" data-browser="ios17_6">No</td>
-<td class="no" data-browser="ios18">No</td>
-<td class="no obsolete" data-browser="samsung19">No</td>
-<td class="no obsolete" data-browser="samsung20">No</td>
-<td class="no obsolete" data-browser="samsung21">No</td>
-<td class="no" data-browser="samsung22">No</td>
-<td class="no obsolete" data-browser="opera_mobile72">No</td>
-<td class="no obsolete" data-browser="opera_mobile73">No</td>
-<td class="no obsolete" data-browser="opera_mobile74">No</td>
-<td class="no obsolete" data-browser="opera_mobile75">No</td>
-<td class="no obsolete" data-browser="opera_mobile76">No</td>
-<td class="no" data-browser="opera_mobile77">No</td>
-<td class="no" data-browser="reactnative0_70_3">No</td>
+<td class="unknown obsolete" data-browser="ios12_2">?</td>
+<td class="unknown obsolete" data-browser="ios13_4">?</td>
+<td class="unknown obsolete" data-browser="ios14_5">?</td>
+<td class="unknown obsolete" data-browser="ios16_6">?</td>
+<td class="unknown obsolete" data-browser="ios17">?</td>
+<td class="unknown obsolete" data-browser="ios17_1">?</td>
+<td class="unknown obsolete" data-browser="ios17_2">?</td>
+<td class="unknown obsolete" data-browser="ios17_3">?</td>
+<td class="yes obsolete" data-browser="ios17_4">Yes</td>
+<td class="yes obsolete" data-browser="ios17_5">Yes</td>
+<td class="yes obsolete" data-browser="ios17_6">Yes</td>
+<td class="yes" data-browser="ios18">Yes</td>
+<td class="unknown obsolete" data-browser="samsung19">?</td>
+<td class="unknown obsolete" data-browser="samsung20">?</td>
+<td class="unknown obsolete" data-browser="samsung21">?</td>
+<td class="unknown" data-browser="samsung22">?</td>
+<td class="unknown obsolete" data-browser="opera_mobile72">?</td>
+<td class="unknown obsolete" data-browser="opera_mobile73">?</td>
+<td class="unknown obsolete" data-browser="opera_mobile74">?</td>
+<td class="unknown obsolete" data-browser="opera_mobile75">?</td>
+<td class="yes obsolete" data-browser="opera_mobile76">Yes</td>
+<td class="yes" data-browser="opera_mobile77">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
+</tr>
+<tr class="subtest" data-parent="ArrayBuffer.prototype.transfer" id="test-ArrayBuffer.prototype.transfer_ArrayBuffer.prototype.detached_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/detached_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-ArrayBuffer.prototype.transfer_ArrayBuffer.prototype.detached_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/detached_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>ArrayBuffer.prototype.detached <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/detached" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
+const buffer1 = new Uint8Array([1, 2]).buffer;
+const buffer2 = buffer1.transfer();
+return buffer1.detached &amp;&amp; !buffer2.detached;
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("252");try{return Function("asyncTestPassed","\nconst buffer1 = new Uint8Array([1, 2]).buffer;\nconst buffer2 = buffer1.transfer();\nreturn buffer1.detached && !buffer2.detached;\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("252");return Function("asyncTestPassed","'use strict';"+"\nconst buffer1 = new Uint8Array([1, 2]).buffer;\nconst buffer2 = buffer1.transfer();\nreturn buffer1.detached && !buffer2.detached;\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+</script></td>
+<td class="unknown obsolete" data-browser="tr">?</td>
+<td class="unknown obsolete" data-browser="babel6corejs2">?</td>
+<td class="unknown obsolete" data-browser="babel7corejs2">?</td>
+<td class="unknown" data-browser="babel7corejs3">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20210808">?</td>
+<td class="unknown obsolete" data-browser="closure20210906">?</td>
+<td class="unknown obsolete" data-browser="closure20211006">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20220502">?</td>
+<td class="unknown obsolete" data-browser="closure20220719">?</td>
+<td class="unknown" data-browser="closure20230228">?</td>
+<td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
+<td class="unknown obsolete" data-browser="typescript3_9corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript4_9corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript5_3corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript5_4corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript5_5corejs3">?</td>
+<td class="unknown" data-browser="typescript5_6corejs3">?</td>
+<td class="unknown" data-browser="es7shim">?</td>
+<td class="no" data-browser="ie11">No</td>
+<td class="no" data-browser="firefox115">No</td>
+<td class="no flagged obsolete" data-browser="firefox118">Flag<a href="#firefox-arraybuffer-note"><sup>[35]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox119">Flag<a href="#firefox-arraybuffer-note"><sup>[35]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox120">Flag<a href="#firefox-arraybuffer-note"><sup>[35]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox121">Flag<a href="#firefox-arraybuffer-note"><sup>[35]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox122">Yes</td>
+<td class="yes obsolete" data-browser="firefox123">Yes</td>
+<td class="yes obsolete" data-browser="firefox124">Yes</td>
+<td class="yes obsolete" data-browser="firefox125">Yes</td>
+<td class="yes obsolete" data-browser="firefox126">Yes</td>
+<td class="yes obsolete" data-browser="firefox127">Yes</td>
+<td class="yes" data-browser="firefox128">Yes</td>
+<td class="yes obsolete" data-browser="firefox129">Yes</td>
+<td class="yes obsolete" data-browser="firefox130">Yes</td>
+<td class="yes" data-browser="firefox131">Yes</td>
+<td class="yes unstable" data-browser="firefox132">Yes</td>
+<td class="yes unstable" data-browser="firefox133">Yes</td>
+<td class="unknown obsolete" data-browser="opera12_10">?</td>
+<td class="yes obsolete" data-browser="chrome119">Yes</td>
+<td class="yes obsolete" data-browser="chrome120">Yes</td>
+<td class="yes obsolete" data-browser="chrome121">Yes</td>
+<td class="yes obsolete" data-browser="chrome122">Yes</td>
+<td class="yes obsolete" data-browser="chrome123">Yes</td>
+<td class="yes obsolete" data-browser="chrome124">Yes</td>
+<td class="yes obsolete" data-browser="chrome125">Yes</td>
+<td class="yes obsolete" data-browser="chrome126">Yes</td>
+<td class="yes obsolete" data-browser="chrome127">Yes</td>
+<td class="yes obsolete" data-browser="chrome128">Yes</td>
+<td class="yes" data-browser="chrome129">Yes</td>
+<td class="yes unstable" data-browser="chrome130">Yes</td>
+<td class="yes unstable" data-browser="chrome131">Yes</td>
+<td class="no obsolete" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge118">Yes</td>
+<td class="yes obsolete" data-browser="edge119">Yes</td>
+<td class="yes obsolete" data-browser="edge120">Yes</td>
+<td class="yes obsolete" data-browser="edge121">Yes</td>
+<td class="yes obsolete" data-browser="edge122">Yes</td>
+<td class="yes obsolete" data-browser="edge123">Yes</td>
+<td class="yes obsolete" data-browser="edge124">Yes</td>
+<td class="yes obsolete" data-browser="edge125">Yes</td>
+<td class="yes obsolete" data-browser="edge126">Yes</td>
+<td class="yes obsolete" data-browser="edge127">Yes</td>
+<td class="yes obsolete" data-browser="edge128">Yes</td>
+<td class="yes" data-browser="edge129">Yes</td>
+<td class="yes unstable" data-browser="edge130">Yes</td>
+<td class="unknown obsolete" data-browser="safari15_6">?</td>
+<td class="unknown obsolete" data-browser="safari16_6">?</td>
+<td class="unknown obsolete" data-browser="safari17">?</td>
+<td class="unknown obsolete" data-browser="safari17_1">?</td>
+<td class="unknown obsolete" data-browser="safari17_2">?</td>
+<td class="unknown obsolete" data-browser="safari17_3">?</td>
+<td class="yes obsolete" data-browser="safari17_4">Yes</td>
+<td class="yes obsolete" data-browser="safari17_5">Yes</td>
+<td class="yes" data-browser="safari17_6">Yes</td>
+<td class="yes" data-browser="safari18">Yes</td>
+<td class="yes unstable" data-browser="safaritp">Yes</td>
+<td class="yes unstable" data-browser="webkit">Yes</td>
+<td class="yes obsolete" data-browser="opera102">Yes</td>
+<td class="yes obsolete" data-browser="opera103">Yes</td>
+<td class="yes obsolete" data-browser="opera104">Yes</td>
+<td class="yes obsolete" data-browser="opera105">Yes</td>
+<td class="yes obsolete" data-browser="opera106">Yes</td>
+<td class="yes obsolete" data-browser="opera107">Yes</td>
+<td class="yes obsolete" data-browser="opera108">Yes</td>
+<td class="yes obsolete" data-browser="opera109">Yes</td>
+<td class="yes obsolete" data-browser="opera110">Yes</td>
+<td class="yes" data-browser="opera111">Yes</td>
+<td class="yes unstable" data-browser="opera112">Yes</td>
+<td class="unknown obsolete" data-browser="rhino1_7_13">?</td>
+<td class="unknown obsolete" data-browser="rhino1_7_14">?</td>
+<td class="unknown obsolete" data-browser="rhino1_7_15">?</td>
+<td class="unknown obsolete" data-browser="phantom2_1">?</td>
+<td class="unknown obsolete" data-browser="node0_4">?</td>
+<td class="unknown obsolete" data-browser="node0_6">?</td>
+<td class="unknown obsolete" data-browser="node0_8">?</td>
+<td class="unknown obsolete" data-browser="node0_10">?</td>
+<td class="unknown obsolete" data-browser="node0_12">?</td>
+<td class="unknown obsolete" data-browser="node14_6">?</td>
+<td class="unknown obsolete" data-browser="node16_0">?</td>
+<td class="unknown obsolete" data-browser="node16_9">?</td>
+<td class="unknown" data-browser="node16_11">?</td>
+<td class="unknown obsolete" data-browser="node17_0">?</td>
+<td class="unknown obsolete" data-browser="node17_2">?</td>
+<td class="unknown obsolete" data-browser="node18_0">?</td>
+<td class="unknown" data-browser="node18_3">?</td>
+<td class="unknown obsolete" data-browser="node19_0">?</td>
+<td class="unknown obsolete" data-browser="node19_2">?</td>
+<td class="unknown" data-browser="node20_0">?</td>
+<td class="yes obsolete" data-browser="node21_0">Yes</td>
+<td class="yes" data-browser="node22_0">Yes</td>
+<td class="unknown obsolete" data-browser="duktape2_6">?</td>
+<td class="unknown" data-browser="duktape2_7">?</td>
+<td class="unknown obsolete" data-browser="jerryscript2_3_0">?</td>
+<td class="unknown" data-browser="jerryscript2_4_0">?</td>
+<td class="unknown obsolete" data-browser="graalvm19">?</td>
+<td class="unknown obsolete" data-browser="graalvm19_3_6">?</td>
+<td class="unknown obsolete" data-browser="graalvm20">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_1">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_3">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_3_1">?</td>
+<td class="unknown obsolete" data-browser="graalvm21">?</td>
+<td class="unknown" data-browser="graalvm21_3_3">?</td>
+<td class="unknown" data-browser="graalvm22_2">?</td>
+<td class="unknown obsolete" data-browser="hermes0_7_0">?</td>
+<td class="unknown" data-browser="hermes0_12_0">?</td>
+<td class="yes obsolete" data-browser="deno1_33">Yes</td>
+<td class="yes obsolete" data-browser="deno1_34">Yes</td>
+<td class="yes obsolete" data-browser="deno1_35">Yes</td>
+<td class="yes" data-browser="deno1_36">Yes</td>
+<td class="unknown obsolete" data-browser="android4_4">?</td>
+<td class="unknown obsolete" data-browser="android4_4_3">?</td>
+<td class="unknown obsolete" data-browser="ios12_2">?</td>
+<td class="unknown obsolete" data-browser="ios13_4">?</td>
+<td class="unknown obsolete" data-browser="ios14_5">?</td>
+<td class="unknown obsolete" data-browser="ios16_6">?</td>
+<td class="unknown obsolete" data-browser="ios17">?</td>
+<td class="unknown obsolete" data-browser="ios17_1">?</td>
+<td class="unknown obsolete" data-browser="ios17_2">?</td>
+<td class="unknown obsolete" data-browser="ios17_3">?</td>
+<td class="yes obsolete" data-browser="ios17_4">Yes</td>
+<td class="yes obsolete" data-browser="ios17_5">Yes</td>
+<td class="yes obsolete" data-browser="ios17_6">Yes</td>
+<td class="yes" data-browser="ios18">Yes</td>
+<td class="unknown obsolete" data-browser="samsung19">?</td>
+<td class="unknown obsolete" data-browser="samsung20">?</td>
+<td class="unknown obsolete" data-browser="samsung21">?</td>
+<td class="unknown" data-browser="samsung22">?</td>
+<td class="unknown obsolete" data-browser="opera_mobile72">?</td>
+<td class="unknown obsolete" data-browser="opera_mobile73">?</td>
+<td class="unknown obsolete" data-browser="opera_mobile74">?</td>
+<td class="unknown obsolete" data-browser="opera_mobile75">?</td>
+<td class="yes obsolete" data-browser="opera_mobile76">Yes</td>
+<td class="yes" data-browser="opera_mobile77">Yes</td>
+<td class="unknown" data-browser="reactnative0_70_3">?</td>
 </tr>
 <tr class="category"><td colspan="158"><span>2025 features</span></td>
 </tr>
 <tr significance="0.125"><td id="test-Duplicate_named_capturing_groups"><span><a class="anchor" href="#test-Duplicate_named_capturing_groups">&#xA7;</a><a href="https://github.com/tc39/proposal-duplicate-named-capturing-groups">Duplicate named capturing groups</a></span><script data-source="
 return /(?&lt;year&gt;[0-9]{4})-[0-9]{2}|[0-9]{2}-(?&lt;year&gt;[0-9]{4})/.test(&quot;12-1995&quot;);
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("252");try{return Function("asyncTestPassed","\nreturn /(?<year>[0-9]{4})-[0-9]{2}|[0-9]{2}-(?<year>[0-9]{4})/.test(\"12-1995\");\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("252");return Function("asyncTestPassed","'use strict';"+"\nreturn /(?<year>[0-9]{4})-[0-9]{2}|[0-9]{2}-(?<year>[0-9]{4})/.test(\"12-1995\");\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("253");try{return Function("asyncTestPassed","\nreturn /(?<year>[0-9]{4})-[0-9]{2}|[0-9]{2}-(?<year>[0-9]{4})/.test(\"12-1995\");\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("253");return Function("asyncTestPassed","'use strict';"+"\nreturn /(?<year>[0-9]{4})-[0-9]{2}|[0-9]{2}-(?<year>[0-9]{4})/.test(\"12-1995\");\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -41644,7 +41806,7 @@ var set = new Set([1, 2, 3]).intersection(new Set([2, 3, 4]));
 return set.size === 2
   &amp;&amp; set.has(2)
   &amp;&amp; set.has(3);
-        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("254");try{return Function("asyncTestPassed","\nvar set = new Set([1, 2, 3]).intersection(new Set([2, 3, 4]));\nreturn set.size === 2\n  && set.has(2)\n  && set.has(3);\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("254");return Function("asyncTestPassed","'use strict';"+"\nvar set = new Set([1, 2, 3]).intersection(new Set([2, 3, 4]));\nreturn set.size === 2\n  && set.has(2)\n  && set.has(3);\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("255");try{return Function("asyncTestPassed","\nvar set = new Set([1, 2, 3]).intersection(new Set([2, 3, 4]));\nreturn set.size === 2\n  && set.has(2)\n  && set.has(3);\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("255");return Function("asyncTestPassed","'use strict';"+"\nvar set = new Set([1, 2, 3]).intersection(new Set([2, 3, 4]));\nreturn set.size === 2\n  && set.has(2)\n  && set.has(3);\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -41808,7 +41970,7 @@ return set.size === 3
   &amp;&amp; set.has(1)
   &amp;&amp; set.has(2)
   &amp;&amp; set.has(3);
-        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("255");try{return Function("asyncTestPassed","\nvar set = new Set([1, 2]).union(new Set([2, 3]));\nreturn set.size === 3\n  && set.has(1)\n  && set.has(2)\n  && set.has(3);\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("255");return Function("asyncTestPassed","'use strict';"+"\nvar set = new Set([1, 2]).union(new Set([2, 3]));\nreturn set.size === 3\n  && set.has(1)\n  && set.has(2)\n  && set.has(3);\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("256");try{return Function("asyncTestPassed","\nvar set = new Set([1, 2]).union(new Set([2, 3]));\nreturn set.size === 3\n  && set.has(1)\n  && set.has(2)\n  && set.has(3);\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("256");return Function("asyncTestPassed","'use strict';"+"\nvar set = new Set([1, 2]).union(new Set([2, 3]));\nreturn set.size === 3\n  && set.has(1)\n  && set.has(2)\n  && set.has(3);\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -41971,7 +42133,7 @@ var set = new Set([1, 2, 3]).difference(new Set([3, 4]));
 return set.size === 2
   &amp;&amp; set.has(1)
   &amp;&amp; set.has(2);
-        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("256");try{return Function("asyncTestPassed","\nvar set = new Set([1, 2, 3]).difference(new Set([3, 4]));\nreturn set.size === 2\n  && set.has(1)\n  && set.has(2);\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("256");return Function("asyncTestPassed","'use strict';"+"\nvar set = new Set([1, 2, 3]).difference(new Set([3, 4]));\nreturn set.size === 2\n  && set.has(1)\n  && set.has(2);\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("257");try{return Function("asyncTestPassed","\nvar set = new Set([1, 2, 3]).difference(new Set([3, 4]));\nreturn set.size === 2\n  && set.has(1)\n  && set.has(2);\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("257");return Function("asyncTestPassed","'use strict';"+"\nvar set = new Set([1, 2, 3]).difference(new Set([3, 4]));\nreturn set.size === 2\n  && set.has(1)\n  && set.has(2);\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -42134,7 +42296,7 @@ var set = new Set([1, 2]).symmetricDifference(new Set([2, 3]));
 return set.size === 2
   &amp;&amp; set.has(1)
   &amp;&amp; set.has(3);
-        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("257");try{return Function("asyncTestPassed","\nvar set = new Set([1, 2]).symmetricDifference(new Set([2, 3]));\nreturn set.size === 2\n  && set.has(1)\n  && set.has(3);\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("257");return Function("asyncTestPassed","'use strict';"+"\nvar set = new Set([1, 2]).symmetricDifference(new Set([2, 3]));\nreturn set.size === 2\n  && set.has(1)\n  && set.has(3);\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("258");try{return Function("asyncTestPassed","\nvar set = new Set([1, 2]).symmetricDifference(new Set([2, 3]));\nreturn set.size === 2\n  && set.has(1)\n  && set.has(3);\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("258");return Function("asyncTestPassed","'use strict';"+"\nvar set = new Set([1, 2]).symmetricDifference(new Set([2, 3]));\nreturn set.size === 2\n  && set.has(1)\n  && set.has(3);\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -42294,7 +42456,7 @@ return set.size === 2
 </tr>
 <tr class="subtest" data-parent="Set_methods" id="test-Set_methods_Set.prototype.isDisjointFrom()"><td><span><a class="anchor" href="#test-Set_methods_Set.prototype.isDisjointFrom()">&#xA7;</a>Set.prototype.isDisjointFrom()</span><script data-source="
 return new Set([1, 2, 3]).isDisjointFrom(new Set([4, 5, 6]));
-        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("258");try{return Function("asyncTestPassed","\nreturn new Set([1, 2, 3]).isDisjointFrom(new Set([4, 5, 6]));\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("258");return Function("asyncTestPassed","'use strict';"+"\nreturn new Set([1, 2, 3]).isDisjointFrom(new Set([4, 5, 6]));\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("259");try{return Function("asyncTestPassed","\nreturn new Set([1, 2, 3]).isDisjointFrom(new Set([4, 5, 6]));\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("259");return Function("asyncTestPassed","'use strict';"+"\nreturn new Set([1, 2, 3]).isDisjointFrom(new Set([4, 5, 6]));\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -42454,7 +42616,7 @@ return new Set([1, 2, 3]).isDisjointFrom(new Set([4, 5, 6]));
 </tr>
 <tr class="subtest" data-parent="Set_methods" id="test-Set_methods_Set.prototype.isSubsetOf()"><td><span><a class="anchor" href="#test-Set_methods_Set.prototype.isSubsetOf()">&#xA7;</a>Set.prototype.isSubsetOf()</span><script data-source="
 return new Set([1, 2, 3]).isSubsetOf(new Set([5, 4, 3, 2, 1]));
-        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("259");try{return Function("asyncTestPassed","\nreturn new Set([1, 2, 3]).isSubsetOf(new Set([5, 4, 3, 2, 1]));\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("259");return Function("asyncTestPassed","'use strict';"+"\nreturn new Set([1, 2, 3]).isSubsetOf(new Set([5, 4, 3, 2, 1]));\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("260");try{return Function("asyncTestPassed","\nreturn new Set([1, 2, 3]).isSubsetOf(new Set([5, 4, 3, 2, 1]));\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("260");return Function("asyncTestPassed","'use strict';"+"\nreturn new Set([1, 2, 3]).isSubsetOf(new Set([5, 4, 3, 2, 1]));\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -42614,7 +42776,7 @@ return new Set([1, 2, 3]).isSubsetOf(new Set([5, 4, 3, 2, 1]));
 </tr>
 <tr class="subtest" data-parent="Set_methods" id="test-Set_methods_Set.prototype.isSupersetOf()"><td><span><a class="anchor" href="#test-Set_methods_Set.prototype.isSupersetOf()">&#xA7;</a>Set.prototype.isSupersetOf()</span><script data-source="
 return new Set([5, 4, 3, 2, 1]).isSupersetOf(new Set([1, 2, 3]));
-        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("260");try{return Function("asyncTestPassed","\nreturn new Set([5, 4, 3, 2, 1]).isSupersetOf(new Set([1, 2, 3]));\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("260");return Function("asyncTestPassed","'use strict';"+"\nreturn new Set([5, 4, 3, 2, 1]).isSupersetOf(new Set([1, 2, 3]));\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("261");try{return Function("asyncTestPassed","\nreturn new Set([5, 4, 3, 2, 1]).isSupersetOf(new Set([1, 2, 3]));\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("261");return Function("asyncTestPassed","'use strict';"+"\nreturn new Set([5, 4, 3, 2, 1]).isSupersetOf(new Set([1, 2, 3]));\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -42932,7 +43094,7 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf(new Set([1, 2, 3]));
 <tr class="subtest" data-parent="RegExp_Pattern_Modifiers" id="test-RegExp_Pattern_Modifiers_i_flag"><td><span><a class="anchor" href="#test-RegExp_Pattern_Modifiers_i_flag">&#xA7;</a>i flag</span><script data-source="
 const regex = /^[a-z](?-i:[a-z])$/i;
 return regex.test(&quot;ab&quot;) &amp;&amp; regex.test(&quot;Ab&quot;) &amp;&amp; !regex.test(&quot;aB&quot;);
-        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("262");try{return Function("asyncTestPassed","\nconst regex = /^[a-z](?-i:[a-z])$/i;\nreturn regex.test(\"ab\") && regex.test(\"Ab\") && !regex.test(\"aB\");\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("262");return Function("asyncTestPassed","'use strict';"+"\nconst regex = /^[a-z](?-i:[a-z])$/i;\nreturn regex.test(\"ab\") && regex.test(\"Ab\") && !regex.test(\"aB\");\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("263");try{return Function("asyncTestPassed","\nconst regex = /^[a-z](?-i:[a-z])$/i;\nreturn regex.test(\"ab\") && regex.test(\"Ab\") && !regex.test(\"aB\");\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("263");return Function("asyncTestPassed","'use strict';"+"\nconst regex = /^[a-z](?-i:[a-z])$/i;\nreturn regex.test(\"ab\") && regex.test(\"Ab\") && !regex.test(\"aB\");\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -43093,7 +43255,7 @@ return regex.test(&quot;ab&quot;) &amp;&amp; regex.test(&quot;Ab&quot;) &amp;&am
 <tr class="subtest" data-parent="RegExp_Pattern_Modifiers" id="test-RegExp_Pattern_Modifiers_m_flag"><td><span><a class="anchor" href="#test-RegExp_Pattern_Modifiers_m_flag">&#xA7;</a>m flag</span><script data-source="
 const regex = /^a|(?m:^b)/;
 return regex.test(&quot;a&quot;) &amp;&amp; regex.test(&quot;b&quot;) &amp;&amp; regex.test(&quot;c\nb&quot;) &amp;&amp; !regex.test(&quot;c\na&quot;);
-        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("263");try{return Function("asyncTestPassed","\nconst regex = /^a|(?m:^b)/;\nreturn regex.test(\"a\") && regex.test(\"b\") && regex.test(\"c\\nb\") && !regex.test(\"c\\na\");\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("263");return Function("asyncTestPassed","'use strict';"+"\nconst regex = /^a|(?m:^b)/;\nreturn regex.test(\"a\") && regex.test(\"b\") && regex.test(\"c\\nb\") && !regex.test(\"c\\na\");\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("264");try{return Function("asyncTestPassed","\nconst regex = /^a|(?m:^b)/;\nreturn regex.test(\"a\") && regex.test(\"b\") && regex.test(\"c\\nb\") && !regex.test(\"c\\na\");\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("264");return Function("asyncTestPassed","'use strict';"+"\nconst regex = /^a|(?m:^b)/;\nreturn regex.test(\"a\") && regex.test(\"b\") && regex.test(\"c\\nb\") && !regex.test(\"c\\na\");\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -43254,7 +43416,7 @@ return regex.test(&quot;a&quot;) &amp;&amp; regex.test(&quot;b&quot;) &amp;&amp;
 <tr class="subtest" data-parent="RegExp_Pattern_Modifiers" id="test-RegExp_Pattern_Modifiers_s_flag"><td><span><a class="anchor" href="#test-RegExp_Pattern_Modifiers_s_flag">&#xA7;</a>s flag</span><script data-source="
 const regex = /.(?-s:.)/s;
 return regex.test(&quot;\na&quot;) &amp;&amp; regex.test(&quot;aa&quot;) &amp;&amp; !regex.test(&quot;\n\n&quot;);
-        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("264");try{return Function("asyncTestPassed","\nconst regex = /.(?-s:.)/s;\nreturn regex.test(\"\\na\") && regex.test(\"aa\") && !regex.test(\"\\n\\n\");\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("264");return Function("asyncTestPassed","'use strict';"+"\nconst regex = /.(?-s:.)/s;\nreturn regex.test(\"\\na\") && regex.test(\"aa\") && !regex.test(\"\\n\\n\");\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("265");try{return Function("asyncTestPassed","\nconst regex = /.(?-s:.)/s;\nreturn regex.test(\"\\na\") && regex.test(\"aa\") && !regex.test(\"\\n\\n\");\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("265");return Function("asyncTestPassed","'use strict';"+"\nconst regex = /.(?-s:.)/s;\nreturn regex.test(\"\\na\") && regex.test(\"aa\") && !regex.test(\"\\n\\n\");\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -43571,7 +43733,7 @@ return regex.test(&quot;\na&quot;) &amp;&amp; regex.test(&quot;aa&quot;) &amp;&a
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_instanceof_Iterator"><td><span><a class="anchor" href="#test-Iterator_Helpers_instanceof_Iterator">&#xA7;</a>instanceof Iterator</span><script data-source="
 return [1, 2, 3].values() instanceof Iterator;
-        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("266");try{return Function("asyncTestPassed","\nreturn [1, 2, 3].values() instanceof Iterator;\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("266");return Function("asyncTestPassed","'use strict';"+"\nreturn [1, 2, 3].values() instanceof Iterator;\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("267");try{return Function("asyncTestPassed","\nreturn [1, 2, 3].values() instanceof Iterator;\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("267");return Function("asyncTestPassed","'use strict';"+"\nreturn [1, 2, 3].values() instanceof Iterator;\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -43733,7 +43895,7 @@ return [1, 2, 3].values() instanceof Iterator;
 class Class extends Iterator { }
 const instance = new Class();
 return instance[Symbol.iterator]() === instance;
-        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("267");try{return Function("asyncTestPassed","\nclass Class extends Iterator { }\nconst instance = new Class();\nreturn instance[Symbol.iterator]() === instance;\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("267");return Function("asyncTestPassed","'use strict';"+"\nclass Class extends Iterator { }\nconst instance = new Class();\nreturn instance[Symbol.iterator]() === instance;\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("268");try{return Function("asyncTestPassed","\nclass Class extends Iterator { }\nconst instance = new Class();\nreturn instance[Symbol.iterator]() === instance;\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("268");return Function("asyncTestPassed","'use strict';"+"\nclass Class extends Iterator { }\nconst instance = new Class();\nreturn instance[Symbol.iterator]() === instance;\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -43896,7 +44058,7 @@ const iterator = Iterator.from([1, 2, 3]);
 return &apos;next&apos; in iterator
   &amp;&amp; iterator instanceof Iterator
   &amp;&amp; Array.from(iterator).join() === &apos;1,2,3&apos;;
-        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("268");try{return Function("asyncTestPassed","\nconst iterator = Iterator.from([1, 2, 3]);\nreturn 'next' in iterator\n  && iterator instanceof Iterator\n  && Array.from(iterator).join() === '1,2,3';\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("268");return Function("asyncTestPassed","'use strict';"+"\nconst iterator = Iterator.from([1, 2, 3]);\nreturn 'next' in iterator\n  && iterator instanceof Iterator\n  && Array.from(iterator).join() === '1,2,3';\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("269");try{return Function("asyncTestPassed","\nconst iterator = Iterator.from([1, 2, 3]);\nreturn 'next' in iterator\n  && iterator instanceof Iterator\n  && Array.from(iterator).join() === '1,2,3';\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("269");return Function("asyncTestPassed","'use strict';"+"\nconst iterator = Iterator.from([1, 2, 3]);\nreturn 'next' in iterator\n  && iterator instanceof Iterator\n  && Array.from(iterator).join() === '1,2,3';\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -44064,7 +44226,7 @@ const iterator = Iterator.from({
 return &apos;next&apos; in iterator
   &amp;&amp; iterator instanceof Iterator
   &amp;&amp; Array.from(iterator).join() === &apos;1,2,3&apos;;
-        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("269");try{return Function("asyncTestPassed","\nconst iterator = Iterator.from({\n  i: 0,\n  next() {\n    return { value: ++this.i, done: this.i > 3 };\n  }\n});\nreturn 'next' in iterator\n  && iterator instanceof Iterator\n  && Array.from(iterator).join() === '1,2,3';\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("269");return Function("asyncTestPassed","'use strict';"+"\nconst iterator = Iterator.from({\n  i: 0,\n  next() {\n    return { value: ++this.i, done: this.i > 3 };\n  }\n});\nreturn 'next' in iterator\n  && iterator instanceof Iterator\n  && Array.from(iterator).join() === '1,2,3';\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("270");try{return Function("asyncTestPassed","\nconst iterator = Iterator.from({\n  i: 0,\n  next() {\n    return { value: ++this.i, done: this.i > 3 };\n  }\n});\nreturn 'next' in iterator\n  && iterator instanceof Iterator\n  && Array.from(iterator).join() === '1,2,3';\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("270");return Function("asyncTestPassed","'use strict';"+"\nconst iterator = Iterator.from({\n  i: 0,\n  next() {\n    return { value: ++this.i, done: this.i > 3 };\n  }\n});\nreturn 'next' in iterator\n  && iterator instanceof Iterator\n  && Array.from(iterator).join() === '1,2,3';\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -44224,7 +44386,7 @@ return &apos;next&apos; in iterator
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_Iterator.prototype.asIndexedPairs"><td><span><a class="anchor" href="#test-Iterator_Helpers_Iterator.prototype.asIndexedPairs">&#xA7;</a>Iterator.prototype.asIndexedPairs</span><script data-source="
 return Array.from([1, 2, 3].values().asIndexedPairs()).join() === &apos;0,1,1,2,2,3&apos;;
-        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("270");try{return Function("asyncTestPassed","\nreturn Array.from([1, 2, 3].values().asIndexedPairs()).join() === '0,1,1,2,2,3';\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("270");return Function("asyncTestPassed","'use strict';"+"\nreturn Array.from([1, 2, 3].values().asIndexedPairs()).join() === '0,1,1,2,2,3';\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("271");try{return Function("asyncTestPassed","\nreturn Array.from([1, 2, 3].values().asIndexedPairs()).join() === '0,1,1,2,2,3';\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("271");return Function("asyncTestPassed","'use strict';"+"\nreturn Array.from([1, 2, 3].values().asIndexedPairs()).join() === '0,1,1,2,2,3';\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -44384,7 +44546,7 @@ return Array.from([1, 2, 3].values().asIndexedPairs()).join() === &apos;0,1,1,2,
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_Iterator.prototype.drop_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/drop_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Iterator_Helpers_Iterator.prototype.drop_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/drop_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Iterator.prototype.drop <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/drop" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return Array.from([1, 2, 3].values().drop(1)).join() === &apos;2,3&apos;;
-        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("271");try{return Function("asyncTestPassed","\nreturn Array.from([1, 2, 3].values().drop(1)).join() === '2,3';\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("271");return Function("asyncTestPassed","'use strict';"+"\nreturn Array.from([1, 2, 3].values().drop(1)).join() === '2,3';\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("272");try{return Function("asyncTestPassed","\nreturn Array.from([1, 2, 3].values().drop(1)).join() === '2,3';\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("272");return Function("asyncTestPassed","'use strict';"+"\nreturn Array.from([1, 2, 3].values().drop(1)).join() === '2,3';\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -44544,7 +44706,7 @@ return Array.from([1, 2, 3].values().drop(1)).join() === &apos;2,3&apos;;
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_Iterator.prototype.every_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/every_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Iterator_Helpers_Iterator.prototype.every_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/every_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Iterator.prototype.every <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/every" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return [1, 2, 3].values().every(it =&gt; typeof it === &apos;number&apos;);
-        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("272");try{return Function("asyncTestPassed","\nreturn [1, 2, 3].values().every(it => typeof it === 'number');\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("272");return Function("asyncTestPassed","'use strict';"+"\nreturn [1, 2, 3].values().every(it => typeof it === 'number');\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("273");try{return Function("asyncTestPassed","\nreturn [1, 2, 3].values().every(it => typeof it === 'number');\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("273");return Function("asyncTestPassed","'use strict';"+"\nreturn [1, 2, 3].values().every(it => typeof it === 'number');\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -44704,7 +44866,7 @@ return [1, 2, 3].values().every(it =&gt; typeof it === &apos;number&apos;);
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_Iterator.prototype.filter_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/filter_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Iterator_Helpers_Iterator.prototype.filter_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/filter_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Iterator.prototype.filter <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/filter" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return Array.from([1, 2, 3].values().filter(it =&gt; it % 2)).join() === &apos;1,3&apos;;
-        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("273");try{return Function("asyncTestPassed","\nreturn Array.from([1, 2, 3].values().filter(it => it % 2)).join() === '1,3';\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("273");return Function("asyncTestPassed","'use strict';"+"\nreturn Array.from([1, 2, 3].values().filter(it => it % 2)).join() === '1,3';\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("274");try{return Function("asyncTestPassed","\nreturn Array.from([1, 2, 3].values().filter(it => it % 2)).join() === '1,3';\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("274");return Function("asyncTestPassed","'use strict';"+"\nreturn Array.from([1, 2, 3].values().filter(it => it % 2)).join() === '1,3';\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -44864,7 +45026,7 @@ return Array.from([1, 2, 3].values().filter(it =&gt; it % 2)).join() === &apos;1
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_Iterator.prototype.find_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/find_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Iterator_Helpers_Iterator.prototype.find_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/find_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Iterator.prototype.find <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/find" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return [1, 2, 3].values().find(it =&gt; it % 2) === 1;
-        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("274");try{return Function("asyncTestPassed","\nreturn [1, 2, 3].values().find(it => it % 2) === 1;\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("274");return Function("asyncTestPassed","'use strict';"+"\nreturn [1, 2, 3].values().find(it => it % 2) === 1;\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("275");try{return Function("asyncTestPassed","\nreturn [1, 2, 3].values().find(it => it % 2) === 1;\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("275");return Function("asyncTestPassed","'use strict';"+"\nreturn [1, 2, 3].values().find(it => it % 2) === 1;\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -45024,7 +45186,7 @@ return [1, 2, 3].values().find(it =&gt; it % 2) === 1;
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_Iterator.prototype.flatMap_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/flatMap_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Iterator_Helpers_Iterator.prototype.flatMap_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/flatMap_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Iterator.prototype.flatMap <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/flatMap" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return Array.from([1, 2, 3].values().flatMap(it =&gt; [it, 0])).join() === &apos;1,0,2,0,3,0&apos;;
-        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("275");try{return Function("asyncTestPassed","\nreturn Array.from([1, 2, 3].values().flatMap(it => [it, 0])).join() === '1,0,2,0,3,0';\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("275");return Function("asyncTestPassed","'use strict';"+"\nreturn Array.from([1, 2, 3].values().flatMap(it => [it, 0])).join() === '1,0,2,0,3,0';\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("276");try{return Function("asyncTestPassed","\nreturn Array.from([1, 2, 3].values().flatMap(it => [it, 0])).join() === '1,0,2,0,3,0';\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("276");return Function("asyncTestPassed","'use strict';"+"\nreturn Array.from([1, 2, 3].values().flatMap(it => [it, 0])).join() === '1,0,2,0,3,0';\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -45186,7 +45348,7 @@ return Array.from([1, 2, 3].values().flatMap(it =&gt; [it, 0])).join() === &apos
 let result = &apos;&apos;;
 [1, 2, 3].values().forEach(it =&gt; result += it);
 return result === &apos;123&apos;;
-        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("276");try{return Function("asyncTestPassed","\nlet result = '';\n[1, 2, 3].values().forEach(it => result += it);\nreturn result === '123';\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("276");return Function("asyncTestPassed","'use strict';"+"\nlet result = '';\n[1, 2, 3].values().forEach(it => result += it);\nreturn result === '123';\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("277");try{return Function("asyncTestPassed","\nlet result = '';\n[1, 2, 3].values().forEach(it => result += it);\nreturn result === '123';\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("277");return Function("asyncTestPassed","'use strict';"+"\nlet result = '';\n[1, 2, 3].values().forEach(it => result += it);\nreturn result === '123';\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -45346,7 +45508,7 @@ return result === &apos;123&apos;;
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_Iterator.prototype.map_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/map_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Iterator_Helpers_Iterator.prototype.map_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/map_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Iterator.prototype.map <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/map" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return Array.from([1, 2, 3].values().map(it =&gt; it * it)).join() === &apos;1,4,9&apos;;
-        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("277");try{return Function("asyncTestPassed","\nreturn Array.from([1, 2, 3].values().map(it => it * it)).join() === '1,4,9';\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("277");return Function("asyncTestPassed","'use strict';"+"\nreturn Array.from([1, 2, 3].values().map(it => it * it)).join() === '1,4,9';\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("278");try{return Function("asyncTestPassed","\nreturn Array.from([1, 2, 3].values().map(it => it * it)).join() === '1,4,9';\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("278");return Function("asyncTestPassed","'use strict';"+"\nreturn Array.from([1, 2, 3].values().map(it => it * it)).join() === '1,4,9';\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -45506,7 +45668,7 @@ return Array.from([1, 2, 3].values().map(it =&gt; it * it)).join() === &apos;1,4
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_Iterator.prototype.reduce_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/reduce_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Iterator_Helpers_Iterator.prototype.reduce_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/reduce_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Iterator.prototype.reduce <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/reduce" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return [1, 2, 3].values().reduce((a, b) =&gt; a + b) === 6;
-        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("278");try{return Function("asyncTestPassed","\nreturn [1, 2, 3].values().reduce((a, b) => a + b) === 6;\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("278");return Function("asyncTestPassed","'use strict';"+"\nreturn [1, 2, 3].values().reduce((a, b) => a + b) === 6;\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("279");try{return Function("asyncTestPassed","\nreturn [1, 2, 3].values().reduce((a, b) => a + b) === 6;\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("279");return Function("asyncTestPassed","'use strict';"+"\nreturn [1, 2, 3].values().reduce((a, b) => a + b) === 6;\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -45666,7 +45828,7 @@ return [1, 2, 3].values().reduce((a, b) =&gt; a + b) === 6;
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_Iterator.prototype.some_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/some_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Iterator_Helpers_Iterator.prototype.some_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/some_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Iterator.prototype.some <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/some" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return [1, 2, 3].values().some(it =&gt; typeof it === &apos;number&apos;);
-        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("279");try{return Function("asyncTestPassed","\nreturn [1, 2, 3].values().some(it => typeof it === 'number');\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("279");return Function("asyncTestPassed","'use strict';"+"\nreturn [1, 2, 3].values().some(it => typeof it === 'number');\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("280");try{return Function("asyncTestPassed","\nreturn [1, 2, 3].values().some(it => typeof it === 'number');\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("280");return Function("asyncTestPassed","'use strict';"+"\nreturn [1, 2, 3].values().some(it => typeof it === 'number');\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -45826,7 +45988,7 @@ return [1, 2, 3].values().some(it =&gt; typeof it === &apos;number&apos;);
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_Iterator.prototype.take_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/take_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Iterator_Helpers_Iterator.prototype.take_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/take_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Iterator.prototype.take <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/take" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return Array.from([1, 2, 3].values().take(2)).join() === &apos;1,2&apos;;
-        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("280");try{return Function("asyncTestPassed","\nreturn Array.from([1, 2, 3].values().take(2)).join() === '1,2';\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("280");return Function("asyncTestPassed","'use strict';"+"\nreturn Array.from([1, 2, 3].values().take(2)).join() === '1,2';\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("281");try{return Function("asyncTestPassed","\nreturn Array.from([1, 2, 3].values().take(2)).join() === '1,2';\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("281");return Function("asyncTestPassed","'use strict';"+"\nreturn Array.from([1, 2, 3].values().take(2)).join() === '1,2';\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -45987,7 +46149,7 @@ return Array.from([1, 2, 3].values().take(2)).join() === &apos;1,2&apos;;
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_Iterator.prototype.toArray_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/toArray_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-Iterator_Helpers_Iterator.prototype.toArray_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/toArray_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>Iterator.prototype.toArray <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/toArray" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 const array = [1, 2, 3].values().toArray();
 return Array.isArray(array) &amp;&amp; array.join() === &apos;1,2,3&apos;;
-        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("281");try{return Function("asyncTestPassed","\nconst array = [1, 2, 3].values().toArray();\nreturn Array.isArray(array) && array.join() === '1,2,3';\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("281");return Function("asyncTestPassed","'use strict';"+"\nconst array = [1, 2, 3].values().toArray();\nreturn Array.isArray(array) && array.join() === '1,2,3';\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("282");try{return Function("asyncTestPassed","\nconst array = [1, 2, 3].values().toArray();\nreturn Array.isArray(array) && array.join() === '1,2,3';\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("282");return Function("asyncTestPassed","'use strict';"+"\nconst array = [1, 2, 3].values().toArray();\nreturn Array.isArray(array) && array.join() === '1,2,3';\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -46147,7 +46309,7 @@ return Array.isArray(array) &amp;&amp; array.join() === &apos;1,2,3&apos;;
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_Iterator.prototype[@@toStringTag]"><td><span><a class="anchor" href="#test-Iterator_Helpers_Iterator.prototype[@@toStringTag]">&#xA7;</a>Iterator.prototype[@@toStringTag]</span><script data-source="
 return Iterator.prototype[Symbol.toStringTag] === &apos;Iterator&apos;;
-        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("282");try{return Function("asyncTestPassed","\nreturn Iterator.prototype[Symbol.toStringTag] === 'Iterator';\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("282");return Function("asyncTestPassed","'use strict';"+"\nreturn Iterator.prototype[Symbol.toStringTag] === 'Iterator';\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("283");try{return Function("asyncTestPassed","\nreturn Iterator.prototype[Symbol.toStringTag] === 'Iterator';\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("283");return Function("asyncTestPassed","'use strict';"+"\nreturn Iterator.prototype[Symbol.toStringTag] === 'Iterator';\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>


### PR DESCRIPTION
This removes the `ArrayBuffer.prototype.realloc()` test, which is not part of the spec, and adds `ArrayBuffer.prototype.transferToFixedLength()` and ArrayBuffer.prototype.detached, which are.
Fixes #1927.