### PR TITLE
Fix correct prototype chains test

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -7600,8 +7600,8 @@ exports.tests = [
           if (!(constructors[i] in global
               && Object.getPrototypeOf(global[constructors[i]]) === constructor
               && Object.getPrototypeOf(global[constructors[i]].prototype) === prototype
-              && Object.getOwnPropertyNames(global[constructors[i]].prototype).sort() + ''
-                === "BYTES_PER_ELEMENT,constructor")) {
+              && Object.getOwnPropertyNames(global[constructors[i]].prototype).indexOf('BYTES_PER_ELEMENT') !== -1
+              && Object.getOwnPropertyNames(global[constructors[i]].prototype).indexOf('constructor') !== -1)) {
             return false;
           }
         }


### PR DESCRIPTION
arraybuffer-base64 proposal introduces 4 new typed array methods (setFromBase64, setFromHex, toBase64, toHex) that break equality check in this test.

Fixes #1996