### PR TITLE
Firefox 134 has full support for Promise.try

### DIFF
--- a/data-es2016plus.js
+++ b/data-es2016plus.js
@@ -8343,6 +8343,7 @@ exports.tests = [
         note_id: 'ff-promise-try',
         note_html: 'The feature is only available on Nightly builds, and has to be enabled via <code>javascript.options.experimental.promise_try</code> setting under <code>about:config</code>.'
       },
+      firefox134: true,
       node23: true,
     }
   }

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -47624,7 +47624,7 @@ return p instanceof Promise &amp;&amp; called &amp;&amp; argsMatch;
 <td class="no obsolete" data-browser="firefox131">No</td>
 <td class="no flagged" data-browser="firefox132">Flag<a href="#ff-promise-try-note"><sup>[41]</sup></a></td>
 <td class="no flagged unstable" data-browser="firefox133">Flag<a href="#ff-promise-try-note"><sup>[41]</sup></a></td>
-<td class="no flagged unstable" data-browser="firefox134">Flag<a href="#ff-promise-try-note"><sup>[41]</sup></a></td>
+<td class="yes unstable" data-browser="firefox134">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="unknown obsolete" data-browser="chrome119">?</td>
 <td class="unknown obsolete" data-browser="chrome120">?</td>


### PR DESCRIPTION
Note that the test is currently broken, it doesn't work on Firefox or Chrome.  Tested with the fix in #1936.