### PR TITLE
Add safari destructuring bug

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -15218,6 +15218,30 @@ exports.tests = [
       }
     },
     {
+      name: 'rest with identical number of elements in RHS',
+      exec: function(){/*
+        var [a, ...b] = [3, 4];
+        var [...c] = [5];
+        return a === 3 && b instanceof Array && (b + "") === "4" &&
+           c instanceof Array && (c + "") === "5";
+      */},
+      res: {
+        tr: true,
+        babel6corejs2: babel.corejs,
+        typescript1corejs2: true,
+        firefox2: false,
+        firefox34: true,
+        opera10_50: false,
+        safari13_1: false,
+        safari14_1: true,
+        ie11: false,
+        edge13: edge.experimental,
+        edge14: true,
+        chrome49: true,
+        node6: true,
+      }
+    },
+    {
       name: 'defaults',
       exec: function(){/*
         var {a = 1, b = 0, z:c = 3} = {b:2, z:undefined};
@@ -16067,6 +16091,31 @@ exports.tests = [
         hermes0_7_0: true,
         reactnative0_70_3: true,
         rhino1_7_13: false
+      }
+    },
+    {
+      name: 'rest with identical number of elements in RHS',
+      exec: function(){/*
+        var a,b,c;
+        [a, ...b] = [3, 4];
+        [...c] = [5];
+        return a === 3 && b instanceof Array && (b + "") === "4" &&
+           c instanceof Array && (c + "") === "5";
+      */},
+      res: {
+        tr: true,
+        babel6corejs2: babel.corejs,
+        typescript1corejs2: true,
+        firefox2: false,
+        firefox34: true,
+        opera10_50: false,
+        safari13_1: false,
+        safari14_1: true,
+        ie11: false,
+        edge13: edge.experimental,
+        edge14: true,
+        chrome49: true,
+        node6: true,
       }
     },
     {


### PR DESCRIPTION
Added new test cases for a Safari destructuring bug, affecting Safari from 9 to 13.1.

Due to the limit of the BrowserStack, I can not verify whether this bug has been fixed in Safari 14 or not. The earliest version I can verify is Safari 14.1. If you have access to Safari 14.0, feel free to suggest the test result and I will update the PR accordingly.

/cc @magic-akari, who reported this bug to Babel.

Context: https://github.com/babel/babel/issues/17773#issuecomment-3842765704