### PR TITLE
Fix RegExp flags tests

### DIFF
--- a/data-es2016plus.js
+++ b/data-es2016plus.js
@@ -6936,22 +6936,10 @@ exports.tests = [
       {
         name: 'shows up in flags',
         exec: function () {/*
-          var expected = ['hasIndices'];
-          // Sorted alphabetically by shortname – "dgimsuy".
-          if ('global' in RegExp.prototype) expected.push('global');
-          if ('ignoreCase' in RegExp.prototype) expected.push('ignoreCase');
-          if ('multiline' in RegExp.prototype) expected.push('multiline');
-          if ('dotAll' in RegExp.prototype) expected.push('dotAll');
-          if ('unicode' in RegExp.prototype) expected.push('unicode');
-          if ('sticky' in RegExp.prototype) expected.push('sticky');
-          var actual = [];
-          var p = new Proxy({}, { get: function (o, k) { actual.push(k); return o[k]; }});
+          var flags = [];
+          var p = new Proxy({}, { get: function (o, k) { flags.push(k); return o[k]; }});
           Object.getOwnPropertyDescriptor(RegExp.prototype, 'flags').get.call(p);
-          if (expected.length !== actual.length) return false;
-          for (var i = 0; i < expected.length; i++) {
-            if (expected[i] !== actual[i]) return false;
-          }
-          return true;
+          return flags.indexOf("hasIndices") !== -1;
         */},
         res: {
           ie11: false,
@@ -6959,9 +6947,8 @@ exports.tests = [
           firefox68: false,
           firefox78: false,
           firefox91: true,
-          firefox116: false,
           safari15: true,
-          chrome90: false,
+          chrome90: true,
           graalvm21_3_3: graalvm.esStagingFlag,
           graalvm22_2: true,
           hermes0_7_0: false,

--- a/data-es6.js
+++ b/data-es6.js
@@ -12219,7 +12219,7 @@ exports.tests = [
       exec: function() {/*
         // RegExp.prototype.flags -> Get -> [[Get]]
         var expected = [];
-        // Sorted alphabetically by shortname – "gimsuy".
+        // Sorted alphabetically by shortname – "gimsuvy".
         if ('hasIndices' in RegExp.prototype) expected.push('hasIndices');
         if ('global' in RegExp.prototype) expected.push('global');
         if ('ignoreCase' in RegExp.prototype) expected.push('ignoreCase');
@@ -12246,9 +12246,11 @@ exports.tests = [
         opera10_50: false,
         xs6: true,
         chrome49: true,
+        chrome112: { val: false, note_id: 'v8-regex-flags-order', note_html: 'The "unicodeSets" flag is added after the "sticky" flag, instead of before it, as the spec requires.' },
         ie11: false,
         edge14: edge.experimental,
         safari10: true,
+        node16_0: { val: false, note_id: 'v8-regex-flags-order' },
         duktape2_0: true,
         graalvm19: true,
         graalvm22_2: graalvm.es6flag,

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -37830,51 +37830,51 @@ return !(&apos;cause&apos; in AggregateError.prototype);
 <td class="tally" data-browser="es7shim" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally" data-browser="firefox115" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="firefox120" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="firefox121" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="firefox122" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="firefox123" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="firefox124" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="firefox125" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="firefox126" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="firefox127" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally" data-browser="firefox128" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="firefox129" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="firefox130" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="firefox131" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="firefox132" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally" data-browser="firefox133" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally unstable" data-browser="firefox134" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally unstable" data-browser="firefox135" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="firefox120" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="firefox121" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="firefox122" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="firefox123" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="firefox124" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="firefox125" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="firefox126" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="firefox127" data-tally="1">2/2</td>
+<td class="tally" data-browser="firefox128" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="firefox129" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="firefox130" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="firefox131" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="firefox132" data-tally="1">2/2</td>
+<td class="tally" data-browser="firefox133" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="firefox134" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="firefox135" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="chrome119" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="chrome120" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="chrome121" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="chrome122" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="chrome123" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="chrome124" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="chrome125" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="chrome126" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="chrome127" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="chrome128" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="chrome129" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally" data-browser="chrome130" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally unstable" data-browser="chrome131" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally unstable" data-browser="chrome132" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="chrome119" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome120" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome121" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome122" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome123" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome124" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome125" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome126" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome127" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome128" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="chrome129" data-tally="1">2/2</td>
+<td class="tally" data-browser="chrome130" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="chrome131" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="chrome132" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="edge119" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="edge120" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="edge121" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="edge122" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="edge123" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="edge124" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="edge125" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="edge126" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="edge127" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="edge128" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="edge129" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally" data-browser="edge130" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally unstable" data-browser="edge131" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="edge119" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="edge120" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="edge121" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="edge122" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="edge123" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="edge124" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="edge125" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="edge126" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="edge127" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="edge128" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="edge129" data-tally="1">2/2</td>
+<td class="tally" data-browser="edge130" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="edge131" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="safari15_6" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="safari16_6" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="safari17" data-tally="1">2/2</td>
@@ -37887,17 +37887,17 @@ return !(&apos;cause&apos; in AggregateError.prototype);
 <td class="tally" data-browser="safari18" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera102" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="opera103" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="opera104" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="opera105" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="opera106" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="opera107" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="opera108" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="opera109" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="opera110" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally" data-browser="opera111" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally unstable" data-browser="opera112" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="opera102" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera103" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera104" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera105" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera106" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera107" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera108" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera109" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera110" data-tally="1">2/2</td>
+<td class="tally" data-browser="opera111" data-tally="1">2/2</td>
+<td class="tally unstable" data-browser="opera112" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="rhino1_7_15" data-tally="0">0/2</td>
@@ -37909,18 +37909,18 @@ return !(&apos;cause&apos; in AggregateError.prototype);
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node14_6" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node16_0" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="node16_9" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally" data-browser="node16_11" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="node17_0" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="node17_2" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="node18_0" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally" data-browser="node18_3" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="node19_0" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="node19_2" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally" data-browser="node20_0" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="node21_0" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally" data-browser="node22_0" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally" data-browser="node23_0" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="node16_9" data-tally="1">2/2</td>
+<td class="tally" data-browser="node16_11" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="node17_0" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="node17_2" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="node18_0" data-tally="1">2/2</td>
+<td class="tally" data-browser="node18_3" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="node19_0" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="node19_2" data-tally="1">2/2</td>
+<td class="tally" data-browser="node20_0" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="node21_0" data-tally="1">2/2</td>
+<td class="tally" data-browser="node22_0" data-tally="1">2/2</td>
+<td class="tally" data-browser="node23_0" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="duktape2_6" data-tally="0">0/2</td>
 <td class="tally" data-browser="duktape2_7" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="jerryscript2_3_0" data-tally="0">0/2</td>
@@ -37936,10 +37936,10 @@ return !(&apos;cause&apos; in AggregateError.prototype);
 <td class="tally" data-browser="graalvm22_2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="hermes0_7_0" data-tally="0">0/2</td>
 <td class="tally" data-browser="hermes0_12_0" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="deno1_33" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="deno1_34" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="deno1_35" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally" data-browser="deno1_36" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="deno1_33" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="deno1_34" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="deno1_35" data-tally="1">2/2</td>
+<td class="tally" data-browser="deno1_36" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ios12_2" data-tally="0">0/2</td>
@@ -37954,16 +37954,16 @@ return !(&apos;cause&apos; in AggregateError.prototype);
 <td class="tally obsolete" data-browser="ios17_5" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="ios17_6" data-tally="1">2/2</td>
 <td class="tally" data-browser="ios18" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="samsung19" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="samsung20" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="samsung21" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally" data-browser="samsung22" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="opera_mobile72" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="opera_mobile73" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="opera_mobile74" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="opera_mobile75" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="opera_mobile76" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally" data-browser="opera_mobile77" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="samsung19" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="samsung20" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="samsung21" data-tally="1">2/2</td>
+<td class="tally" data-browser="samsung22" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera_mobile72" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera_mobile73" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera_mobile74" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera_mobile75" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="opera_mobile76" data-tally="1">2/2</td>
+<td class="tally" data-browser="opera_mobile77" data-tally="1">2/2</td>
 <td class="tally" data-browser="reactnative0_70_3" data-tally="0">0/2</td>
 </tr>
 <tr class="subtest" data-parent="RegExp_Match_Indices_(`hasIndices`_/_`d`_flag)" id="test-RegExp_Match_Indices_(`hasIndices`_/_`d`_flag)_constructor_supports_it"><td><span><a class="anchor" href="#test-RegExp_Match_Indices_(`hasIndices`_/_`d`_flag)_constructor_supports_it">&#xA7;</a>constructor supports it</span><script data-source="
@@ -38129,23 +38129,11 @@ return new RegExp(&apos;a&apos;, &apos;d&apos;) instanceof RegExp;
 <td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="subtest" data-parent="RegExp_Match_Indices_(`hasIndices`_/_`d`_flag)" id="test-RegExp_Match_Indices_(`hasIndices`_/_`d`_flag)_shows_up_in_flags"><td><span><a class="anchor" href="#test-RegExp_Match_Indices_(`hasIndices`_/_`d`_flag)_shows_up_in_flags">&#xA7;</a>shows up in flags</span><script data-source="
-var expected = [&apos;hasIndices&apos;];
-// Sorted alphabetically by shortname &#x2013; &quot;dgimsuy&quot;.
-if (&apos;global&apos; in RegExp.prototype) expected.push(&apos;global&apos;);
-if (&apos;ignoreCase&apos; in RegExp.prototype) expected.push(&apos;ignoreCase&apos;);
-if (&apos;multiline&apos; in RegExp.prototype) expected.push(&apos;multiline&apos;);
-if (&apos;dotAll&apos; in RegExp.prototype) expected.push(&apos;dotAll&apos;);
-if (&apos;unicode&apos; in RegExp.prototype) expected.push(&apos;unicode&apos;);
-if (&apos;sticky&apos; in RegExp.prototype) expected.push(&apos;sticky&apos;);
-var actual = [];
-var p = new Proxy({}, { get: function (o, k) { actual.push(k); return o[k]; }});
+var flags = [];
+var p = new Proxy({}, { get: function (o, k) { flags.push(k); return o[k]; }});
 Object.getOwnPropertyDescriptor(RegExp.prototype, &apos;flags&apos;).get.call(p);
-if (expected.length !== actual.length) return false;
-for (var i = 0; i &lt; expected.length; i++) {
-  if (expected[i] !== actual[i]) return false;
-}
-return true;
-        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("229");try{return Function("asyncTestPassed","\nvar expected = ['hasIndices'];\n// Sorted alphabetically by shortname – \"dgimsuy\".\nif ('global' in RegExp.prototype) expected.push('global');\nif ('ignoreCase' in RegExp.prototype) expected.push('ignoreCase');\nif ('multiline' in RegExp.prototype) expected.push('multiline');\nif ('dotAll' in RegExp.prototype) expected.push('dotAll');\nif ('unicode' in RegExp.prototype) expected.push('unicode');\nif ('sticky' in RegExp.prototype) expected.push('sticky');\nvar actual = [];\nvar p = new Proxy({}, { get: function (o, k) { actual.push(k); return o[k]; }});\nObject.getOwnPropertyDescriptor(RegExp.prototype, 'flags').get.call(p);\nif (expected.length !== actual.length) return false;\nfor (var i = 0; i < expected.length; i++) {\n  if (expected[i] !== actual[i]) return false;\n}\nreturn true;\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("229");return Function("asyncTestPassed","'use strict';"+"\nvar expected = ['hasIndices'];\n// Sorted alphabetically by shortname – \"dgimsuy\".\nif ('global' in RegExp.prototype) expected.push('global');\nif ('ignoreCase' in RegExp.prototype) expected.push('ignoreCase');\nif ('multiline' in RegExp.prototype) expected.push('multiline');\nif ('dotAll' in RegExp.prototype) expected.push('dotAll');\nif ('unicode' in RegExp.prototype) expected.push('unicode');\nif ('sticky' in RegExp.prototype) expected.push('sticky');\nvar actual = [];\nvar p = new Proxy({}, { get: function (o, k) { actual.push(k); return o[k]; }});\nObject.getOwnPropertyDescriptor(RegExp.prototype, 'flags').get.call(p);\nif (expected.length !== actual.length) return false;\nfor (var i = 0; i < expected.length; i++) {\n  if (expected[i] !== actual[i]) return false;\n}\nreturn true;\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+return flags.indexOf(&quot;hasIndices&quot;) !== -1;
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("229");try{return Function("asyncTestPassed","\nvar flags = [];\nvar p = new Proxy({}, { get: function (o, k) { flags.push(k); return o[k]; }});\nObject.getOwnPropertyDescriptor(RegExp.prototype, 'flags').get.call(p);\nreturn flags.indexOf(\"hasIndices\") !== -1;\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("229");return Function("asyncTestPassed","'use strict';"+"\nvar flags = [];\nvar p = new Proxy({}, { get: function (o, k) { flags.push(k); return o[k]; }});\nObject.getOwnPropertyDescriptor(RegExp.prototype, 'flags').get.call(p);\nreturn flags.indexOf(\"hasIndices\") !== -1;\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -38169,51 +38157,51 @@ return true;
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes" data-browser="firefox115">Yes</td>
-<td class="no obsolete" data-browser="firefox120">No</td>
-<td class="no obsolete" data-browser="firefox121">No</td>
-<td class="no obsolete" data-browser="firefox122">No</td>
-<td class="no obsolete" data-browser="firefox123">No</td>
-<td class="no obsolete" data-browser="firefox124">No</td>
-<td class="no obsolete" data-browser="firefox125">No</td>
-<td class="no obsolete" data-browser="firefox126">No</td>
-<td class="no obsolete" data-browser="firefox127">No</td>
-<td class="no" data-browser="firefox128">No</td>
-<td class="no obsolete" data-browser="firefox129">No</td>
-<td class="no obsolete" data-browser="firefox130">No</td>
-<td class="no obsolete" data-browser="firefox131">No</td>
-<td class="no obsolete" data-browser="firefox132">No</td>
-<td class="no" data-browser="firefox133">No</td>
-<td class="no unstable" data-browser="firefox134">No</td>
-<td class="no unstable" data-browser="firefox135">No</td>
+<td class="yes obsolete" data-browser="firefox120">Yes</td>
+<td class="yes obsolete" data-browser="firefox121">Yes</td>
+<td class="yes obsolete" data-browser="firefox122">Yes</td>
+<td class="yes obsolete" data-browser="firefox123">Yes</td>
+<td class="yes obsolete" data-browser="firefox124">Yes</td>
+<td class="yes obsolete" data-browser="firefox125">Yes</td>
+<td class="yes obsolete" data-browser="firefox126">Yes</td>
+<td class="yes obsolete" data-browser="firefox127">Yes</td>
+<td class="yes" data-browser="firefox128">Yes</td>
+<td class="yes obsolete" data-browser="firefox129">Yes</td>
+<td class="yes obsolete" data-browser="firefox130">Yes</td>
+<td class="yes obsolete" data-browser="firefox131">Yes</td>
+<td class="yes obsolete" data-browser="firefox132">Yes</td>
+<td class="yes" data-browser="firefox133">Yes</td>
+<td class="yes unstable" data-browser="firefox134">Yes</td>
+<td class="yes unstable" data-browser="firefox135">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
-<td class="no obsolete" data-browser="chrome119">No</td>
-<td class="no obsolete" data-browser="chrome120">No</td>
-<td class="no obsolete" data-browser="chrome121">No</td>
-<td class="no obsolete" data-browser="chrome122">No</td>
-<td class="no obsolete" data-browser="chrome123">No</td>
-<td class="no obsolete" data-browser="chrome124">No</td>
-<td class="no obsolete" data-browser="chrome125">No</td>
-<td class="no obsolete" data-browser="chrome126">No</td>
-<td class="no obsolete" data-browser="chrome127">No</td>
-<td class="no obsolete" data-browser="chrome128">No</td>
-<td class="no obsolete" data-browser="chrome129">No</td>
-<td class="no" data-browser="chrome130">No</td>
-<td class="no unstable" data-browser="chrome131">No</td>
-<td class="no unstable" data-browser="chrome132">No</td>
+<td class="yes obsolete" data-browser="chrome119">Yes</td>
+<td class="yes obsolete" data-browser="chrome120">Yes</td>
+<td class="yes obsolete" data-browser="chrome121">Yes</td>
+<td class="yes obsolete" data-browser="chrome122">Yes</td>
+<td class="yes obsolete" data-browser="chrome123">Yes</td>
+<td class="yes obsolete" data-browser="chrome124">Yes</td>
+<td class="yes obsolete" data-browser="chrome125">Yes</td>
+<td class="yes obsolete" data-browser="chrome126">Yes</td>
+<td class="yes obsolete" data-browser="chrome127">Yes</td>
+<td class="yes obsolete" data-browser="chrome128">Yes</td>
+<td class="yes obsolete" data-browser="chrome129">Yes</td>
+<td class="yes" data-browser="chrome130">Yes</td>
+<td class="yes unstable" data-browser="chrome131">Yes</td>
+<td class="yes unstable" data-browser="chrome132">Yes</td>
 <td class="no obsolete" data-browser="edge18">No</td>
-<td class="no obsolete" data-browser="edge119">No</td>
-<td class="no obsolete" data-browser="edge120">No</td>
-<td class="no obsolete" data-browser="edge121">No</td>
-<td class="no obsolete" data-browser="edge122">No</td>
-<td class="no obsolete" data-browser="edge123">No</td>
-<td class="no obsolete" data-browser="edge124">No</td>
-<td class="no obsolete" data-browser="edge125">No</td>
-<td class="no obsolete" data-browser="edge126">No</td>
-<td class="no obsolete" data-browser="edge127">No</td>
-<td class="no obsolete" data-browser="edge128">No</td>
-<td class="no obsolete" data-browser="edge129">No</td>
-<td class="no" data-browser="edge130">No</td>
-<td class="no unstable" data-browser="edge131">No</td>
+<td class="yes obsolete" data-browser="edge119">Yes</td>
+<td class="yes obsolete" data-browser="edge120">Yes</td>
+<td class="yes obsolete" data-browser="edge121">Yes</td>
+<td class="yes obsolete" data-browser="edge122">Yes</td>
+<td class="yes obsolete" data-browser="edge123">Yes</td>
+<td class="yes obsolete" data-browser="edge124">Yes</td>
+<td class="yes obsolete" data-browser="edge125">Yes</td>
+<td class="yes obsolete" data-browser="edge126">Yes</td>
+<td class="yes obsolete" data-browser="edge127">Yes</td>
+<td class="yes obsolete" data-browser="edge128">Yes</td>
+<td class="yes obsolete" data-browser="edge129">Yes</td>
+<td class="yes" data-browser="edge130">Yes</td>
+<td class="yes unstable" data-browser="edge131">Yes</td>
 <td class="yes obsolete" data-browser="safari15_6">Yes</td>
 <td class="yes obsolete" data-browser="safari16_6">Yes</td>
 <td class="yes obsolete" data-browser="safari17">Yes</td>
@@ -38226,17 +38214,17 @@ return true;
 <td class="yes" data-browser="safari18">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="no obsolete" data-browser="opera102">No</td>
-<td class="no obsolete" data-browser="opera103">No</td>
-<td class="no obsolete" data-browser="opera104">No</td>
-<td class="no obsolete" data-browser="opera105">No</td>
-<td class="no obsolete" data-browser="opera106">No</td>
-<td class="no obsolete" data-browser="opera107">No</td>
-<td class="no obsolete" data-browser="opera108">No</td>
-<td class="no obsolete" data-browser="opera109">No</td>
-<td class="no obsolete" data-browser="opera110">No</td>
-<td class="no" data-browser="opera111">No</td>
-<td class="no unstable" data-browser="opera112">No</td>
+<td class="yes obsolete" data-browser="opera102">Yes</td>
+<td class="yes obsolete" data-browser="opera103">Yes</td>
+<td class="yes obsolete" data-browser="opera104">Yes</td>
+<td class="yes obsolete" data-browser="opera105">Yes</td>
+<td class="yes obsolete" data-browser="opera106">Yes</td>
+<td class="yes obsolete" data-browser="opera107">Yes</td>
+<td class="yes obsolete" data-browser="opera108">Yes</td>
+<td class="yes obsolete" data-browser="opera109">Yes</td>
+<td class="yes obsolete" data-browser="opera110">Yes</td>
+<td class="yes" data-browser="opera111">Yes</td>
+<td class="yes unstable" data-browser="opera112">Yes</td>
 <td class="unknown obsolete" data-browser="rhino1_7_13">?</td>
 <td class="unknown obsolete" data-browser="rhino1_7_14">?</td>
 <td class="no obsolete" data-browser="rhino1_7_15">No</td>
@@ -38248,18 +38236,18 @@ return true;
 <td class="unknown obsolete" data-browser="node0_12">?</td>
 <td class="unknown obsolete" data-browser="node14_6">?</td>
 <td class="no obsolete" data-browser="node16_0">No</td>
-<td class="no obsolete" data-browser="node16_9">No</td>
-<td class="no" data-browser="node16_11">No</td>
-<td class="no obsolete" data-browser="node17_0">No</td>
-<td class="no obsolete" data-browser="node17_2">No</td>
-<td class="no obsolete" data-browser="node18_0">No</td>
-<td class="no" data-browser="node18_3">No</td>
-<td class="no obsolete" data-browser="node19_0">No</td>
-<td class="no obsolete" data-browser="node19_2">No</td>
-<td class="no" data-browser="node20_0">No</td>
-<td class="no obsolete" data-browser="node21_0">No</td>
-<td class="no" data-browser="node22_0">No</td>
-<td class="no" data-browser="node23_0">No</td>
+<td class="yes obsolete" data-browser="node16_9">Yes</td>
+<td class="yes" data-browser="node16_11">Yes</td>
+<td class="yes obsolete" data-browser="node17_0">Yes</td>
+<td class="yes obsolete" data-browser="node17_2">Yes</td>
+<td class="yes obsolete" data-browser="node18_0">Yes</td>
+<td class="yes" data-browser="node18_3">Yes</td>
+<td class="yes obsolete" data-browser="node19_0">Yes</td>
+<td class="yes obsolete" data-browser="node19_2">Yes</td>
+<td class="yes" data-browser="node20_0">Yes</td>
+<td class="yes obsolete" data-browser="node21_0">Yes</td>
+<td class="yes" data-browser="node22_0">Yes</td>
+<td class="yes" data-browser="node23_0">Yes</td>
 <td class="unknown obsolete" data-browser="duktape2_6">?</td>
 <td class="unknown" data-browser="duktape2_7">?</td>
 <td class="unknown obsolete" data-browser="jerryscript2_3_0">?</td>
@@ -38275,10 +38263,10 @@ return true;
 <td class="yes" data-browser="graalvm22_2">Yes</td>
 <td class="no obsolete" data-browser="hermes0_7_0">No</td>
 <td class="no" data-browser="hermes0_12_0">No</td>
-<td class="no obsolete" data-browser="deno1_33">No</td>
-<td class="no obsolete" data-browser="deno1_34">No</td>
-<td class="no obsolete" data-browser="deno1_35">No</td>
-<td class="no" data-browser="deno1_36">No</td>
+<td class="yes obsolete" data-browser="deno1_33">Yes</td>
+<td class="yes obsolete" data-browser="deno1_34">Yes</td>
+<td class="yes obsolete" data-browser="deno1_35">Yes</td>
+<td class="yes" data-browser="deno1_36">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios12_2">?</td>
@@ -38293,16 +38281,16 @@ return true;
 <td class="yes obsolete" data-browser="ios17_5">Yes</td>
 <td class="yes obsolete" data-browser="ios17_6">Yes</td>
 <td class="yes" data-browser="ios18">Yes</td>
-<td class="no obsolete" data-browser="samsung19">No</td>
-<td class="no obsolete" data-browser="samsung20">No</td>
-<td class="no obsolete" data-browser="samsung21">No</td>
-<td class="no" data-browser="samsung22">No</td>
-<td class="no obsolete" data-browser="opera_mobile72">No</td>
-<td class="no obsolete" data-browser="opera_mobile73">No</td>
-<td class="no obsolete" data-browser="opera_mobile74">No</td>
-<td class="no obsolete" data-browser="opera_mobile75">No</td>
-<td class="no obsolete" data-browser="opera_mobile76">No</td>
-<td class="no" data-browser="opera_mobile77">No</td>
+<td class="yes obsolete" data-browser="samsung19">Yes</td>
+<td class="yes obsolete" data-browser="samsung20">Yes</td>
+<td class="yes obsolete" data-browser="samsung21">Yes</td>
+<td class="yes" data-browser="samsung22">Yes</td>
+<td class="yes obsolete" data-browser="opera_mobile72">Yes</td>
+<td class="yes obsolete" data-browser="opera_mobile73">Yes</td>
+<td class="yes obsolete" data-browser="opera_mobile74">Yes</td>
+<td class="yes obsolete" data-browser="opera_mobile75">Yes</td>
+<td class="yes obsolete" data-browser="opera_mobile76">Yes</td>
+<td class="yes" data-browser="opera_mobile77">Yes</td>
 <td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
 <tr class="category"><td colspan="160"><span>2023 features</span></td>

--- a/es6/index.html
+++ b/es6/index.html
@@ -112714,34 +112714,34 @@ return correctProtoBound(function(){})
 <td class="tally unstable" data-browser="firefox134" data-tally="1">36/36</td>
 <td class="tally unstable" data-browser="firefox135" data-tally="1">36/36</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/36</td>
-<td class="tally obsolete" data-browser="chrome119" data-tally="1">36/36</td>
-<td class="tally obsolete" data-browser="chrome120" data-tally="1">36/36</td>
-<td class="tally obsolete" data-browser="chrome121" data-tally="1">36/36</td>
-<td class="tally obsolete" data-browser="chrome122" data-tally="1">36/36</td>
-<td class="tally obsolete" data-browser="chrome123" data-tally="1">36/36</td>
-<td class="tally obsolete" data-browser="chrome124" data-tally="1">36/36</td>
-<td class="tally obsolete" data-browser="chrome125" data-tally="1">36/36</td>
-<td class="tally obsolete" data-browser="chrome126" data-tally="1">36/36</td>
-<td class="tally obsolete" data-browser="chrome127" data-tally="1">36/36</td>
-<td class="tally obsolete" data-browser="chrome128" data-tally="1">36/36</td>
-<td class="tally obsolete" data-browser="chrome129" data-tally="1">36/36</td>
-<td class="tally" data-browser="chrome130" data-tally="1">36/36</td>
-<td class="tally unstable" data-browser="chrome131" data-tally="1">36/36</td>
-<td class="tally unstable" data-browser="chrome132" data-tally="1">36/36</td>
+<td class="tally obsolete" data-browser="chrome119" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)">35/36</td>
+<td class="tally obsolete" data-browser="chrome120" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)">35/36</td>
+<td class="tally obsolete" data-browser="chrome121" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)">35/36</td>
+<td class="tally obsolete" data-browser="chrome122" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)">35/36</td>
+<td class="tally obsolete" data-browser="chrome123" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)">35/36</td>
+<td class="tally obsolete" data-browser="chrome124" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)">35/36</td>
+<td class="tally obsolete" data-browser="chrome125" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)">35/36</td>
+<td class="tally obsolete" data-browser="chrome126" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)">35/36</td>
+<td class="tally obsolete" data-browser="chrome127" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)">35/36</td>
+<td class="tally obsolete" data-browser="chrome128" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)">35/36</td>
+<td class="tally obsolete" data-browser="chrome129" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)">35/36</td>
+<td class="tally" data-browser="chrome130" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)">35/36</td>
+<td class="tally unstable" data-browser="chrome131" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)">35/36</td>
+<td class="tally unstable" data-browser="chrome132" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)">35/36</td>
 <td class="tally obsolete" data-browser="edge18" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)" data-flagged-tally="0.9722222222222222">24/36</td>
-<td class="tally obsolete" data-browser="edge119" data-tally="1">36/36</td>
-<td class="tally obsolete" data-browser="edge120" data-tally="1">36/36</td>
-<td class="tally obsolete" data-browser="edge121" data-tally="1">36/36</td>
-<td class="tally obsolete" data-browser="edge122" data-tally="1">36/36</td>
-<td class="tally obsolete" data-browser="edge123" data-tally="1">36/36</td>
-<td class="tally obsolete" data-browser="edge124" data-tally="1">36/36</td>
-<td class="tally obsolete" data-browser="edge125" data-tally="1">36/36</td>
-<td class="tally obsolete" data-browser="edge126" data-tally="1">36/36</td>
-<td class="tally obsolete" data-browser="edge127" data-tally="1">36/36</td>
-<td class="tally obsolete" data-browser="edge128" data-tally="1">36/36</td>
-<td class="tally obsolete" data-browser="edge129" data-tally="1">36/36</td>
-<td class="tally" data-browser="edge130" data-tally="1">36/36</td>
-<td class="tally unstable" data-browser="edge131" data-tally="1">36/36</td>
+<td class="tally obsolete" data-browser="edge119" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)">35/36</td>
+<td class="tally obsolete" data-browser="edge120" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)">35/36</td>
+<td class="tally obsolete" data-browser="edge121" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)">35/36</td>
+<td class="tally obsolete" data-browser="edge122" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)">35/36</td>
+<td class="tally obsolete" data-browser="edge123" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)">35/36</td>
+<td class="tally obsolete" data-browser="edge124" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)">35/36</td>
+<td class="tally obsolete" data-browser="edge125" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)">35/36</td>
+<td class="tally obsolete" data-browser="edge126" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)">35/36</td>
+<td class="tally obsolete" data-browser="edge127" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)">35/36</td>
+<td class="tally obsolete" data-browser="edge128" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)">35/36</td>
+<td class="tally obsolete" data-browser="edge129" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)">35/36</td>
+<td class="tally" data-browser="edge130" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)">35/36</td>
+<td class="tally unstable" data-browser="edge131" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)">35/36</td>
 <td class="tally obsolete" data-browser="safari15_6" data-tally="1">36/36</td>
 <td class="tally obsolete" data-browser="safari16_6" data-tally="1">36/36</td>
 <td class="tally obsolete" data-browser="safari17" data-tally="1">36/36</td>
@@ -112754,17 +112754,17 @@ return correctProtoBound(function(){})
 <td class="tally" data-browser="safari18" data-tally="1">36/36</td>
 <td class="tally unstable" data-browser="safaritp" data-tally="1">36/36</td>
 <td class="tally unstable" data-browser="webkit" data-tally="1">36/36</td>
-<td class="tally obsolete" data-browser="opera102" data-tally="1">36/36</td>
-<td class="tally obsolete" data-browser="opera103" data-tally="1">36/36</td>
-<td class="tally obsolete" data-browser="opera104" data-tally="1">36/36</td>
-<td class="tally obsolete" data-browser="opera105" data-tally="1">36/36</td>
-<td class="tally obsolete" data-browser="opera106" data-tally="1">36/36</td>
-<td class="tally obsolete" data-browser="opera107" data-tally="1">36/36</td>
-<td class="tally obsolete" data-browser="opera108" data-tally="1">36/36</td>
-<td class="tally obsolete" data-browser="opera109" data-tally="1">36/36</td>
-<td class="tally obsolete" data-browser="opera110" data-tally="1">36/36</td>
-<td class="tally" data-browser="opera111" data-tally="1">36/36</td>
-<td class="tally unstable" data-browser="opera112" data-tally="1">36/36</td>
+<td class="tally obsolete" data-browser="opera102" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)">35/36</td>
+<td class="tally obsolete" data-browser="opera103" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)">35/36</td>
+<td class="tally obsolete" data-browser="opera104" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)">35/36</td>
+<td class="tally obsolete" data-browser="opera105" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)">35/36</td>
+<td class="tally obsolete" data-browser="opera106" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)">35/36</td>
+<td class="tally obsolete" data-browser="opera107" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)">35/36</td>
+<td class="tally obsolete" data-browser="opera108" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)">35/36</td>
+<td class="tally obsolete" data-browser="opera109" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)">35/36</td>
+<td class="tally obsolete" data-browser="opera110" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)">35/36</td>
+<td class="tally" data-browser="opera111" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)">35/36</td>
+<td class="tally unstable" data-browser="opera112" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)">35/36</td>
 <td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/36</td>
 <td class="tally obsolete" data-browser="rhino1_7_14" data-tally="0">0/36</td>
 <td class="tally obsolete" data-browser="rhino1_7_15" data-tally="0">0/36</td>
@@ -112778,7 +112778,7 @@ return correctProtoBound(function(){})
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/36</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/36</td>
 <td class="tally obsolete" data-browser="node14_6" data-tally="1">36/36</td>
-<td class="tally obsolete" data-browser="node16_0" data-tally="1">36/36</td>
+<td class="tally obsolete" data-browser="node16_0" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)">35/36</td>
 <td class="tally obsolete" data-browser="node16_9" data-tally="1">36/36</td>
 <td class="tally" data-browser="node16_11" data-tally="1">36/36</td>
 <td class="tally obsolete" data-browser="node17_0" data-tally="1">36/36</td>
@@ -112787,10 +112787,10 @@ return correctProtoBound(function(){})
 <td class="tally" data-browser="node18_3" data-tally="1">36/36</td>
 <td class="tally obsolete" data-browser="node19_0" data-tally="1">36/36</td>
 <td class="tally obsolete" data-browser="node19_2" data-tally="1">36/36</td>
-<td class="tally" data-browser="node20_0" data-tally="1">36/36</td>
-<td class="tally obsolete" data-browser="node21_0" data-tally="1">36/36</td>
-<td class="tally" data-browser="node22_0" data-tally="1">36/36</td>
-<td class="tally" data-browser="node23_0" data-tally="1">36/36</td>
+<td class="tally" data-browser="node20_0" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)">35/36</td>
+<td class="tally obsolete" data-browser="node21_0" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)">35/36</td>
+<td class="tally" data-browser="node22_0" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)">35/36</td>
+<td class="tally" data-browser="node23_0" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)">35/36</td>
 <td class="tally obsolete" data-browser="duktape2_6" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">12/36</td>
 <td class="tally" data-browser="duktape2_7" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">12/36</td>
 <td class="tally obsolete" data-browser="jerryscript1_0" data-tally="0">0/36</td>
@@ -112813,10 +112813,10 @@ return correctProtoBound(function(){})
 <td class="tally" data-browser="graalvm22_2" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)" data-flagged-tally="1">35/36</td>
 <td class="tally obsolete" data-browser="hermes0_7_0" data-tally="0.7777777777777778" style="background-color:hsl(93,51%,50%)">28/36</td>
 <td class="tally" data-browser="hermes0_12_0" data-tally="0.8055555555555556" style="background-color:hsl(96,50%,50%)">29/36</td>
-<td class="tally obsolete" data-browser="deno1_33" data-tally="1">36/36</td>
-<td class="tally obsolete" data-browser="deno1_34" data-tally="1">36/36</td>
-<td class="tally obsolete" data-browser="deno1_35" data-tally="1">36/36</td>
-<td class="tally" data-browser="deno1_36" data-tally="1">36/36</td>
+<td class="tally obsolete" data-browser="deno1_33" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)">35/36</td>
+<td class="tally obsolete" data-browser="deno1_34" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)">35/36</td>
+<td class="tally obsolete" data-browser="deno1_35" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)">35/36</td>
+<td class="tally" data-browser="deno1_36" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)">35/36</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/36</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/36</td>
 <td class="tally obsolete" data-browser="ios12_2" data-tally="1">36/36</td>
@@ -112838,9 +112838,9 @@ return correctProtoBound(function(){})
 <td class="tally obsolete" data-browser="opera_mobile72" data-tally="1">36/36</td>
 <td class="tally obsolete" data-browser="opera_mobile73" data-tally="1">36/36</td>
 <td class="tally obsolete" data-browser="opera_mobile74" data-tally="1">36/36</td>
-<td class="tally obsolete" data-browser="opera_mobile75" data-tally="1">36/36</td>
-<td class="tally obsolete" data-browser="opera_mobile76" data-tally="1">36/36</td>
-<td class="tally" data-browser="opera_mobile77" data-tally="1">36/36</td>
+<td class="tally obsolete" data-browser="opera_mobile75" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)">35/36</td>
+<td class="tally obsolete" data-browser="opera_mobile76" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)">35/36</td>
+<td class="tally" data-browser="opera_mobile77" data-tally="0.9722222222222222" style="background-color:hsl(116,43%,50%)">35/36</td>
 <td class="tally" data-browser="reactnative0_70_3" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">30/36</td>
 </tr>
 <tr class="subtest" data-parent="Proxy,_internal_&apos;get&apos;_calls" id="test-Proxy,_internal_&apos;get&apos;_calls_ToPrimitive"><td><span><a class="anchor" href="#test-Proxy,_internal_&apos;get&apos;_calls_ToPrimitive">&#xA7;</a>ToPrimitive</span><script data-source="
@@ -115392,7 +115392,7 @@ return get[0] === Symbol.match &amp;&amp; get.slice(1) + &apos;&apos; === &quot;
 <tr class="subtest" data-parent="Proxy,_internal_&apos;get&apos;_calls" id="test-Proxy,_internal_&apos;get&apos;_calls_RegExp.prototype.flags"><td><span><a class="anchor" href="#test-Proxy,_internal_&apos;get&apos;_calls_RegExp.prototype.flags">&#xA7;</a>RegExp.prototype.flags</span><script data-source="
 // RegExp.prototype.flags -&gt; Get -&gt; [[Get]]
 var expected = [];
-// Sorted alphabetically by shortname &#x2013; &quot;gimsuy&quot;.
+// Sorted alphabetically by shortname &#x2013; &quot;gimsuvy&quot;.
 if (&apos;hasIndices&apos; in RegExp.prototype) expected.push(&apos;hasIndices&apos;);
 if (&apos;global&apos; in RegExp.prototype) expected.push(&apos;global&apos;);
 if (&apos;ignoreCase&apos; in RegExp.prototype) expected.push(&apos;ignoreCase&apos;);
@@ -115410,7 +115410,7 @@ for (var i = 0; i &lt; expected.length; i++) {
   if (expected[i] !== actual[i]) return false;
 }
 return true;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("638");try{return Function("asyncTestPassed","\n// RegExp.prototype.flags -> Get -> [[Get]]\nvar expected = [];\n// Sorted alphabetically by shortname – \"gimsuy\".\nif ('hasIndices' in RegExp.prototype) expected.push('hasIndices');\nif ('global' in RegExp.prototype) expected.push('global');\nif ('ignoreCase' in RegExp.prototype) expected.push('ignoreCase');\nif ('multiline' in RegExp.prototype) expected.push('multiline');\nif ('dotAll' in RegExp.prototype) expected.push('dotAll');\nif ('unicode' in RegExp.prototype) expected.push('unicode');\nif ('unicodeSets' in RegExp.prototype) expected.push('unicodeSets');\nif ('sticky' in RegExp.prototype) expected.push('sticky');\n\nvar actual = [];\nvar p = new Proxy({}, { get: function(o, k) { actual.push(k); return o[k]; }});\nObject.getOwnPropertyDescriptor(RegExp.prototype, 'flags').get.call(p);\nif (expected.length !== actual.length) return false;\nfor (var i = 0; i < expected.length; i++) {\n  if (expected[i] !== actual[i]) return false;\n}\nreturn true;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("638");return Function("asyncTestPassed","'use strict';"+"\n// RegExp.prototype.flags -> Get -> [[Get]]\nvar expected = [];\n// Sorted alphabetically by shortname – \"gimsuy\".\nif ('hasIndices' in RegExp.prototype) expected.push('hasIndices');\nif ('global' in RegExp.prototype) expected.push('global');\nif ('ignoreCase' in RegExp.prototype) expected.push('ignoreCase');\nif ('multiline' in RegExp.prototype) expected.push('multiline');\nif ('dotAll' in RegExp.prototype) expected.push('dotAll');\nif ('unicode' in RegExp.prototype) expected.push('unicode');\nif ('unicodeSets' in RegExp.prototype) expected.push('unicodeSets');\nif ('sticky' in RegExp.prototype) expected.push('sticky');\n\nvar actual = [];\nvar p = new Proxy({}, { get: function(o, k) { actual.push(k); return o[k]; }});\nObject.getOwnPropertyDescriptor(RegExp.prototype, 'flags').get.call(p);\nif (expected.length !== actual.length) return false;\nfor (var i = 0; i < expected.length; i++) {\n  if (expected[i] !== actual[i]) return false;\n}\nreturn true;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("638");try{return Function("asyncTestPassed","\n// RegExp.prototype.flags -> Get -> [[Get]]\nvar expected = [];\n// Sorted alphabetically by shortname – \"gimsuvy\".\nif ('hasIndices' in RegExp.prototype) expected.push('hasIndices');\nif ('global' in RegExp.prototype) expected.push('global');\nif ('ignoreCase' in RegExp.prototype) expected.push('ignoreCase');\nif ('multiline' in RegExp.prototype) expected.push('multiline');\nif ('dotAll' in RegExp.prototype) expected.push('dotAll');\nif ('unicode' in RegExp.prototype) expected.push('unicode');\nif ('unicodeSets' in RegExp.prototype) expected.push('unicodeSets');\nif ('sticky' in RegExp.prototype) expected.push('sticky');\n\nvar actual = [];\nvar p = new Proxy({}, { get: function(o, k) { actual.push(k); return o[k]; }});\nObject.getOwnPropertyDescriptor(RegExp.prototype, 'flags').get.call(p);\nif (expected.length !== actual.length) return false;\nfor (var i = 0; i < expected.length; i++) {\n  if (expected[i] !== actual[i]) return false;\n}\nreturn true;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("638");return Function("asyncTestPassed","'use strict';"+"\n// RegExp.prototype.flags -> Get -> [[Get]]\nvar expected = [];\n// Sorted alphabetically by shortname – \"gimsuvy\".\nif ('hasIndices' in RegExp.prototype) expected.push('hasIndices');\nif ('global' in RegExp.prototype) expected.push('global');\nif ('ignoreCase' in RegExp.prototype) expected.push('ignoreCase');\nif ('multiline' in RegExp.prototype) expected.push('multiline');\nif ('dotAll' in RegExp.prototype) expected.push('dotAll');\nif ('unicode' in RegExp.prototype) expected.push('unicode');\nif ('unicodeSets' in RegExp.prototype) expected.push('unicodeSets');\nif ('sticky' in RegExp.prototype) expected.push('sticky');\n\nvar actual = [];\nvar p = new Proxy({}, { get: function(o, k) { actual.push(k); return o[k]; }});\nObject.getOwnPropertyDescriptor(RegExp.prototype, 'flags').get.call(p);\nif (expected.length !== actual.length) return false;\nfor (var i = 0; i < expected.length; i++) {\n  if (expected[i] !== actual[i]) return false;\n}\nreturn true;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="es6tr">?</td>
 <td class="unknown obsolete" data-browser="tr">?</td>
@@ -115455,34 +115455,34 @@ return true;
 <td class="yes unstable" data-browser="firefox134">Yes</td>
 <td class="yes unstable" data-browser="firefox135">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
-<td class="yes obsolete" data-browser="chrome119">Yes</td>
-<td class="yes obsolete" data-browser="chrome120">Yes</td>
-<td class="yes obsolete" data-browser="chrome121">Yes</td>
-<td class="yes obsolete" data-browser="chrome122">Yes</td>
-<td class="yes obsolete" data-browser="chrome123">Yes</td>
-<td class="yes obsolete" data-browser="chrome124">Yes</td>
-<td class="yes obsolete" data-browser="chrome125">Yes</td>
-<td class="yes obsolete" data-browser="chrome126">Yes</td>
-<td class="yes obsolete" data-browser="chrome127">Yes</td>
-<td class="yes obsolete" data-browser="chrome128">Yes</td>
-<td class="yes obsolete" data-browser="chrome129">Yes</td>
-<td class="yes" data-browser="chrome130">Yes</td>
-<td class="yes unstable" data-browser="chrome131">Yes</td>
-<td class="yes unstable" data-browser="chrome132">Yes</td>
+<td class="no obsolete" data-browser="chrome119">No<a href="#v8-regex-flags-order-note"><sup>[35]</sup></a></td>
+<td class="no obsolete" data-browser="chrome120">No<a href="#v8-regex-flags-order-note"><sup>[35]</sup></a></td>
+<td class="no obsolete" data-browser="chrome121">No<a href="#v8-regex-flags-order-note"><sup>[35]</sup></a></td>
+<td class="no obsolete" data-browser="chrome122">No<a href="#v8-regex-flags-order-note"><sup>[35]</sup></a></td>
+<td class="no obsolete" data-browser="chrome123">No<a href="#v8-regex-flags-order-note"><sup>[35]</sup></a></td>
+<td class="no obsolete" data-browser="chrome124">No<a href="#v8-regex-flags-order-note"><sup>[35]</sup></a></td>
+<td class="no obsolete" data-browser="chrome125">No<a href="#v8-regex-flags-order-note"><sup>[35]</sup></a></td>
+<td class="no obsolete" data-browser="chrome126">No<a href="#v8-regex-flags-order-note"><sup>[35]</sup></a></td>
+<td class="no obsolete" data-browser="chrome127">No<a href="#v8-regex-flags-order-note"><sup>[35]</sup></a></td>
+<td class="no obsolete" data-browser="chrome128">No<a href="#v8-regex-flags-order-note"><sup>[35]</sup></a></td>
+<td class="no obsolete" data-browser="chrome129">No<a href="#v8-regex-flags-order-note"><sup>[35]</sup></a></td>
+<td class="no" data-browser="chrome130">No<a href="#v8-regex-flags-order-note"><sup>[35]</sup></a></td>
+<td class="no unstable" data-browser="chrome131">No<a href="#v8-regex-flags-order-note"><sup>[35]</sup></a></td>
+<td class="no unstable" data-browser="chrome132">No<a href="#v8-regex-flags-order-note"><sup>[35]</sup></a></td>
 <td class="no flagged obsolete" data-browser="edge18">Flag<a href="#edge-experimental-flag-note"><sup>[30]</sup></a></td>
-<td class="yes obsolete" data-browser="edge119">Yes</td>
-<td class="yes obsolete" data-browser="edge120">Yes</td>
-<td class="yes obsolete" data-browser="edge121">Yes</td>
-<td class="yes obsolete" data-browser="edge122">Yes</td>
-<td class="yes obsolete" data-browser="edge123">Yes</td>
-<td class="yes obsolete" data-browser="edge124">Yes</td>
-<td class="yes obsolete" data-browser="edge125">Yes</td>
-<td class="yes obsolete" data-browser="edge126">Yes</td>
-<td class="yes obsolete" data-browser="edge127">Yes</td>
-<td class="yes obsolete" data-browser="edge128">Yes</td>
-<td class="yes obsolete" data-browser="edge129">Yes</td>
-<td class="yes" data-browser="edge130">Yes</td>
-<td class="yes unstable" data-browser="edge131">Yes</td>
+<td class="no obsolete" data-browser="edge119">No<a href="#v8-regex-flags-order-note"><sup>[35]</sup></a></td>
+<td class="no obsolete" data-browser="edge120">No<a href="#v8-regex-flags-order-note"><sup>[35]</sup></a></td>
+<td class="no obsolete" data-browser="edge121">No<a href="#v8-regex-flags-order-note"><sup>[35]</sup></a></td>
+<td class="no obsolete" data-browser="edge122">No<a href="#v8-regex-flags-order-note"><sup>[35]</sup></a></td>
+<td class="no obsolete" data-browser="edge123">No<a href="#v8-regex-flags-order-note"><sup>[35]</sup></a></td>
+<td class="no obsolete" data-browser="edge124">No<a href="#v8-regex-flags-order-note"><sup>[35]</sup></a></td>
+<td class="no obsolete" data-browser="edge125">No<a href="#v8-regex-flags-order-note"><sup>[35]</sup></a></td>
+<td class="no obsolete" data-browser="edge126">No<a href="#v8-regex-flags-order-note"><sup>[35]</sup></a></td>
+<td class="no obsolete" data-browser="edge127">No<a href="#v8-regex-flags-order-note"><sup>[35]</sup></a></td>
+<td class="no obsolete" data-browser="edge128">No<a href="#v8-regex-flags-order-note"><sup>[35]</sup></a></td>
+<td class="no obsolete" data-browser="edge129">No<a href="#v8-regex-flags-order-note"><sup>[35]</sup></a></td>
+<td class="no" data-browser="edge130">No<a href="#v8-regex-flags-order-note"><sup>[35]</sup></a></td>
+<td class="no unstable" data-browser="edge131">No<a href="#v8-regex-flags-order-note"><sup>[35]</sup></a></td>
 <td class="yes obsolete" data-browser="safari15_6">Yes</td>
 <td class="yes obsolete" data-browser="safari16_6">Yes</td>
 <td class="yes obsolete" data-browser="safari17">Yes</td>
@@ -115495,17 +115495,17 @@ return true;
 <td class="yes" data-browser="safari18">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
-<td class="yes obsolete" data-browser="opera102">Yes</td>
-<td class="yes obsolete" data-browser="opera103">Yes</td>
-<td class="yes obsolete" data-browser="opera104">Yes</td>
-<td class="yes obsolete" data-browser="opera105">Yes</td>
-<td class="yes obsolete" data-browser="opera106">Yes</td>
-<td class="yes obsolete" data-browser="opera107">Yes</td>
-<td class="yes obsolete" data-browser="opera108">Yes</td>
-<td class="yes obsolete" data-browser="opera109">Yes</td>
-<td class="yes obsolete" data-browser="opera110">Yes</td>
-<td class="yes" data-browser="opera111">Yes</td>
-<td class="yes unstable" data-browser="opera112">Yes</td>
+<td class="no obsolete" data-browser="opera102">No<a href="#v8-regex-flags-order-note"><sup>[35]</sup></a></td>
+<td class="no obsolete" data-browser="opera103">No<a href="#v8-regex-flags-order-note"><sup>[35]</sup></a></td>
+<td class="no obsolete" data-browser="opera104">No<a href="#v8-regex-flags-order-note"><sup>[35]</sup></a></td>
+<td class="no obsolete" data-browser="opera105">No<a href="#v8-regex-flags-order-note"><sup>[35]</sup></a></td>
+<td class="no obsolete" data-browser="opera106">No<a href="#v8-regex-flags-order-note"><sup>[35]</sup></a></td>
+<td class="no obsolete" data-browser="opera107">No<a href="#v8-regex-flags-order-note"><sup>[35]</sup></a></td>
+<td class="no obsolete" data-browser="opera108">No<a href="#v8-regex-flags-order-note"><sup>[35]</sup></a></td>
+<td class="no obsolete" data-browser="opera109">No<a href="#v8-regex-flags-order-note"><sup>[35]</sup></a></td>
+<td class="no obsolete" data-browser="opera110">No<a href="#v8-regex-flags-order-note"><sup>[35]</sup></a></td>
+<td class="no" data-browser="opera111">No<a href="#v8-regex-flags-order-note"><sup>[35]</sup></a></td>
+<td class="no unstable" data-browser="opera112">No<a href="#v8-regex-flags-order-note"><sup>[35]</sup></a></td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="rhino1_7_14">No</td>
 <td class="no obsolete" data-browser="rhino1_7_15">No</td>
@@ -115519,7 +115519,7 @@ return true;
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
 <td class="yes obsolete" data-browser="node14_6">Yes</td>
-<td class="yes obsolete" data-browser="node16_0">Yes</td>
+<td class="no obsolete" data-browser="node16_0">No<a href="#v8-regex-flags-order-note"><sup>[35]</sup></a></td>
 <td class="yes obsolete" data-browser="node16_9">Yes</td>
 <td class="yes" data-browser="node16_11">Yes</td>
 <td class="yes obsolete" data-browser="node17_0">Yes</td>
@@ -115528,10 +115528,10 @@ return true;
 <td class="yes" data-browser="node18_3">Yes</td>
 <td class="yes obsolete" data-browser="node19_0">Yes</td>
 <td class="yes obsolete" data-browser="node19_2">Yes</td>
-<td class="yes" data-browser="node20_0">Yes</td>
-<td class="yes obsolete" data-browser="node21_0">Yes</td>
-<td class="yes" data-browser="node22_0">Yes</td>
-<td class="yes" data-browser="node23_0">Yes</td>
+<td class="no" data-browser="node20_0">No<a href="#v8-regex-flags-order-note"><sup>[35]</sup></a></td>
+<td class="no obsolete" data-browser="node21_0">No<a href="#v8-regex-flags-order-note"><sup>[35]</sup></a></td>
+<td class="no" data-browser="node22_0">No<a href="#v8-regex-flags-order-note"><sup>[35]</sup></a></td>
+<td class="no" data-browser="node23_0">No<a href="#v8-regex-flags-order-note"><sup>[35]</sup></a></td>
 <td class="yes obsolete" data-browser="duktape2_6">Yes</td>
 <td class="yes" data-browser="duktape2_7">Yes</td>
 <td class="unknown obsolete" data-browser="jerryscript1_0">?</td>
@@ -115551,13 +115551,13 @@ return true;
 <td class="yes obsolete" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes obsolete" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="graalvm21_3_3">Yes</td>
-<td class="no flagged" data-browser="graalvm22_2">Flag<a href="#graalvm-js-ecmascript-version-6-note"><sup>[35]</sup></a></td>
+<td class="no flagged" data-browser="graalvm22_2">Flag<a href="#graalvm-js-ecmascript-version-6-note"><sup>[36]</sup></a></td>
 <td class="yes obsolete" data-browser="hermes0_7_0">Yes</td>
 <td class="yes" data-browser="hermes0_12_0">Yes</td>
-<td class="yes obsolete" data-browser="deno1_33">Yes</td>
-<td class="yes obsolete" data-browser="deno1_34">Yes</td>
-<td class="yes obsolete" data-browser="deno1_35">Yes</td>
-<td class="yes" data-browser="deno1_36">Yes</td>
+<td class="no obsolete" data-browser="deno1_33">No<a href="#v8-regex-flags-order-note"><sup>[35]</sup></a></td>
+<td class="no obsolete" data-browser="deno1_34">No<a href="#v8-regex-flags-order-note"><sup>[35]</sup></a></td>
+<td class="no obsolete" data-browser="deno1_35">No<a href="#v8-regex-flags-order-note"><sup>[35]</sup></a></td>
+<td class="no" data-browser="deno1_36">No<a href="#v8-regex-flags-order-note"><sup>[35]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios12_2">Yes</td>
@@ -115579,9 +115579,9 @@ return true;
 <td class="yes obsolete" data-browser="opera_mobile72">Yes</td>
 <td class="yes obsolete" data-browser="opera_mobile73">Yes</td>
 <td class="yes obsolete" data-browser="opera_mobile74">Yes</td>
-<td class="yes obsolete" data-browser="opera_mobile75">Yes</td>
-<td class="yes obsolete" data-browser="opera_mobile76">Yes</td>
-<td class="yes" data-browser="opera_mobile77">Yes</td>
+<td class="no obsolete" data-browser="opera_mobile75">No<a href="#v8-regex-flags-order-note"><sup>[35]</sup></a></td>
+<td class="no obsolete" data-browser="opera_mobile76">No<a href="#v8-regex-flags-order-note"><sup>[35]</sup></a></td>
+<td class="no" data-browser="opera_mobile77">No<a href="#v8-regex-flags-order-note"><sup>[35]</sup></a></td>
 <td class="yes" data-browser="reactnative0_70_3">Yes</td>
 </tr>
 <tr class="subtest" data-parent="Proxy,_internal_&apos;get&apos;_calls" id="test-Proxy,_internal_&apos;get&apos;_calls_RegExp.prototype.test"><td><span><a class="anchor" href="#test-Proxy,_internal_&apos;get&apos;_calls_RegExp.prototype.test">&#xA7;</a>RegExp.prototype.test</span><script data-source="
@@ -127897,8 +127897,8 @@ return result === &quot;012349 DB-1EFGHIJKLAC&quot;;
 <td class="unknown" data-browser="typescript5_6corejs3">?</td>
 <td class="unknown" data-browser="es6shim">?</td>
 <td class="unknown obsolete" data-browser="konq4_14">?</td>
-<td class="yes obsolete" data-browser="ie10">Yes<a href="#ie_property_order-note"><sup>[36]</sup></a></td>
-<td class="yes" data-browser="ie11">Yes<a href="#ie_property_order-note"><sup>[36]</sup></a></td>
+<td class="yes obsolete" data-browser="ie10">Yes<a href="#ie_property_order-note"><sup>[37]</sup></a></td>
+<td class="yes" data-browser="ie11">Yes<a href="#ie_property_order-note"><sup>[37]</sup></a></td>
 <td class="yes" data-browser="firefox115">Yes</td>
 <td class="yes obsolete" data-browser="firefox120">Yes</td>
 <td class="yes obsolete" data-browser="firefox121">Yes</td>
@@ -127931,7 +127931,7 @@ return result === &quot;012349 DB-1EFGHIJKLAC&quot;;
 <td class="yes" data-browser="chrome130">Yes</td>
 <td class="yes unstable" data-browser="chrome131">Yes</td>
 <td class="yes unstable" data-browser="chrome132">Yes</td>
-<td class="yes obsolete" data-browser="edge18">Yes<a href="#ie_property_order-note"><sup>[36]</sup></a></td>
+<td class="yes obsolete" data-browser="edge18">Yes<a href="#ie_property_order-note"><sup>[37]</sup></a></td>
 <td class="yes obsolete" data-browser="edge119">Yes</td>
 <td class="yes obsolete" data-browser="edge120">Yes</td>
 <td class="yes obsolete" data-browser="edge121">Yes</td>
@@ -128072,26 +128072,26 @@ return Reflect.ownKeys(obj).join(&apos;&apos;) === &quot;012349 DB-1AEFGHIJKLMNO
 </script></td>
 <td class="unknown obsolete" data-browser="es6tr">?</td>
 <td class="unknown obsolete" data-browser="tr">?</td>
-<td class="no obsolete" data-browser="babel6corejs2">No<a href="#forin-order-note"><sup>[37]</sup></a></td>
-<td class="no obsolete" data-browser="babel7corejs2">No<a href="#forin-order-note"><sup>[37]</sup></a></td>
-<td class="no" data-browser="babel7corejs3">No<a href="#forin-order-note"><sup>[37]</sup></a></td>
-<td class="no obsolete" data-browser="closure20200927">No<a href="#forin-order-note"><sup>[37]</sup></a></td>
-<td class="no obsolete" data-browser="closure20210808">No<a href="#forin-order-note"><sup>[37]</sup></a></td>
-<td class="no obsolete" data-browser="closure20210906">No<a href="#forin-order-note"><sup>[37]</sup></a></td>
-<td class="no obsolete" data-browser="closure20211006">No<a href="#forin-order-note"><sup>[37]</sup></a></td>
-<td class="no obsolete" data-browser="closure20211107">No<a href="#forin-order-note"><sup>[37]</sup></a></td>
-<td class="no obsolete" data-browser="closure20220502">No<a href="#forin-order-note"><sup>[37]</sup></a></td>
-<td class="no obsolete" data-browser="closure20220719">No<a href="#forin-order-note"><sup>[37]</sup></a></td>
-<td class="no" data-browser="closure20230228">No<a href="#forin-order-note"><sup>[37]</sup></a></td>
+<td class="no obsolete" data-browser="babel6corejs2">No<a href="#forin-order-note"><sup>[38]</sup></a></td>
+<td class="no obsolete" data-browser="babel7corejs2">No<a href="#forin-order-note"><sup>[38]</sup></a></td>
+<td class="no" data-browser="babel7corejs3">No<a href="#forin-order-note"><sup>[38]</sup></a></td>
+<td class="no obsolete" data-browser="closure20200927">No<a href="#forin-order-note"><sup>[38]</sup></a></td>
+<td class="no obsolete" data-browser="closure20210808">No<a href="#forin-order-note"><sup>[38]</sup></a></td>
+<td class="no obsolete" data-browser="closure20210906">No<a href="#forin-order-note"><sup>[38]</sup></a></td>
+<td class="no obsolete" data-browser="closure20211006">No<a href="#forin-order-note"><sup>[38]</sup></a></td>
+<td class="no obsolete" data-browser="closure20211107">No<a href="#forin-order-note"><sup>[38]</sup></a></td>
+<td class="no obsolete" data-browser="closure20220502">No<a href="#forin-order-note"><sup>[38]</sup></a></td>
+<td class="no obsolete" data-browser="closure20220719">No<a href="#forin-order-note"><sup>[38]</sup></a></td>
+<td class="no" data-browser="closure20230228">No<a href="#forin-order-note"><sup>[38]</sup></a></td>
 <td class="unknown obsolete" data-browser="jsx">?</td>
-<td class="no obsolete" data-browser="typescript2_9corejs2">No<a href="#forin-order-note"><sup>[37]</sup></a></td>
-<td class="no obsolete" data-browser="typescript3_9corejs3">No<a href="#forin-order-note"><sup>[37]</sup></a></td>
-<td class="no obsolete" data-browser="typescript4_9corejs3">No<a href="#forin-order-note"><sup>[37]</sup></a></td>
-<td class="no obsolete" data-browser="typescript5_3corejs3">No<a href="#forin-order-note"><sup>[37]</sup></a></td>
-<td class="no obsolete" data-browser="typescript5_4corejs3">No<a href="#forin-order-note"><sup>[37]</sup></a></td>
-<td class="no obsolete" data-browser="typescript5_5corejs3">No<a href="#forin-order-note"><sup>[37]</sup></a></td>
-<td class="no" data-browser="typescript5_6corejs3">No<a href="#forin-order-note"><sup>[37]</sup></a></td>
-<td class="no" data-browser="es6shim">No<a href="#forin-order-note"><sup>[37]</sup></a></td>
+<td class="no obsolete" data-browser="typescript2_9corejs2">No<a href="#forin-order-note"><sup>[38]</sup></a></td>
+<td class="no obsolete" data-browser="typescript3_9corejs3">No<a href="#forin-order-note"><sup>[38]</sup></a></td>
+<td class="no obsolete" data-browser="typescript4_9corejs3">No<a href="#forin-order-note"><sup>[38]</sup></a></td>
+<td class="no obsolete" data-browser="typescript5_3corejs3">No<a href="#forin-order-note"><sup>[38]</sup></a></td>
+<td class="no obsolete" data-browser="typescript5_4corejs3">No<a href="#forin-order-note"><sup>[38]</sup></a></td>
+<td class="no obsolete" data-browser="typescript5_5corejs3">No<a href="#forin-order-note"><sup>[38]</sup></a></td>
+<td class="no" data-browser="typescript5_6corejs3">No<a href="#forin-order-note"><sup>[38]</sup></a></td>
+<td class="no" data-browser="es6shim">No<a href="#forin-order-note"><sup>[38]</sup></a></td>
 <td class="unknown obsolete" data-browser="konq4_14">?</td>
 <td class="unknown obsolete" data-browser="ie10">?</td>
 <td class="no" data-browser="ie11">No</td>
@@ -130936,7 +130936,7 @@ return false;
 </tr>
 <tr class="category"><td colspan="174"><span>Annex b</span></td>
 </tr>
-<tr class="supertest optional-feature" significance="0.125"><td id="test-non-strict_function_semantics"><span><a class="anchor" href="#test-non-strict_function_semantics">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-labelled-function-declarations">non-strict function semantics</a><a href="#hoisted-block-functions-note"><sup>[38]</sup></a></span></td>
+<tr class="supertest optional-feature" significance="0.125"><td id="test-non-strict_function_semantics"><span><a class="anchor" href="#test-non-strict_function_semantics">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-labelled-function-declarations">non-strict function semantics</a><a href="#hoisted-block-functions-note"><sup>[39]</sup></a></span></td>
 <td class="tally obsolete not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
@@ -131662,7 +131662,7 @@ return foo() === 2 &amp;&amp; bar() === 3 &amp;&amp; baz() === 4 &amp;&amp; qux(
 <td class="yes" data-browser="opera_mobile77">Yes</td>
 <td class="no" data-browser="reactnative0_70_3">No</td>
 </tr>
-<tr class="supertest optional-feature" significance="0.125"><td id="test-__proto___in_object_literals"><span><a class="anchor" href="#test-__proto___in_object_literals">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-__proto__-property-names-in-object-initializers">__proto__ in object literals</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto#Specifications" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;<a href="#proto-in-object-literals-note"><sup>[39]</sup></a></span></td>
+<tr class="supertest optional-feature" significance="0.125"><td id="test-__proto___in_object_literals"><span><a class="anchor" href="#test-__proto___in_object_literals">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-__proto__-property-names-in-object-initializers">__proto__ in object literals</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto#Specifications" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;<a href="#proto-in-object-literals-note"><sup>[40]</sup></a></span></td>
 <td class="tally obsolete not-applicable" data-browser="es6tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/5</td>
 <td class="tally obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/5</td>
 <td class="tally obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/5</td>
@@ -137009,7 +137009,7 @@ return a === 3;
     </pre>
       </div>
       <!-- FOOTNOTES -->
-    <p id="khtml-note">  <sup>[1]</sup> Results are only applicable for the KHTML rendering engine.</p><p id="harmony-flag-old-note">  <sup>[2]</sup> Flagged features have to be enabled via <code>--harmony</code> flag</p><p id="harmony-flag-note">  <sup>[3]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="graalvm-node-mode-note">  <sup>[4]</sup> Executed in Node.js/JVM mode via <code>graalvm/bin/node --jvm</code>.</p><p id="graalvm-js-intl-mode-note">  <sup>[5]</sup> Executed using <code>js --js.intl-402</code>.</p><p id="proper-tail-calls-note">  <sup>[6]</sup> <a href="https://www.stefanjudis.com/today-i-learned/proper-tail-calls-in-javascript/">The feature can be enabled with <code>use strict</code> and JavaScript flag <code>&quot;--harmony-tailcalls&quot;</code></a> in certain versions of Node.js. Since Node.js 8.2.1, the V8 flags <code>--harmony-tailcalls</code> and <code>--harmony-explicit-tailcalls</code> have been removed. See: <a href="https://www.chromestatus.com/feature/5516876633341952">Chrome Platform Status</a>, <a href="https://javascript.plainenglish.io/tail-calls-in-javascript-will-there-be-a-comeback-63ac3a0523a5">blog in JavaScript in Plain English</a>, and <a href="https://v8.dev/blog/modern-javascript#proper-tail-calls">V8 Dev Blog</a> for details.</p><p id="tr-tco-note">  <sup>[7]</sup> Requires the <code>properTailCalls</code> compile option.</p><p id="typescript-es6-note">  <sup>[8]</sup> TypeScript&apos;s compiler will accept code using this feature if the <code>--target ES6</code> flag is set, but passes it through unmodified and does not supply a runtime polyfill.</p><p id="typescript-downlevel-iteration-note">  <sup>[9]</sup> Requires the <code>downlevelIteration</code> compile option.</p><p id="babel-core-js-note">  <sup>[10]</sup> This feature is supported when using Babel with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="compiler-iterable-note">  <sup>[11]</sup> This compiler requires generic iterables have either a <code>Symbol.iterator</code> or non-standard <code>&quot;@@iterator&quot;</code> method.</p><p id="typescript-not-downlevel-iteration-note">  <sup>[12]</sup> Does not work with the <code>downlevelIteration</code> compile option.</p><p id="ff-shorthand-methods-note">  <sup>[13]</sup> Firefox incorrectly produces an error in strict mode if the method is named <code>&quot;arguments&quot;</code>, <code>&quot;eval&quot;</code>, or <code>&quot;delete&quot;</code>.</p><p id="chrome-experimental-note">  <sup>[14]</sup> The feature has to be enabled via &quot;Experimental Javascript features&quot; setting under <code>about:flags</code></p><p id="typescript-core-js-note">  <sup>[15]</sup> This feature is supported when using TypeScript with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="safari-templ-cahing-note">  <sup>[16]</sup> Safari 12 caches TemplateStrings using a GC-able &quot;CodeBlock&quot;. But TemplateStrings are supposed to always be identical! When the CodeBlock is reclaimed, the TemplateStrings&apos; identity is broken. Thankfully, <code>[[Call]]</code> vs <code>[[Construct]]</code> generate different CodeBlocks, which exposes the <a href="https://bugs.webkit.org/show_bug.cgi?id=190756">broken behavior.</a></p><p id="hermes-catch-destructuring-note">  <sup>[17]</sup> Hermes isn&apos;t currently supporting destructuring in catch parameters</p><p id="babel-optional-flag-note">  <sup>[18]</sup> This feature features requires an optional transformer setting.</p><p id="block-level-function-note">  <sup>[19]</sup> Note that prior to ES6, it was <a href="http://wiki.ecmascript.org/doku.php?id=conventions:no_non_standard_strict_decls">recommended</a> that ES5 implementations forbid block-level declarations in strict mode.</p><p id="hermes-class-note">  <sup>[20]</sup> Hermes isn&apos;t currently supporting classes apparently</p><p id="compiler-proto-note">  <sup>[21]</sup> Requires native support for <code>Object.prototype.__proto__</code></p><p id="compiled-extends-note">  <sup>[22]</sup> This compiler transforms <code>extends</code> into code that uses native <code>Object.prototype.__proto__</code> or copies properties from the superclass, instead of using the prototype chain.</p><p id="typescript-extends-note">  <sup>[23]</sup> TypeScript transforms <code>extends</code> into code that copies static properties from the superclass (but uses the prototype chain for instance properties).</p><p id="babel-regenerator-note">  <sup>[24]</sup> This feature requires native generators or <code>regenerator-runtime</code>, it&apos;s a part of <code>babel-polyfill</code> or <code>babel-runtime</code>.</p><p id="ie-clampedarray-note">  <sup>[25]</sup> A buggy implementation of <code>Uint8ClampedArray</code> on initial IE11 release has been fixed with the patch on <a href="https://support.microsoft.com/en-us/help/2929437/description-of-the-security-update-for-internet-explorer-11-on-windows">KB2929437</a></p><p id="ie-subarray-note">  <sup>[26]</sup> This test depends on <code>Uint8ClampedArray</code> which has been introduced with <a href="https://support.microsoft.com/en-us/help/2929437/description-of-the-security-update-for-internet-explorer-11-on-windows">KB2929437</a>, so it fails on early IE11 builds.</p><p id="proxy-enumerate-note">  <sup>[27]</sup> The 2015 version of the specification also specifies an <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-proxy-object-internal-methods-and-internal-slots-enumerate">&quot;enumerate&quot; handler</a>, which was removed in the 2016 version.</p><p id="reflect-enumerate-note">  <sup>[28]</sup> The 2015 version of the specification also specifies <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-reflect.enumerate">Reflect.enumerate</a>, which was removed in the 2016 version.</p><p id="symbol-iterator-functionality-note">  <sup>[29]</sup> Functionality for <code>Symbol.iterator</code> is tested by the &quot;generic iterators&quot; subtests for the <a href="#test-spread_(...)_operator">spread (...) operator</a>, <a href="#test-for..of_loops">for..of loops</a>, <a href="#test-destructuring">destructuring</a>, <a href="#test-generators">yield *</a>, and <a href="#test-Array_static_methods">Array.from</a>.</p><p id="edge-experimental-flag-note">  <sup>[30]</sup> Flagged features have to be enabled via &quot;Enable experimental Javascript features&quot; setting under <code>about:flags</code></p><p id="ejs-no-with-note">  <sup>[31]</sup> <code>with</code> is not supported in ejs</p><p id="name-configurable-note">  <sup>[32]</sup> Requires function <code>&quot;name&quot;</code> properties to be natively configurable</p><p id="chromu-imul-note">  <sup>[33]</sup> Available since Chrome 28</p><p id="closure-mathfround-note">  <sup>[34]</sup> Requires native support for <code>Float32Array</code></p><p id="graalvm-js-ecmascript-version-6-note">  <sup>[35]</sup> Requires the <code>--js.ecmascript-version=6</code> flag.</p><p id="ie_property_order-note">  <sup>[36]</sup> Unlike other engines, Chakra sorts properties removed by <code>delete</code>, then recreated by assignment, to their original creation positions, not their latest positions.</p><p id="forin-order-note">  <sup>[37]</sup> This uses native for-in enumeration order, rather than the correct order.</p><p id="hoisted-block-functions-note">  <sup>[38]</sup> The 2015 version of the specification contains <a href="https://esdiscuss.org/topic/block-level-function-declarations-web-legacy-compatibility-bug">multiple bugs</a> for hoisted block-level function declaration semantics, which these tests disregard.</p><p id="proto-in-object-literals-note">  <sup>[39]</sup> Note that this is distinct from the existence or functionality of <code>Object.prototype.__proto__</code>.</p></div>
+    <p id="khtml-note">  <sup>[1]</sup> Results are only applicable for the KHTML rendering engine.</p><p id="harmony-flag-old-note">  <sup>[2]</sup> Flagged features have to be enabled via <code>--harmony</code> flag</p><p id="harmony-flag-note">  <sup>[3]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="graalvm-node-mode-note">  <sup>[4]</sup> Executed in Node.js/JVM mode via <code>graalvm/bin/node --jvm</code>.</p><p id="graalvm-js-intl-mode-note">  <sup>[5]</sup> Executed using <code>js --js.intl-402</code>.</p><p id="proper-tail-calls-note">  <sup>[6]</sup> <a href="https://www.stefanjudis.com/today-i-learned/proper-tail-calls-in-javascript/">The feature can be enabled with <code>use strict</code> and JavaScript flag <code>&quot;--harmony-tailcalls&quot;</code></a> in certain versions of Node.js. Since Node.js 8.2.1, the V8 flags <code>--harmony-tailcalls</code> and <code>--harmony-explicit-tailcalls</code> have been removed. See: <a href="https://www.chromestatus.com/feature/5516876633341952">Chrome Platform Status</a>, <a href="https://javascript.plainenglish.io/tail-calls-in-javascript-will-there-be-a-comeback-63ac3a0523a5">blog in JavaScript in Plain English</a>, and <a href="https://v8.dev/blog/modern-javascript#proper-tail-calls">V8 Dev Blog</a> for details.</p><p id="tr-tco-note">  <sup>[7]</sup> Requires the <code>properTailCalls</code> compile option.</p><p id="typescript-es6-note">  <sup>[8]</sup> TypeScript&apos;s compiler will accept code using this feature if the <code>--target ES6</code> flag is set, but passes it through unmodified and does not supply a runtime polyfill.</p><p id="typescript-downlevel-iteration-note">  <sup>[9]</sup> Requires the <code>downlevelIteration</code> compile option.</p><p id="babel-core-js-note">  <sup>[10]</sup> This feature is supported when using Babel with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="compiler-iterable-note">  <sup>[11]</sup> This compiler requires generic iterables have either a <code>Symbol.iterator</code> or non-standard <code>&quot;@@iterator&quot;</code> method.</p><p id="typescript-not-downlevel-iteration-note">  <sup>[12]</sup> Does not work with the <code>downlevelIteration</code> compile option.</p><p id="ff-shorthand-methods-note">  <sup>[13]</sup> Firefox incorrectly produces an error in strict mode if the method is named <code>&quot;arguments&quot;</code>, <code>&quot;eval&quot;</code>, or <code>&quot;delete&quot;</code>.</p><p id="chrome-experimental-note">  <sup>[14]</sup> The feature has to be enabled via &quot;Experimental Javascript features&quot; setting under <code>about:flags</code></p><p id="typescript-core-js-note">  <sup>[15]</sup> This feature is supported when using TypeScript with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="safari-templ-cahing-note">  <sup>[16]</sup> Safari 12 caches TemplateStrings using a GC-able &quot;CodeBlock&quot;. But TemplateStrings are supposed to always be identical! When the CodeBlock is reclaimed, the TemplateStrings&apos; identity is broken. Thankfully, <code>[[Call]]</code> vs <code>[[Construct]]</code> generate different CodeBlocks, which exposes the <a href="https://bugs.webkit.org/show_bug.cgi?id=190756">broken behavior.</a></p><p id="hermes-catch-destructuring-note">  <sup>[17]</sup> Hermes isn&apos;t currently supporting destructuring in catch parameters</p><p id="babel-optional-flag-note">  <sup>[18]</sup> This feature features requires an optional transformer setting.</p><p id="block-level-function-note">  <sup>[19]</sup> Note that prior to ES6, it was <a href="http://wiki.ecmascript.org/doku.php?id=conventions:no_non_standard_strict_decls">recommended</a> that ES5 implementations forbid block-level declarations in strict mode.</p><p id="hermes-class-note">  <sup>[20]</sup> Hermes isn&apos;t currently supporting classes apparently</p><p id="compiler-proto-note">  <sup>[21]</sup> Requires native support for <code>Object.prototype.__proto__</code></p><p id="compiled-extends-note">  <sup>[22]</sup> This compiler transforms <code>extends</code> into code that uses native <code>Object.prototype.__proto__</code> or copies properties from the superclass, instead of using the prototype chain.</p><p id="typescript-extends-note">  <sup>[23]</sup> TypeScript transforms <code>extends</code> into code that copies static properties from the superclass (but uses the prototype chain for instance properties).</p><p id="babel-regenerator-note">  <sup>[24]</sup> This feature requires native generators or <code>regenerator-runtime</code>, it&apos;s a part of <code>babel-polyfill</code> or <code>babel-runtime</code>.</p><p id="ie-clampedarray-note">  <sup>[25]</sup> A buggy implementation of <code>Uint8ClampedArray</code> on initial IE11 release has been fixed with the patch on <a href="https://support.microsoft.com/en-us/help/2929437/description-of-the-security-update-for-internet-explorer-11-on-windows">KB2929437</a></p><p id="ie-subarray-note">  <sup>[26]</sup> This test depends on <code>Uint8ClampedArray</code> which has been introduced with <a href="https://support.microsoft.com/en-us/help/2929437/description-of-the-security-update-for-internet-explorer-11-on-windows">KB2929437</a>, so it fails on early IE11 builds.</p><p id="proxy-enumerate-note">  <sup>[27]</sup> The 2015 version of the specification also specifies an <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-proxy-object-internal-methods-and-internal-slots-enumerate">&quot;enumerate&quot; handler</a>, which was removed in the 2016 version.</p><p id="reflect-enumerate-note">  <sup>[28]</sup> The 2015 version of the specification also specifies <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-reflect.enumerate">Reflect.enumerate</a>, which was removed in the 2016 version.</p><p id="symbol-iterator-functionality-note">  <sup>[29]</sup> Functionality for <code>Symbol.iterator</code> is tested by the &quot;generic iterators&quot; subtests for the <a href="#test-spread_(...)_operator">spread (...) operator</a>, <a href="#test-for..of_loops">for..of loops</a>, <a href="#test-destructuring">destructuring</a>, <a href="#test-generators">yield *</a>, and <a href="#test-Array_static_methods">Array.from</a>.</p><p id="edge-experimental-flag-note">  <sup>[30]</sup> Flagged features have to be enabled via &quot;Enable experimental Javascript features&quot; setting under <code>about:flags</code></p><p id="ejs-no-with-note">  <sup>[31]</sup> <code>with</code> is not supported in ejs</p><p id="name-configurable-note">  <sup>[32]</sup> Requires function <code>&quot;name&quot;</code> properties to be natively configurable</p><p id="chromu-imul-note">  <sup>[33]</sup> Available since Chrome 28</p><p id="closure-mathfround-note">  <sup>[34]</sup> Requires native support for <code>Float32Array</code></p><p id="v8-regex-flags-order-note">  <sup>[35]</sup> The &quot;unicodeSets&quot; flag is added after the &quot;sticky&quot; flag, instead of before it, as the spec requires.</p><p id="graalvm-js-ecmascript-version-6-note">  <sup>[36]</sup> Requires the <code>--js.ecmascript-version=6</code> flag.</p><p id="ie_property_order-note">  <sup>[37]</sup> Unlike other engines, Chakra sorts properties removed by <code>delete</code>, then recreated by assignment, to their original creation positions, not their latest positions.</p><p id="forin-order-note">  <sup>[38]</sup> This uses native for-in enumeration order, rather than the correct order.</p><p id="hoisted-block-functions-note">  <sup>[39]</sup> The 2015 version of the specification contains <a href="https://esdiscuss.org/topic/block-level-function-declarations-web-legacy-compatibility-bug">multiple bugs</a> for hoisted block-level function declaration semantics, which these tests disregard.</p><p id="proto-in-object-literals-note">  <sup>[40]</sup> Note that this is distinct from the existence or functionality of <code>Object.prototype.__proto__</code>.</p></div>
   </div>
   <pre class="info-tooltip" style="display:none"></pre>
 </body>


### PR DESCRIPTION
Fixed the ```RegExp Match Indices (`hasIndices` / `d` flag)``` / `shows up in flags` test. It was testing for all flags being in the RegExp prototype, in order. This is already done by a separate test (`Proxy, internal 'get' calls` / `RegExp.prototype.flags`), which is still present in `data-es6.js`, and still failing on newer V8 versions.

Support for the now fixed test is assumed to start the same versions as the constructor subtest, and is copied from there. Actually verified on Edge 129, Chrome 130 and Firefox 131.

Added a note on `Proxy, internal 'get' calls` / `RegExp.prototype.flags` about newer Chrome and NodeJS versions failing due to wrong property order.