### PR TITLE
Added unicode flag to the ES6 `RegExp.prototype[Symbol.match]` test

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -12322,6 +12322,7 @@ exports.tests = [
         var p = new Proxy({ exec: function() { return null; } }, { get: function(o, k) { get.push(k); return o[k]; }});
         RegExp.prototype[Symbol.match].call(p);
         p.global = true;
+        p.unicode = true;
         RegExp.prototype[Symbol.match].call(p);
         var str = get + '';
         return str === "global,exec,global,unicode,exec" || str === 'flags,exec,flags,exec';


### PR DESCRIPTION
This makes it pass in any browser with or without unicodeSets support. Browsers that check the individual properties (in compliance with ES6) instead of flags (in compliance with later versions of the spec) check unicode first, and check unicodeSets if unicode is not truthy. Current versions of V8 in particular are affected, after adding support for unicodeSets, but still not looking up flags.