### PR TITLE
fix Promise.try

### DIFF
--- a/data-es2016plus.js
+++ b/data-es2016plus.js
@@ -8337,7 +8337,7 @@ exports.tests = [
       var p2 = Promise.try(function () {
         'use strict';
         argsMatch = this === undefined && arguments.length === 2 && args[0] === p && args[1] === 2;
-      }, [p, 2]);
+      }, p, 2);
 
       return p instanceof Promise && called && argsMatch;
     */},

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -47582,10 +47582,10 @@ var p = Promise.try(function () { called = true; })
 var p2 = Promise.try(function () {
   &apos;use strict&apos;;
   argsMatch = this === undefined &amp;&amp; arguments.length === 2 &amp;&amp; args[0] === p &amp;&amp; args[1] === 2;
-}, [p, 2]);
+}, p, 2);
 
 return p instanceof Promise &amp;&amp; called &amp;&amp; argsMatch;
-    ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("287");try{return Function("asyncTestPassed","\nvar called = false;\nvar argsMatch = false;\nvar p = Promise.try(function () { called = true; })\nvar p2 = Promise.try(function () {\n  'use strict';\n  argsMatch = this === undefined && arguments.length === 2 && args[0] === p && args[1] === 2;\n}, [p, 2]);\n\nreturn p instanceof Promise && called && argsMatch;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("287");return Function("asyncTestPassed","'use strict';"+"\nvar called = false;\nvar argsMatch = false;\nvar p = Promise.try(function () { called = true; })\nvar p2 = Promise.try(function () {\n  'use strict';\n  argsMatch = this === undefined && arguments.length === 2 && args[0] === p && args[1] === 2;\n}, [p, 2]);\n\nreturn p instanceof Promise && called && argsMatch;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+    ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("287");try{return Function("asyncTestPassed","\nvar called = false;\nvar argsMatch = false;\nvar p = Promise.try(function () { called = true; })\nvar p2 = Promise.try(function () {\n  'use strict';\n  argsMatch = this === undefined && arguments.length === 2 && args[0] === p && args[1] === 2;\n}, p, 2);\n\nreturn p instanceof Promise && called && argsMatch;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("287");return Function("asyncTestPassed","'use strict';"+"\nvar called = false;\nvar argsMatch = false;\nvar p = Promise.try(function () { called = true; })\nvar p2 = Promise.try(function () {\n  'use strict';\n  argsMatch = this === undefined && arguments.length === 2 && args[0] === p && args[1] === 2;\n}, p, 2);\n\nreturn p instanceof Promise && called && argsMatch;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>


### PR DESCRIPTION
`Promise.try` is not supposed to receive the arguments to the callback packed in an array.
See the [Mozilla documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/try) and the [specification](https://tc39.es/proposal-promise-try/#sec-promise.try)